### PR TITLE
feat(security): implement csp for soc2 compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ A comprehensive web-based management system for martial arts dojos. Dojo Planner
 - **Framework**: Next.js with App Router
 - **Language**: TypeScript
 - **Styling**: Tailwind CSS with Shadcn UI components
+- **Typography**: Inter font (self-hosted via `next/font`)
 - **Authentication**: Clerk
 - **Database**: PostgreSQL via DrizzleORM
 - **Payments**: Stripe
@@ -186,6 +187,23 @@ npm run check:types   # TypeScript type checking
 npm run check:deps    # Detect unused dependencies
 npm run check:i18n    # Validate translations
 ```
+
+## Security
+
+### Content Security Policy (CSP)
+
+The application implements a strict Content Security Policy for SOC2 CC6.6 compliance, protecting against XSS attacks. Configuration is in `next.config.ts`.
+
+**Whitelisted vendors:**
+- **Clerk** - Authentication (`*.clerk.com`, `*.clerk.accounts.dev`)
+- **Sentry** - Error monitoring (`*.ingest.sentry.io`, `sentry.io`)
+- **Upstash** - Rate limiting (`*.upstash.io`)
+- **Better Stack** - Logging (`*.betterstack.com`)
+
+**Key notes:**
+- `'unsafe-inline'` is required in `script-src` (Next.js) and `style-src` (Clerk)
+- Inter font is self-hosted via `next/font` enabling strict `font-src 'self'`
+- See `claude.md` for detailed CSP documentation and how to add new vendors
 
 ## Claude Code MCP Setup
 

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -2,10 +2,18 @@ import type { Metadata } from 'next';
 import { NextIntlClientProvider } from 'next-intl';
 import { setRequestLocale } from 'next-intl/server';
 import { ThemeProvider } from 'next-themes';
+import { Inter } from 'next/font/google';
 import { notFound } from 'next/navigation';
 import { routing } from '@/libs/I18nRouting';
 import { runMigrations } from '@/libs/RunMigrations';
 import '@/styles/global.css';
+
+// Self-hosted Inter font via next/font (eliminates rsms.me external dependency for CSP)
+const inter = Inter({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-inter',
+});
 
 export const metadata: Metadata = {
   icons: [
@@ -70,8 +78,8 @@ export default async function RootLayout(props: {
   await runMigrations();
 
   return (
-    <html lang={locale} suppressHydrationWarning>
-      <body>
+    <html lang={locale} suppressHydrationWarning className={inter.variable}>
+      <body className={inter.className}>
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,8 +1,5 @@
 @layer theme, base, clerk, components, utilities; /* Ensure Clerk is compatible with Tailwind CSS v4 */
 
-/* Inter font import - must be at the top */
-@import url('https://rsms.me/inter/inter.css');
-
 @import 'tailwindcss';
 @import './dojo-planner-colors.css';
 
@@ -12,8 +9,8 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
-  /* Typography - Font Family */
-  --font-family-inter: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  /* Typography - Font Family (uses --font-inter CSS variable from next/font) */
+  --font-family-inter: var(--font-inter), -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --font-sans: var(--font-family-inter);
 
   /* Typography - Text Styles */


### PR DESCRIPTION
Add comprehensive CSP header to protect against XSS attacks:
- Whitelist Clerk, Sentry, Upstash, Better Stack domains
- Self-host Inter font via next/font (eliminates rsms.me dependency)
- Document CSP configuration in README.md and claude.md

## SOC2 Compliance Coverage

| Control | Description | Implementation |
|---------|-------------|----------------|
| CC6.6 | Logical Access Security | CSP prevents XSS by restricting resource loading |
| CC6.6 | Boundary Protection | `default-src 'self'` blocks unauthorized origins |
| CC6.6 | Input/Output Controls | `form-action 'self'` restricts form submissions |
| CC6.1 | Access Controls | `frame-src` restricts iframe embedding |

## Files Changed

| File | Change |
|------|--------|
| `next.config.ts` | CSP header implementation |
| `src/app/[locale]/layout.tsx` | Self-hosted Inter font via next/font |
| `src/styles/global.css` | Use CSS variable for font-family |
| `README.md` | Security section with CSP documentation |
| `claude.md` | Detailed CSP configuration guide |

## Limitations

- `'unsafe-inline'` required in `script-src` (Next.js theme/RSC)
- `'unsafe-inline'` required in `style-src` (Clerk inline styles)