### PR TITLE
Fix for Useless assignment to local variable

### DIFF
--- a/src/app/[locale]/api/organization/[orgId]/subscription/route.ts
+++ b/src/app/[locale]/api/organization/[orgId]/subscription/route.ts
@@ -25,7 +25,7 @@ export async function GET(
     const planDetails = determineSubscriptionPlan(subscription);
 
     // Map plan ID to subscription type for display
-    let subscriptionType: 'free' | 'free_trial' | 'monthly' | 'annual' = 'free';
+    let subscriptionType: 'free' | 'free_trial' | 'monthly' | 'annual';
 
     switch (planDetails.plan.id) {
       case PLAN_ID.ANNUAL:


### PR DESCRIPTION
In general, the way to fix this issue is to avoid assigning an initial value to a local variable if that value is never read before being overwritten. You can keep the type annotation for clarity and type safety, but omit the initializer so the variable is only assigned when it is actually needed.

In this specific code, the best fix is to declare `subscriptionType` with its union type but without initializing it to `'free'`. Because every branch of the `switch` (including the `default`) assigns a value to `subscriptionType` before it is used in the `NextResponse.json` call, TypeScript will still infer that `subscriptionType` is definitely assigned along all control-flow paths, and runtime behavior remains unchanged. Concretely, on line 28, change `let subscriptionType: 'free' | 'free_trial' | 'monthly' | 'annual' = 'free';` to `let subscriptionType: 'free' | 'free_trial' | 'monthly' | 'annual';`. No additional imports, methods, or other definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._