### PR TITLE
fix(templates): resolve StatsCards grid layout issue

### DIFF
--- a/src/templates/StatsCards.tsx
+++ b/src/templates/StatsCards.tsx
@@ -47,7 +47,11 @@ export function StatsCards({
   fullWidth = true,
 }: StatsCardsProps) {
   const containerClass = fullWidth ? 'w-full space-y-6' : 'space-y-6';
-  const gridClass = `grid grid-cols-1 gap-4 md:grid-cols-${columns}`;
+
+  // Use explicit class names to ensure they're included in Tailwind's CSS bundle
+  const gridClass = columns === 3
+    ? 'grid grid-cols-1 gap-4 md:grid-cols-3'
+    : 'grid grid-cols-1 gap-4 md:grid-cols-4';
 
   return (
     <div className={`${containerClass} ${className}`.trim()}>


### PR DESCRIPTION
fix(templates): resolve StatsCards grid layout issue with dynamic Tailwind classes

Replace dynamic CSS class generation with explicit conditional logic 
to ensure Tailwind CSS classes are properly included in the build.
The template literal approach `md:grid-cols-${columns}` was causing
grid layout failures due to CSS purging issues.

- Use explicit class names for 3 and 4 column layouts
- Add comment explaining the change rationale
- Fixes StatsCards display on programs page and other pages using this template

- [x] test, test:e2e, check (deps, i18n, types), lint all pass without warnings or errors