### PR TITLE
feat(components/ui): apply theming to label and input components, new password input component

### DIFF
--- a/src/components/ui/input/index.ts
+++ b/src/components/ui/input/index.ts
@@ -1,1 +1,2 @@
 export * from './input';
+export * from './password-input';

--- a/src/components/ui/input/input.stories.tsx
+++ b/src/components/ui/input/input.stories.tsx
@@ -11,13 +11,33 @@ const meta = {
   argTypes: {
     type: {
       control: 'select',
-      options: ['text', 'email', 'password', 'number', 'date', 'tel', 'url'],
+      options: ['text', 'email', 'password', 'number'],
+      description: 'Input field type',
+    },
+    variant: {
+      control: 'select',
+      options: ['default', 'highlight'],
+      description: 'Input field visual style variant',
+      table: {
+        type: { summary: 'default | highlight' },
+        defaultValue: { summary: 'default' },
+      },
+    },
+    error: {
+      control: 'boolean',
+      description: 'Input field error state',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
     },
     disabled: {
       control: 'boolean',
+      description: 'Input disabled state',
     },
     placeholder: {
       control: 'text',
+      description: 'Input field placeholder',
     },
   },
 } satisfies Meta<typeof Input>;
@@ -25,7 +45,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Text: Story = {
   args: {
     placeholder: 'Enter text...',
   },
@@ -54,8 +74,22 @@ export const Number: Story = {
 
 export const Disabled: Story = {
   args: {
-    placeholder: 'Disabled input',
+    placeholder: 'Disabled',
     disabled: true,
+  },
+};
+
+export const Error: Story = {
+  args: {
+    placeholder: 'Placeholder',
+    error: true,
+  },
+};
+
+export const Highlight: Story = {
+  args: {
+    placeholder: 'Placeholder',
+    variant: 'highlight',
   },
 };
 
@@ -63,18 +97,4 @@ export const WithDefaultValue: Story = {
   args: {
     defaultValue: 'Default value',
   },
-};
-
-export const AllTypes: Story = {
-  render: () => (
-    <div className="flex w-full max-w-sm flex-col gap-4">
-      <Input type="text" placeholder="Text input" />
-      <Input type="email" placeholder="Email input" />
-      <Input type="password" placeholder="Password input" />
-      <Input type="number" placeholder="Number input" />
-      <Input type="date" />
-      <Input type="tel" placeholder="Phone input" />
-      <Input type="url" placeholder="URL input" />
-    </div>
-  ),
 };

--- a/src/components/ui/input/input.tsx
+++ b/src/components/ui/input/input.tsx
@@ -1,14 +1,23 @@
 import { cn } from '@/utils/Helpers';
 
-function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+export type InputProps = React.ComponentProps<'input'> & {
+  error?: boolean;
+  variant?: 'default' | 'highlight';
+};
+
+function Input({ className, type, error, variant = 'default', ...props }: InputProps) {
   return (
     <input
       type={type}
       data-slot="input"
+      aria-invalid={error || props['aria-invalid']}
       className={cn(
-        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'file:text-foreground placeholder:text-neutral-800 selection:bg-primary selection:text-primary-foreground dark:bg-input/30 flex h-9 w-full min-w-0 rounded-md border px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-100 md:text-sm',
+        // Variant-specific styles
+        variant === 'default' && 'border-neutral-600 bg-neutral-100 text-neutral-1500 disabled:bg-neutral-500 disabled:text-neutral-800',
+        variant === 'highlight' && 'border-neutral-1500 bg-neutral-100 text-neutral-1500 disabled:bg-neutral-500 disabled:text-neutral-800',
         'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
-        'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+        'aria-invalid:ring-red-500/20 dark:aria-invalid:ring-red-500/40 aria-invalid:border-red-500',
         className,
       )}
       {...props}

--- a/src/components/ui/input/password-input.stories.tsx
+++ b/src/components/ui/input/password-input.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { Label } from '../label';
+import { PasswordInput } from './password-input';
+
+const meta = {
+  title: 'UI/Primitives/PasswordInput',
+  component: PasswordInput,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'highlight'],
+      description: 'Input field visual style variant',
+      table: {
+        type: { summary: 'default | highlight' },
+        defaultValue: { summary: 'default' },
+      },
+    },
+    error: {
+      control: 'boolean',
+      description: 'Input field error state',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Input field disabled state',
+    },
+    showToggle: {
+      control: 'boolean',
+      description: 'Show visibility toggle',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'true' },
+      },
+    },
+    placeholder: {
+      control: 'text',
+      description: 'Input field placeholder',
+    },
+  },
+} satisfies Meta<typeof PasswordInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    placeholder: 'Enter password...',
+  },
+};
+
+export const WithValue: Story = {
+  args: {
+    defaultValue: 'Password1234#',
+  },
+};
+
+export const NoToggle: Story = {
+  args: {
+    placeholder: 'Password (no toggle)',
+    showToggle: false,
+  },
+};
+
+export const Error: Story = {
+  args: {
+    placeholder: 'Enter password...',
+    error: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    placeholder: 'Enter password...',
+    disabled: true,
+  },
+};
+
+export const Highlight: Story = {
+  args: {
+    placeholder: 'Enter password...',
+    variant: 'highlight',
+  },
+};
+
+export const UseCase: Story = {
+  render: () => (
+    <div className="flex w-full max-w-sm flex-col gap-4">
+      <div className="space-y-2">
+        <Label htmlFor="password-demo">
+          Password
+        </Label>
+        <PasswordInput
+          id="password-demo"
+          placeholder="Enter your password"
+        />
+        <p className="text-sm text-neutral-600">
+          Click the eye icon to toggle password visibility
+        </p>
+      </div>
+    </div>
+  ),
+};

