### PR TITLE
Fix for Useless assignment to local variable

### DIFF
--- a/src/features/catalog/CatalogPage.tsx
+++ b/src/features/catalog/CatalogPage.tsx
@@ -138,7 +138,7 @@ export function CatalogPage({ organizationId }: CatalogPageProps) {
 
   const handleSaveItem = useCallback(async (formData: CatalogItemFormData, isEdit: boolean, itemId?: string) => {
     try {
-      let savedItemId = itemId;
+      let savedItemId: string | undefined;
 
       if (isEdit && itemId) {
         // Update existing item


### PR DESCRIPTION
To fix the problem, remove the useless initialization so that `savedItemId` is declared without an initial value and only set when needed. This preserves existing functionality while eliminating the dead assignment.

Concretely, in `src/features/catalog/CatalogPage.tsx` inside `handleSaveItem`, change `let savedItemId = itemId;` to a declaration without initialization, e.g. `let savedItemId: string | undefined;`. This keeps the variable available for the `else` (create) branch where it is later assigned and used in the `imageCreate` call, and does not affect the edit branch which never uses `savedItemId`. No new imports or helper functions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._