### PR TITLE
chore(members): fixed ability to add member on failed payment

### DIFF
--- a/src/features/members/wizard/AddMemberModal.tsx
+++ b/src/features/members/wizard/AddMemberModal.tsx
@@ -165,7 +165,7 @@ export const AddMemberModal = ({ isOpen, onCloseAction }: AddMemberModalProps) =
 
   return (
     <Dialog open={isOpen} onOpenChange={isOpen => !isOpen && handleCancel()}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="sm:max-w-3xl">
         <DialogHeader>
           <DialogTitle>
             {wizard.step === 'member-type' && 'Choose Member Type'}

--- a/src/features/members/wizard/MemberPaymentStep.tsx
+++ b/src/features/members/wizard/MemberPaymentStep.tsx
@@ -197,9 +197,6 @@ export const MemberPaymentStep = ({
 
   const isFormValid = isCardFormValid || isAchFormValid;
 
-  // Payment can proceed only if payment was approved (not just processed)
-  const canProceed = paymentProcessed === true && paymentStatus === 'approved';
-
   const handleProcessPayment = async () => {
     if (!isFormValid || isProcessingPayment) {
       return;
@@ -494,7 +491,8 @@ export const MemberPaymentStep = ({
           </Button>
         </div>
         <div className="flex gap-3">
-          {!canProceed && (
+          {/* Show Process Payment button when payment has not been processed yet */}
+          {!paymentProcessed && (
             <Button
               onClick={handleProcessPayment}
               disabled={!isFormValid || isProcessingPayment || isLoading}
@@ -509,7 +507,30 @@ export const MemberPaymentStep = ({
                 : t('process_payment_button')}
             </Button>
           )}
-          {canProceed && (
+          {/* When payment is declined, show both Retry and Continue Anyway buttons */}
+          {paymentStatus === 'declined' && (
+            <>
+              <Button
+                variant="outline"
+                onClick={handleProcessPayment}
+                disabled={!isFormValid || isProcessingPayment || isLoading}
+              >
+                {isProcessingPayment
+                  ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        {t('processing_button')}
+                      </>
+                    )
+                  : t('retry_payment_button')}
+              </Button>
+              <Button onClick={onNextAction} disabled={isLoading} variant="destructive">
+                {isLoading ? `${t('continue_anyway_button')}...` : t('continue_anyway_button')}
+              </Button>
+            </>
+          )}
+          {/* Show Next button when payment is approved */}
+          {paymentStatus === 'approved' && (
             <Button onClick={onNextAction} disabled={isLoading}>
               {isLoading ? `${t('next_button')}...` : t('next_button')}
             </Button>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -321,6 +321,8 @@
       "cancel_button": "Cancel",
       "next_button": "Next",
       "process_payment_button": "Process Payment",
+      "retry_payment_button": "Retry Payment",
+      "continue_anyway_button": "Continue Anyway",
       "processing_button": "Processing...",
       "payment_approved_title": "Payment Approved",
       "payment_approved_message": "The payment has been successfully processed. You can now proceed to complete member registration.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -321,6 +321,8 @@
       "cancel_button": "Annuler",
       "next_button": "Suivant",
       "process_payment_button": "Traiter le paiement",
+      "retry_payment_button": "Réessayer le paiement",
+      "continue_anyway_button": "Continuer quand même",
       "processing_button": "Traitement en cours...",
       "payment_approved_title": "Paiement approuvé",
       "payment_approved_message": "Le paiement a été traité avec succès. Vous pouvez maintenant terminer l'inscription du membre.",


### PR DESCRIPTION
- fixed ability to add member on failed payment
- increased width of modal dialog for payment step to allow for buttons and alerts

- [x] test, test:e2e, lint, check (deps, i18n, types) all pass without warnings or errors