### PR TITLE
fix(navigation): enabled organization selector in AppSidebar

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,14 @@ const baseConfig: NextConfig = {
   outputFileTracingIncludes: {
     '/': ['./migrations/**/*'],
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'img.clerk.com',
+      },
+    ],
+  },
   experimental: {
     turbopackFileSystemCacheForDev: true,
   },

--- a/src/features/dashboard/AppSidebar.tsx
+++ b/src/features/dashboard/AppSidebar.tsx
@@ -1,16 +1,15 @@
 'use client';
 
-import { OrganizationSwitcher, useClerk } from '@clerk/nextjs';
+import { useClerk } from '@clerk/nextjs';
 import { BookMarked, Briefcase, CalendarDays, CircleUser, CreditCard, HelpCircle, Home, LogOut, Mail, Map, Megaphone, Settings, ShieldCheck, Users, Users2 } from 'lucide-react';
-import { useLocale, useTranslations } from 'next-intl';
+import { useTranslations } from 'next-intl';
 import { Badge } from '@/components/ui/badge';
 import { Sidebar, SidebarContent, SidebarHeader, SidebarRail } from '@/components/ui/sidebar';
 import { AppSidebarNav } from '@/features/dashboard/AppSidebarNav';
+import { OrganizationSelector } from '@/features/dashboard/OrganizationSelector';
 import { Logo } from '@/templates/Logo';
-import { getI18nPath } from '@/utils/Helpers';
 
 export const AppSidebar = (props: React.ComponentProps<typeof Sidebar>) => {
-  const locale = useLocale();
   const t = useTranslations('DashboardLayout');
   const { signOut } = useClerk();
 
@@ -21,22 +20,7 @@ export const AppSidebar = (props: React.ComponentProps<typeof Sidebar>) => {
           <Logo />
         </div>
 
-        <OrganizationSwitcher
-          organizationProfileMode="navigation"
-          organizationProfileUrl={getI18nPath('/dashboard/organization-profile', locale)}
-          afterCreateOrganizationUrl="/onboarding/organization-selection"
-          hidePersonal
-          skipInvitationScreen
-          appearance={{
-            elements: {
-              organizationSwitcherTrigger: 'w-64 md:w-60 justify-between',
-              organizationSwitcherPopoverRootBox: {
-                // WORKAROUND: conflict with Shadcn Sidebar, solution from https://github.com/clerk/javascript/issues/3739
-                pointerEvents: 'auto',
-              },
-            },
-          }}
-        />
+        <OrganizationSelector />
       </SidebarHeader>
       <SidebarContent>
         <AppSidebarNav

--- a/src/features/dashboard/OrganizationSelector.tsx
+++ b/src/features/dashboard/OrganizationSelector.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useClerk, useOrganization } from '@clerk/nextjs';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+
+type OrgData = {
+  id: string;
+  name: string | null;
+  image_url: string | null;
+};
+
+/**
+ * Custom organization selector component that replaces Clerk's OrganizationSwitcher.
+ * Displays organization logos and allows switching between organizations.
+ */
+export const OrganizationSelector = () => {
+  const { organization, isLoaded: orgLoaded } = useOrganization();
+  const { user, setActive } = useClerk();
+  const router = useRouter();
+  const [isChanging, setIsChanging] = useState(false);
+  const [organizations, setOrganizations] = useState<OrgData[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Get user's organizations on mount
+  useEffect(() => {
+    const fetchOrganizations = async () => {
+      if (!user) {
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        const orgs = user.organizationMemberships?.map(membership => ({
+          id: membership.organization.id,
+          name: membership.organization.name,
+          image_url: membership.organization.imageUrl,
+        })) || [];
+        setOrganizations(orgs);
+      } catch (error) {
+        console.error('Failed to fetch organizations:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchOrganizations();
+  }, [user]);
+
+  // Handle organization change
+  const handleOrganizationChange = useCallback(
+    async (organizationId: string) => {
+      if (!organizations || !setActive) {
+        return;
+      }
+
+      const selectedOrg = organizations.find(org => org.id === organizationId);
+      if (!selectedOrg) {
+        return;
+      }
+
+      setIsChanging(true);
+      try {
+        await setActive({ organization: selectedOrg.id });
+        // Refresh the page to fetch new organization data
+        router.refresh();
+      } catch (error) {
+        console.error('Failed to switch organization:', error);
+      } finally {
+        setIsChanging(false);
+      }
+    },
+    [organizations, setActive, router],
+  );
+
+  if (!orgLoaded || !organization || isLoading || organizations.length === 0) {
+    return null;
+  }
+
+  return (
+    <Select value={organization.id} onValueChange={handleOrganizationChange} disabled={isChanging}>
+      <SelectTrigger className="w-64 md:w-60">
+        <SelectValue asChild>
+          <div className="flex items-center gap-2">
+            {organization.imageUrl && (
+              <Image
+                src={organization.imageUrl}
+                alt={organization.name || 'Organization'}
+                width={20}
+                height={20}
+                className="rounded-sm object-cover"
+              />
+            )}
+            <span className="truncate">{organization.name}</span>
+          </div>
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent>
+        {organizations.map(org => (
+          <SelectItem key={org.id} value={org.id}>
+            <div className="flex items-center gap-2">
+              {org.image_url && (
+                <Image
+                  src={org.image_url}
+                  alt={org.name || 'Organization'}
+                  width={16}
+                  height={16}
+                  className="rounded-sm object-cover"
+                />
+              )}
+              <span>{org.name}</span>
+            </div>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+};


### PR DESCRIPTION
- Enabled dynamic organization selector in AppSidebar populated from Clerk. Data for Members, Staff dynamically changes based on active organization selected (will extend to other screens as they get updated).


- [x] lint, test, test:e2e, checks (deps, i18n, types) all pass without warnings or errors