--- a/src/components/ui/input/password-input.tsx
+++ b/src/components/ui/input/password-input.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { Eye, EyeOff } from 'lucide-react';
+import { useState } from 'react';
+import { cn } from '@/utils/Helpers';
+import { Input } from './input';
+
+export type PasswordInputProps = Omit<React.ComponentProps<'input'>, 'type'> & {
+  error?: boolean;
+  variant?: 'default' | 'highlight';
+  showToggle?: boolean;
+};
+
+function PasswordInput({
+  className,
+  showToggle = true,
+  disabled,
+  ...props
+}: PasswordInputProps) {
+  const [showPassword, setShowPassword] = useState(false);
+
+  const toggleVisibility = () => setShowPassword(!showPassword);
+
+  if (!showToggle || disabled) {
+    return <Input type="password" className={className} disabled={disabled} {...props} />;
+  }
+
+  return (
+    <div className="relative">
+      <Input
+        type={showPassword ? 'text' : 'password'}
+        className={cn('pr-10', className)}
+        disabled={disabled}
+        {...props}
+      />
+      <button
+        type="button"
+        onClick={toggleVisibility}
+        className="absolute top-1/2 right-3 z-10 flex h-5 w-5 -translate-y-1/2 items-center justify-center text-neutral-800 hover:text-neutral-1500 focus:text-neutral-1500 focus:outline-none"
+        aria-label={showPassword ? 'Hide password' : 'Show password'}
+      >
+        {showPassword
+          ? (
+              <EyeOff className="h-4 w-4" />
+            )
+          : (
+              <Eye className="h-4 w-4" />
+            )}
+      </button>
+    </div>
+  );
+}
+
+export { PasswordInput };

--- a/src/components/ui/label/label.stories.tsx
+++ b/src/components/ui/label/label.stories.tsx
@@ -19,6 +19,13 @@ export const Default: Story = {
   },
 };
 
+export const Required: Story = {
+  args: {
+    children: 'Label',
+    required: true,
+  },
+};
+
 export const WithFor: Story = {
   args: {
     htmlFor: 'input-id',
@@ -36,7 +43,7 @@ export const WithCustomClass: Story = {
 export const FormLabel: Story = {
   render: () => (
     <div className="flex flex-col gap-2">
-      <Label htmlFor="name">Name</Label>
+      <Label htmlFor="name" required>Name</Label>
       <input
         id="name"
         type="text"

--- a/src/components/ui/label/label.tsx
+++ b/src/components/ui/label/label.tsx
@@ -3,19 +3,33 @@
 import * as LabelPrimitive from '@radix-ui/react-label';
 import { cn } from '@/utils/Helpers';
 
+export type LabelProps = React.ComponentProps<typeof LabelPrimitive.Root> & {
+  required?: boolean;
+};
+
 function Label({
   className,
+  required,
+  children,
   ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+}: LabelProps) {
   return (
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        'flex items-center gap-2 text-caption leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
+        'flex items-center gap-1 text-caption leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
+        'text-neutral-1500',
         className,
       )}
       {...props}
-    />
+    >
+      {children}
+      {required && (
+        <span className="ml-1 text-red-500" aria-label="required">
+          *
+        </span>
+      )}
+    </LabelPrimitive.Root>
   );
 }
 


### PR DESCRIPTION
Implement Dojo Planner theming for:

| Component                             | Description                                                             | Storybook URL    |
| ---------------------------- | ----------------------------------------------- |------------------|
| `<Input>`                                | Adds Theming                                                        | http://localhost:6006/?path=/docs/ui-primitives-input--docs    |
| `<PasswordComponent>`    | Wraps `<Input>` component to add password visibility toggle  | http://localhost:6006/?path=/docs/ui-primitives-passwordinput--docs    |
| `<Label>`                               | Adds Theming                                                         | http://localhost:6006/?path=/docs/ui-primitives-label--docs    |

