### PR TITLE
feat(dx): added MCP server configuration for Claude Code integration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,26 @@
+{
+  "mcpServers": {
+    "postgres": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-postgres"],
+      "env": {
+        "DATABASE_URL": "${DATABASE_URL}"
+      }
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    },
+    "fetch": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-fetch"]
+    },
+    "puppeteer": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-puppeteer"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -187,6 +187,46 @@ npm run check:deps    # Detect unused dependencies
 npm run check:i18n    # Validate translations
 ```
 
+## Claude Code MCP Setup
+
+This project includes MCP (Model Context Protocol) server configuration for enhanced AI-assisted development with Claude Code. The `.mcp.json` file configures servers for database queries, GitHub integration, web fetching, and browser automation.
+
+### Required Environment Variables
+
+MCP servers read from your **shell environment**, not from `.env.local`. Add the following to your `~/.zshenv` (this file is read by GUI apps on macOS):
+
+```shell
+# Required for postgres MCP server
+export DATABASE_URL=your_postgres_connection_string
+
+# Required for GitHub MCP server
+export GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxxxxxxxxxxx
+```
+
+After editing, fully quit and reopen VSCode (Cmd+Q, then relaunch).
+
+### Creating a GitHub Personal Access Token
+
+1. Go to [GitHub Token Settings](https://github.com/settings/tokens?type=beta)
+2. Click **"Generate new token"**
+3. Configure:
+   - **Token name:** `Claude Code MCP`
+   - **Expiration:** 90 days (or your preference)
+   - **Repository access:** Select this repository
+   - **Permissions:** `Contents` (read), `Pull requests` (read/write), `Issues` (read/write)
+4. Add the token to `~/.zshenv` (required for GUI apps on macOS)
+
+### Available MCP Servers
+
+| Server | Purpose | Requires |
+|--------|---------|----------|
+| `postgres` | Query database, inspect schemas | `DATABASE_URL` |
+| `github` | Manage PRs, issues, view CI status | `GITHUB_PERSONAL_ACCESS_TOKEN` |
+| `fetch` | Enhanced web requests for API testing | Nothing |
+| `puppeteer` | Browser automation, screenshots, E2E test development | Nothing |
+
+After configuring, restart Claude Code to load the MCP servers.
+
 ## Commit Messages
 
 The project uses [Conventional Commits](https://www.conventionalcommits.org/). Use the interactive CLI to write properly formatted commit messages:

--- a/claude.md
+++ b/claude.md
@@ -253,6 +253,45 @@ npm run stripe:setup-price # Create test prices
 - Console + remote ingestion
 - Conditional based on env vars
 
+### MCP Servers (Claude Code Integration)
+
+**Config:** `.mcp.json`
+
+MCP (Model Context Protocol) servers extend Claude Code's capabilities for this project.
+
+**Available Servers:**
+
+| Server | Package | Purpose |
+|--------|---------|---------|
+| `postgres` | `@modelcontextprotocol/server-postgres` | Query database, inspect schemas, debug data |
+| `github` | `@modelcontextprotocol/server-github` | PRs, issues, CI status, code search |
+| `fetch` | `@modelcontextprotocol/server-fetch` | Enhanced web requests, API testing |
+| `puppeteer` | `@modelcontextprotocol/server-puppeteer` | Browser automation, screenshots, E2E test development |
+
+**Environment Variables (shell environment, not `.env.local`):**
+
+MCP servers read from your shell environment. Add to `~/.zshenv` (required for GUI apps on macOS):
+```bash
+# Required for postgres server
+export DATABASE_URL=postgresql://...
+
+# Required for github server
+export GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxxxxxxxxxxx
+```
+
+After editing, fully quit and reopen VSCode (Cmd+Q, then relaunch).
+
+**Usage Examples:**
+- "Query the members table" → Uses postgres server
+- "List open PRs" → Uses github server
+- "Navigate to localhost:3000/dashboard and take a screenshot" → Uses puppeteer server
+
+**Puppeteer + Playwright Workflow:**
+The puppeteer server helps with E2E test development:
+1. Navigate to pages and take screenshots to see current state
+2. Discover selectors interactively before writing Playwright tests
+3. Validate user flows manually before codifying them
+
 ## Storybook
 
 **Framework:** `@storybook/nextjs-vite` v10.1.11


### PR DESCRIPTION
Add project-level MCP (Model Context Protocol) configuration to enhance
Claude Code capabilities with database queries, GitHub integration,
web fetching, and browser automation for E2E test development.

Changes:
- Add .mcp.json with postgres, github, fetch, and puppeteer servers
- Document MCP setup in README.md with environment variable instructions
- Add MCP servers section to CLAUDE.md under Vendor Integrations

Environment setup (macOS):
MCP servers read from shell environment, not .env.local. Add to ~/.zshenv:

  export DATABASE_URL=postgresql://...
  export GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxxxxxxxxxxx

Then fully quit and reopen VSCode (Cmd+Q) to load the new variables.

GitHub PAT requires: Contents (read), Pull requests (read/write), Issues (read/write)
Create at: https://github.com/settings/tokens?type=beta

MCP servers are optional - Claude Code works normally without them.