### PR TITLE
feat(components/ui): apply theming to table, pagination and badge components

### DIFF
--- a/src/components/ui/badge/badgeVariants.ts
+++ b/src/components/ui/badge/badgeVariants.ts
@@ -6,13 +6,13 @@ export const badgeVariants = cva(
     variants: {
       variant: {
         default:
-          'border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
+          'border-transparent bg-neutral-500 text-neutral-1500 [a&]:hover:bg-neutral-600',
         secondary:
-          'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
+          'border-transparent bg-neutral-1400 text-neutral-100 [a&]:hover:bg-neutral-1300',
         destructive:
-          'border-transparent bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90',
+          'border-transparent bg-red-500 text-neutral-100 focus-visible:ring-red-500/20 [a&]:hover:bg-red-500/90',
         outline:
-          'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+          'border-neutral-600 bg-transparent text-neutral-1500 dark:border-neutral-950 dark:text-neutral-100 [a&]:hover:bg-neutral-500 [a&]:hover:text-neutral-1500 [a&]:dark:hover:bg-neutral-1400 [a&]:dark:hover:text-neutral-100',
       },
     },
     defaultVariants: {

--- a/src/components/ui/pagination/Pagination.stories.tsx
+++ b/src/components/ui/pagination/Pagination.stories.tsx
@@ -109,17 +109,3 @@ export const ManyPages = {
     />
   ),
 };
-
-export const DarkMode = {
-  render: () => (
-    <PaginationDemo
-      initialPage={4}
-      totalPages={12}
-      totalItems={240}
-      itemsPerPage={10}
-    />
-  ),
-  parameters: {
-    backgrounds: { default: 'dark' },
-  },
-};

--- a/src/components/ui/pagination/Pagination.tsx
+++ b/src/components/ui/pagination/Pagination.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { cn } from '@/utils/Helpers';
 
 type PaginationProps = {
   currentPage: number;
@@ -78,19 +79,19 @@ export function Pagination({
   const shouldShowControls = totalPages > 1;
 
   return (
-    <div className="flex flex-wrap items-center justify-between gap-4">
-      <div className="text-sm text-muted-foreground">
+    <div className="flex w-full items-center justify-between gap-4">
+      <div className="shrink-0 text-left text-sm text-neutral-1000">
         Showing
         {' '}
-        {startItem}
-        {' '}
-        to
-        {' '}
-        {endItem}
+        <span className="font-semibold">
+          {startItem}
+          -
+          {endItem}
+        </span>
         {' '}
         of
         {' '}
-        {totalItems}
+        <span className="font-semibold">{totalItems}</span>
         {' '}
         entries
       </div>
@@ -98,13 +99,13 @@ export function Pagination({
       {shouldShowControls && (
         <div className="flex shrink-0 items-center gap-2">
           <Button
-            variant="outline"
+            variant="ghost"
             size="sm"
             onClick={() => onPageChangeAction(Math.max(0, currentPage - 1))}
             disabled={currentPage === 0}
-            className="gap-2"
+            className="h-10 gap-2 border border-neutral-400 bg-neutral-100 text-neutral-1000 shadow-none disabled:text-neutral-600"
           >
-            <ChevronLeft className="h-4 w-4" />
+            <ArrowLeft className="h-4 w-4" />
             Previous
           </Button>
 
@@ -114,7 +115,7 @@ export function Pagination({
                 return (
                   <span
                     key={`ellipsis-${page.id}`}
-                    className="flex items-center justify-center px-2 py-2 text-sm text-muted-foreground"
+                    className="flex items-center justify-center px-3 py-2 text-sm text-neutral-1000"
                   >
                     ...
                   </span>
@@ -127,10 +128,15 @@ export function Pagination({
               return (
                 <Button
                   key={`page-${pageNum}`}
-                  variant={isActive ? 'default' : 'outline'}
+                  variant="ghost"
                   size="sm"
                   onClick={() => onPageChangeAction(pageNum)}
-                  className="min-w-10"
+                  className={cn(
+                    'min-w-10 h-10 border shadow-none',
+                    isActive
+                      ? 'border-neutral-1500 bg-neutral-1500 text-neutral-100 hover:bg-neutral-1500'
+                      : 'border-neutral-400 bg-neutral-100 text-neutral-1000 hover:bg-neutral-200',
+                  )}
                 >
                   {pageNum + 1}
                 </Button>
@@ -139,14 +145,14 @@ export function Pagination({
           </div>
 
           <Button
-            variant="outline"
+            variant="ghost"
             size="sm"
             onClick={() => onPageChangeAction(Math.min(totalPages - 1, currentPage + 1))}
             disabled={currentPage === totalPages - 1}
-            className="gap-2"
+            className="h-10 gap-2 border border-neutral-400 bg-neutral-100 text-neutral-1000 shadow-none disabled:text-neutral-600"
           >
             Next
-            <ChevronRight className="h-4 w-4" />
+            <ArrowRight className="h-4 w-4" />
           </Button>
         </div>
       )}

--- a/src/components/ui/table/table.stories.tsx
+++ b/src/components/ui/table/table.stories.tsx
@@ -1,4 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { useState } from 'react';
+import { Avatar, AvatarFallback } from '../avatar';
+import { Pagination } from '../pagination/Pagination';
 import {
   Table,
   TableBody,
@@ -128,4 +131,183 @@ export const WithoutCaption: Story = {
       </TableBody>
     </Table>
   ),
+};
+
+// Wrapper component to manage pagination state
+function BillingHistoryDemo() {
+  const [currentPage, setCurrentPage] = useState(0);
+
+  return (
+    <div className="w-full">
+      <h2 className="mb-6 text-title font-medium">Billing History</h2>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Member</TableHead>
+            <TableHead>Date</TableHead>
+            <TableHead>Amount</TableHead>
+            <TableHead>Purpose</TableHead>
+            <TableHead>Method</TableHead>
+            <TableHead>Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableCell>
+              <div className="flex items-center gap-3">
+                <Avatar className="h-8 w-8">
+                  <AvatarFallback>OR</AvatarFallback>
+                </Avatar>
+                <span className="font-medium">Olivia Rhye</span>
+              </div>
+            </TableCell>
+            <TableCell>April 15, 2025</TableCell>
+            <TableCell>$160.00</TableCell>
+            <TableCell>Membership Dues</TableCell>
+            <TableCell>Card Ending ••••1234</TableCell>
+            <TableCell>
+              <div className="flex items-center gap-2">
+                <button type="button" className="p-1">
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                  </svg>
+                </button>
+                <button type="button" className="p-1">
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                </button>
+              </div>
+            </TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>
+              <div className="flex items-center gap-3">
+                <Avatar className="h-8 w-8">
+                  <AvatarFallback>OR</AvatarFallback>
+                </Avatar>
+                <span className="font-medium">Olivia Rhye</span>
+              </div>
+            </TableCell>
+            <TableCell>May 15, 2025</TableCell>
+            <TableCell>$160.00</TableCell>
+            <TableCell>Membership Dues</TableCell>
+            <TableCell>Card Ending ••••1234</TableCell>
+            <TableCell>
+              <div className="flex items-center gap-2">
+                <button type="button" className="p-1">
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                  </svg>
+                </button>
+                <button type="button" className="p-1">
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                </button>
+              </div>
+            </TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>
+              <div className="flex items-center gap-3">
+                <Avatar className="h-8 w-8">
+                  <AvatarFallback>OR</AvatarFallback>
+                </Avatar>
+                <span className="font-medium">Olivia Rhye</span>
+              </div>
+            </TableCell>
+            <TableCell>June 15, 2025</TableCell>
+            <TableCell>$160.00</TableCell>
+            <TableCell>Membership Dues</TableCell>
+            <TableCell>Card Ending ••••1234</TableCell>
+            <TableCell>
+              <div className="flex items-center gap-2">
+                <button type="button" className="p-1">
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                  </svg>
+                </button>
+                <button type="button" className="p-1">
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                </button>
+              </div>
+            </TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>
+              <div className="flex items-center gap-3">
+                <Avatar className="h-8 w-8">
+                  <AvatarFallback>OR</AvatarFallback>
+                </Avatar>
+                <span className="font-medium">Olivia Rhye</span>
+              </div>
+            </TableCell>
+            <TableCell>July 15, 2025</TableCell>
+            <TableCell>$160.00</TableCell>
+            <TableCell>Membership Dues</TableCell>
+            <TableCell>Card Ending ••••1234</TableCell>
+            <TableCell>
+              <div className="flex items-center gap-2">
+                <button type="button" className="p-1">
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                  </svg>
+                </button>
+                <button type="button" className="p-1">
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                </button>
+              </div>
+            </TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>
+              <div className="flex items-center gap-3">
+                <Avatar className="h-8 w-8">
+                  <AvatarFallback>OR</AvatarFallback>
+                </Avatar>
+                <span className="font-medium">Olivia Rhye</span>
+              </div>
+            </TableCell>
+            <TableCell>August 15, 2025</TableCell>
+            <TableCell>$160.00</TableCell>
+            <TableCell>Membership Dues</TableCell>
+            <TableCell>Card Ending ••••1234</TableCell>
+            <TableCell>
+              <div className="flex items-center gap-2">
+                <button type="button" className="p-1">
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                  </svg>
+                </button>
+                <button type="button" className="p-1">
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                </button>
+              </div>
+            </TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+
+      <div className="mt-6">
+        <Pagination
+          currentPage={currentPage}
+          totalPages={4}
+          totalItems={20}
+          itemsPerPage={5}
+          onPageChangeAction={setCurrentPage}
+        />
+      </div>
+    </div>
+  );
+}
+
+export const BillingHistory: Story = {
+  render: () => <BillingHistoryDemo />,
 };

--- a/src/components/ui/table/table.tsx
+++ b/src/components/ui/table/table.tsx
@@ -10,7 +10,7 @@ function Table({ className, ...props }: React.ComponentProps<'table'>) {
     >
       <table
         data-slot="table"
-        className={cn('w-full caption-bottom text-body font-medium', className)}
+        className={cn('w-full caption-bottom text-body font-normal', className)}
         {...props}
       />
     </div>
@@ -21,7 +21,7 @@ function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
   return (
     <thead
       data-slot="table-header"
-      className={cn('[&_tr]:border-b', className)}
+      className={cn('bg-neutral-300 [&_tr]:border-b [&_tr]:border-neutral-400', className)}
       {...props}
     />
   );
@@ -31,7 +31,7 @@ function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
   return (
     <tbody
       data-slot="table-body"
-      className={cn('[&_tr:last-child]:border-0', className)}
+      className={cn('[&_tr:last-child]:border-0 [&_tr]:border-neutral-400', className)}
       {...props}
     />
   );
@@ -42,7 +42,7 @@ function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
     <tfoot
       data-slot="table-footer"
       className={cn(
-        'bg-muted/50 border-t font-medium [&>tr]:last:border-b-0',
+        'border-t border-neutral-500 bg-neutral-200 font-medium [&>tr]:last:border-b-0',
         className,
       )}
       {...props}
@@ -55,7 +55,7 @@ function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
     <tr
       data-slot="table-row"
       className={cn(
-        'hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors',
+        'border-b border-neutral-400 transition-colors hover:bg-neutral-100 data-[state=selected]:bg-neutral-200',
         className,
       )}
       {...props}
@@ -68,7 +68,7 @@ function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
     <th
       data-slot="table-head"
       className={cn(
-        'text-body font-medium text-muted-foreground h-12 px-4 text-left align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        'h-12 px-4 text-left align-middle text-body-small font-medium text-neutral-1500 [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
         className,
       )}
       {...props}
@@ -81,7 +81,7 @@ function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
     <td
       data-slot="table-cell"
       className={cn(
-        'p-4 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        'p-4 align-middle text-neutral-1500 [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
         className,
       )}
       {...props}
@@ -96,7 +96,7 @@ function TableCaption({
   return (
     <caption
       data-slot="table-caption"
-      className={cn('text-body-small font-medium text-muted-foreground mt-4', className)}
+      className={cn('mt-4 text-body-small font-medium text-neutral-1000', className)}
       {...props}
     />
   );


### PR DESCRIPTION
Add theming to table, pagination and badge components. 

- http://localhost:6006/?path=/docs/ui-display-table--docs
- http://localhost:6006/?path=/docs/ui-utility-pagination--docs

<img width="1016" height="646" alt="Screenshot 2025-11-20 at 2 26 18 PM" src="https://github.com/user-attachments/assets/4a183db4-111d-43e2-80eb-c556fc9ff71a" />

- http://localhost:6006/?path=/docs/ui-primitives-badge--docs

<img width="1013" height="183" alt="Screenshot 2025-11-20 at 2 25 09 PM" src="https://github.com/user-attachments/assets/a65b41fb-54b7-4daf-8c91-a111fa59f129" />

 



