### PR TITLE
fix(payments): reconcile payments using rest api per kiosk changes

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -363,15 +363,16 @@ npm run stripe:setup-price # Create test prices
 
 ### IQPro (Member Payments)
 
-**Package:** `@dojo-planner/iqpro-client` (GitHub)
+**Transport:** Direct REST API via `fetch` — **no SDK dependency at runtime**. Every IQPro call logs the full request body and full response body (or error body) via the structured `logger` so vague IQPro 4xx errors can be diagnosed from Better Stack without re-running.
 
-**Purpose:** Processes member-level payments (one-time charges and recurring autopay subscriptions). Organization-level SaaS billing continues through Stripe.
+**Purpose:** Processes member-level payments (one-time charges and recurring autopay subscriptions) and organization-level SaaS subscriptions. Stripe remains as a legacy fallback for org-level billing only.
 
 **Key Files:**
-- `src/libs/IQPro.ts` - Client singleton, OAuth token management, tokenization config endpoint, ACH tokenization (`tokenizeAch`), gateway processor lookup (`getGatewayProcessors`)
-- `src/services/PaymentProviderService.ts` - Provider-agnostic interface + factory
-- `src/services/IQProPaymentService.ts` - IQPro implementation (InsertCard schema with token + maskedCard BIN format; ACH tokenization via `tokenizeAch` before InsertAch)
-- `src/services/MemberPaymentService.ts` - Payment orchestration (customer → method → charge/subscription → DB)
+- `src/libs/IQPro.ts` - REST helpers (`iqproPost`, `iqproGet`, `iqproPut`), OAuth token management, tokenization config endpoint, ACH tokenization (`tokenizeAch`), gateway processor lookup (`getGatewayProcessors`), server-authoritative fee calculation (`calculateTransactionFees`)
+- `src/services/PaymentProviderService.ts` - Provider-agnostic interface + factory; defines `FeeBreakdown`, `TransactionLineItem`, `TransactionBillingAddress` types
+- `src/services/IQProPaymentService.ts` - IQPro implementation (REST). `createCustomer` returns `{ customerId, billingAddressId }` (the billing-address ID is fetched via `iqproGet` and forwarded into transaction payloads as `paymentMethod.customer.customerBillingAddressId` so the ACH processor can resolve the cardholder name). Card uses InsertCard schema with token + maskedCard BIN format; ACH uses `tokenizeAch` then InsertAch. `processPayment` builds the canonical `Sale` payload with `remit` (tax + paymentAdjustments), `address[]`, and `lineItems[]`. Sandbox certification errors on ACH (`"not a valid transaction for certification"`) are tolerated as `pendingsettlement → approved` so dev flows work.
+- `src/services/MemberPaymentService.ts` - Payment orchestration (customer → method → calculate fees → charge/subscription → DB). Tax state for fee calculation comes from `params.memberAddress.state`. For autopay: subscription is created **and** an immediate Sale charge runs for the first period (IQPro subscriptions don't auto-charge on creation). If the initial charge fails after subscription creation, the failure is surfaced and `iqproSubscriptionId` is NOT persisted on the membership — the IQPro subscription will exist but the local membership stays unactivated.
+- `src/services/SaasSubscriptionService.ts` - Org SaaS subscriptions via REST. Uses `iqproPost`/`iqproGet`/`iqproPut` for customer create, payment method, subscription create/get/update, and cancel.
 - `src/routers/Payment.ts` - ORPC `payment.process` + `payment.getTokenizationConfig` endpoints
 - `src/validations/PaymentValidation.ts` - Zod input schema
 - `src/app/[locale]/webhook/iqpro/route.ts` - Webhook handler

--- a/knip.json
+++ b/knip.json
@@ -13,7 +13,6 @@
   "ignoreDependencies": [
     "@swc/helpers",
     "@semantic-release/npm",
-    "@dojo-planner/iqpro-client",
     "conventional-changelog-conventionalcommits",
     "tw-animate-css"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@clerk/localizations": "^3.37.2",
         "@clerk/nextjs": "^6.39.0",
         "@clerk/themes": "^2.4.57",
-        "@dojo-planner/iqpro-client": "github:rccn-llc/iqpro-client",
         "@logtape/logtape": "^1.3.7",
         "@orpc/client": "^1.13.5",
         "@orpc/server": "^1.13.5",
@@ -1679,39 +1678,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@dojo-planner/iqpro-client": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/rccn-llc/iqpro-client.git#0d983f91fae0061af8e47ed0119802d2a9b28d4f",
-      "license": "MIT",
-      "dependencies": {
-        "dotenv": "^16.3.1",
-        "zod": "^3.22.4"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@dojo-planner/iqpro-client/node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/@dojo-planner/iqpro-client/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@dprint/formatter": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@clerk/localizations": "^3.37.2",
     "@clerk/nextjs": "^6.39.0",
     "@clerk/themes": "^2.4.57",
-    "@dojo-planner/iqpro-client": "github:rccn-llc/iqpro-client",
     "@logtape/logtape": "^1.3.7",
     "@orpc/client": "^1.13.5",
     "@orpc/server": "^1.13.5",

--- a/src/libs/IQPro.test.ts
+++ b/src/libs/IQPro.test.ts
@@ -16,14 +16,23 @@ vi.mock('./Env', () => ({
   },
 }));
 
-// Mock Logger
+// Mock Logger — capture every log so tests can assert the full request/response
+// payload tracing required for IQPro debugging.
+const mockLogger = {
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+};
 vi.mock('./Logger', () => ({
-  logger: {
-    info: vi.fn(),
-    error: vi.fn(),
-    warn: vi.fn(),
-  },
+  logger: mockLogger,
 }));
+
+function mockOAuthOk() {
+  mockFetch.mockResolvedValueOnce(new Response(
+    JSON.stringify({ access_token: 'test-bearer-token-123', expires_in: 3600 }),
+    { status: 200 },
+  ));
+}
 
 describe('tokenizeAch', () => {
   beforeEach(() => {
@@ -215,6 +224,273 @@ describe('tokenizeAch', () => {
     })).rejects.toThrow('IQPro is not configured');
 
     // Restore original mock for other tests
+    vi.doMock('./Env', () => ({
+      Env: {
+        IQPRO_CLIENT_ID: 'test-client-id',
+        IQPRO_CLIENT_SECRET: 'test-client-secret',
+        IQPRO_SCOPE: 'test-scope',
+        IQPRO_OAUTH_URL: 'https://sandbox.oauth.example.com/token',
+        IQPRO_BASE_URL: 'https://sandbox.api.basyspro.com',
+        IQPRO_GATEWAY_ID: 'test-gateway-id',
+      },
+    }));
+  });
+});
+
+describe('iqproPost', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('logs both request body and response body in full', async () => {
+    const mod = await import('./IQPro');
+    mod.resetOAuthToken();
+
+    mockOAuthOk();
+    mockFetch.mockResolvedValueOnce(new Response(
+      JSON.stringify({ data: { customerId: 'cust_42' } }),
+      { status: 200 },
+    ));
+
+    const requestBody = { name: 'Acme', referenceId: 'mem_1' };
+    const result = await mod.iqproPost('/api/gateway/test-gateway-id/customer', requestBody);
+
+    expect(result).toEqual({ data: { customerId: 'cust_42' } });
+
+    // Request body must be logged with the full JSON serialized
+    const requestLog = mockLogger.info.mock.calls.find(c => c[0] === '[IQPro] POST request');
+
+    expect(requestLog?.[1]).toEqual({
+      path: '/api/gateway/test-gateway-id/customer',
+      body: JSON.stringify(requestBody, null, 2),
+    });
+
+    // Response body must also be logged in full
+    const responseLog = mockLogger.info.mock.calls.find(c => c[0] === '[IQPro] POST response');
+
+    expect(responseLog?.[1]).toEqual({
+      path: '/api/gateway/test-gateway-id/customer',
+      status: 200,
+      response: JSON.stringify({ data: { customerId: 'cust_42' } }),
+    });
+  });
+
+  it('logs the full error body on failure and throws with status', async () => {
+    const mod = await import('./IQPro');
+    mod.resetOAuthToken();
+
+    mockOAuthOk();
+    mockFetch.mockResolvedValueOnce(new Response(
+      'Validation failed: missing field',
+      { status: 400 },
+    ));
+
+    await expect(
+      mod.iqproPost('/api/gateway/test-gateway-id/customer', { x: 1 }),
+    ).rejects.toThrow('IQPro API /api/gateway/test-gateway-id/customer failed: 400 Validation failed: missing field');
+
+    expect(mockLogger.error).toHaveBeenCalledWith('[IQPro] POST failed', {
+      path: '/api/gateway/test-gateway-id/customer',
+      status: 400,
+      response: 'Validation failed: missing field',
+    });
+  });
+});
+
+describe('iqproGet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('returns parsed JSON and logs request + response', async () => {
+    const mod = await import('./IQPro');
+    mod.resetOAuthToken();
+
+    mockOAuthOk();
+    mockFetch.mockResolvedValueOnce(new Response(
+      JSON.stringify({ data: { addresses: [{ customerAddressId: 'addr_1', isBilling: true }] } }),
+      { status: 200 },
+    ));
+
+    const result = await mod.iqproGet<{ data: { addresses: Array<{ customerAddressId: string }> } }>(
+      '/api/gateway/test-gateway-id/customer/cust_42',
+    );
+
+    expect(result.data.addresses[0]?.customerAddressId).toBe('addr_1');
+    expect(mockLogger.info).toHaveBeenCalledWith('[IQPro] GET request', {
+      path: '/api/gateway/test-gateway-id/customer/cust_42',
+    });
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      '[IQPro] GET response',
+      expect.objectContaining({
+        path: '/api/gateway/test-gateway-id/customer/cust_42',
+        status: 200,
+      }),
+    );
+  });
+});
+
+describe('iqproPut', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('PUTs the body and returns parsed JSON', async () => {
+    const mod = await import('./IQPro');
+    mod.resetOAuthToken();
+
+    mockOAuthOk();
+    mockFetch.mockResolvedValueOnce(new Response(
+      JSON.stringify({ data: { id: 'sub_1' } }),
+      { status: 200 },
+    ));
+
+    const result = await mod.iqproPut('/api/gateway/test-gateway-id/subscription/sub_1', { name: 'X' });
+
+    expect(result).toEqual({ data: { id: 'sub_1' } });
+
+    const call = mockFetch.mock.calls.find(c => (c[0] as string).includes('/subscription/sub_1'))!;
+
+    expect(call[1].method).toBe('PUT');
+    expect(JSON.parse(call[1].body)).toEqual({ name: 'X' });
+  });
+});
+
+describe('calculateTransactionFees', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('sends token (not BIN) when both could be supplied', async () => {
+    const mod = await import('./IQPro');
+    mod.resetOAuthToken();
+
+    mockOAuthOk();
+    mockFetch.mockResolvedValueOnce(new Response(
+      JSON.stringify({
+        data: {
+          baseAmount: 100,
+          taxAmount: 8.5,
+          surchargeAmount: 3,
+          serviceFeesAmount: 0,
+          convenienceFeesAmount: 0,
+          amount: 111.5,
+          isSurchargeable: true,
+          isPinCapable: false,
+          surchargeRate: 0.03,
+          tip: 0,
+          cardBrand: 'Visa',
+          cardType: 'credit',
+        },
+      }),
+      { status: 200 },
+    ));
+
+    const result = await mod.calculateTransactionFees({
+      baseAmount: 100,
+      processorId: 'proc_1',
+      state: 'CA',
+      paymentMethod: 'card',
+      token: 'tok_xyz',
+      creditCardBin: '424242',
+    });
+
+    expect(result.amount).toBe(111.5);
+    expect(result.surchargeAmount).toBe(3);
+
+    const feesCall = mockFetch.mock.calls.find(c => (c[0] as string).includes('/calculatefees'))!;
+    const body = JSON.parse(feesCall[1].body);
+
+    // token preferred over BIN
+    expect(body.token).toBe('tok_xyz');
+    expect(body.creditCardBin).toBeUndefined();
+    expect(body.state).toBe('CA');
+    expect(body.processorId).toBe('proc_1');
+    expect(body.transactionType).toBe('Sale');
+    expect(body.addTaxToTotal).toBe(true);
+  });
+
+  it('falls back to BIN when no token is provided', async () => {
+    const mod = await import('./IQPro');
+    mod.resetOAuthToken();
+
+    mockOAuthOk();
+    mockFetch.mockResolvedValueOnce(new Response(
+      JSON.stringify({ data: { baseAmount: 50, taxAmount: 0, surchargeAmount: 0, serviceFeesAmount: 0, convenienceFeesAmount: 0, amount: 50, isSurchargeable: false, isPinCapable: false, surchargeRate: 0, tip: 0, cardBrand: null, cardType: null } }),
+      { status: 200 },
+    ));
+
+    await mod.calculateTransactionFees({
+      baseAmount: 50,
+      processorId: 'proc_1',
+      state: 'CA',
+      paymentMethod: 'card',
+      creditCardBin: '424242',
+    });
+
+    const feesCall = mockFetch.mock.calls.find(c => (c[0] as string).includes('/calculatefees'))!;
+    const body = JSON.parse(feesCall[1].body);
+
+    expect(body.token).toBeUndefined();
+    expect(body.creditCardBin).toBe('424242');
+  });
+});
+
+describe('getGatewayProcessors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('extracts default card and ACH processor IDs', async () => {
+    const mod = await import('./IQPro');
+    mod.resetOAuthToken();
+    mod.resetGatewayProcessors();
+
+    mockOAuthOk();
+    mockFetch.mockResolvedValueOnce(new Response(
+      JSON.stringify({
+        data: {
+          processors: [
+            { processorId: 'card_proc', isDefaultCard: true, isDefaultAch: false },
+            { processorId: 'ach_proc', isDefaultCard: false, isDefaultAch: true },
+            { processorId: 'other_proc', isDefaultCard: false, isDefaultAch: false },
+          ],
+        },
+      }),
+      { status: 200 },
+    ));
+
+    const result = await mod.getGatewayProcessors();
+
+    expect(result).toEqual({ cardProcessorId: 'card_proc', achProcessorId: 'ach_proc' });
+  });
+
+  it('returns nulls when IQPro is not configured', async () => {
+    vi.doMock('./Env', () => ({
+      Env: {
+        IQPRO_CLIENT_ID: undefined,
+        IQPRO_CLIENT_SECRET: undefined,
+        IQPRO_SCOPE: undefined,
+        IQPRO_OAUTH_URL: undefined,
+        IQPRO_BASE_URL: undefined,
+        IQPRO_GATEWAY_ID: undefined,
+      },
+    }));
+    vi.resetModules();
+
+    const { getGatewayProcessors, resetGatewayProcessors } = await import('./IQPro');
+
+    resetGatewayProcessors();
+    const result = await getGatewayProcessors();
+
+    expect(result).toEqual({ cardProcessorId: null, achProcessorId: null });
+
+    // Restore
     vi.doMock('./Env', () => ({
       Env: {
         IQPRO_CLIENT_ID: 'test-client-id',

--- a/src/libs/IQPro.ts
+++ b/src/libs/IQPro.ts
@@ -1,11 +1,13 @@
+/**
+ * IQPro REST integration.
+ *
+ * All calls go directly through `fetch` with an OAuth bearer token — no SDK
+ * dependency. Every request and response is logged in full so vague IQPro
+ * 4xx errors can be diagnosed from Better Stack without re-running the call.
+ */
+
 import { Env } from './Env';
 import { logger } from './Logger';
-
-// Module name as a variable so that bundlers (turbopack / webpack) do NOT
-// statically resolve the optional @dojo-planner/iqpro-client package.
-const IQPRO_MODULE = '@dojo-planner/iqpro-client';
-
-let iqproClient: unknown | null = null;
 
 // ===== Tokenization config types =====
 
@@ -33,32 +35,7 @@ export function isIQProConfigured(): boolean {
   );
 }
 
-/**
- * Get the IQPro client singleton. Returns null if not configured.
- * Lazily initialized on first call.
- */
-export async function getIQProClient(): Promise<unknown | null> {
-  if (!isIQProConfigured()) {
-    return null;
-  }
-
-  if (!iqproClient) {
-    const mod = await import(/* webpackIgnore: true */ IQPRO_MODULE);
-    const IQProClient = mod.IQProClient;
-    iqproClient = new IQProClient({
-      clientId: Env.IQPRO_CLIENT_ID!,
-      clientSecret: Env.IQPRO_CLIENT_SECRET!,
-      scope: Env.IQPRO_SCOPE!,
-      oauthUrl: Env.IQPRO_OAUTH_URL!,
-      baseUrl: Env.IQPRO_BASE_URL!,
-    });
-    (iqproClient as { setGatewayContext: (id: string) => void }).setGatewayContext(Env.IQPRO_GATEWAY_ID!);
-  }
-
-  return iqproClient;
-}
-
-// ===== Tokenization config =====
+// ===== OAuth token (cached per process) =====
 
 let cachedOAuthToken: { token: string; expiresAt: number } | null = null;
 
@@ -94,6 +71,136 @@ async function getOAuthToken(): Promise<string> {
   return cachedOAuthToken.token;
 }
 
+// ===== REST helpers =====
+
+/**
+ * Authenticated POST to the IQPro gateway API.
+ * Logs the full request body and full response body (or error body).
+ */
+export async function iqproPost<T = Record<string, unknown>>(
+  path: string,
+  body: unknown,
+): Promise<T> {
+  const token = await getOAuthToken();
+  const baseUrl = Env.IQPRO_BASE_URL!;
+
+  logger.info('[IQPro] POST request', {
+    path,
+    body: JSON.stringify(body, null, 2),
+  });
+
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  const text = await res.text();
+
+  if (!res.ok) {
+    logger.error('[IQPro] POST failed', {
+      path,
+      status: res.status,
+      response: text || '(empty body)',
+    });
+    throw new Error(`IQPro API ${path} failed: ${res.status} ${text}`);
+  }
+
+  logger.info('[IQPro] POST response', {
+    path,
+    status: res.status,
+    response: text || '(empty body)',
+  });
+
+  return text ? (JSON.parse(text) as T) : ({} as T);
+}
+
+/**
+ * Authenticated PUT to the IQPro gateway API.
+ * Logs the full request body and full response body (or error body).
+ */
+export async function iqproPut<T = Record<string, unknown>>(
+  path: string,
+  body: unknown,
+): Promise<T> {
+  const token = await getOAuthToken();
+  const baseUrl = Env.IQPRO_BASE_URL!;
+
+  logger.info('[IQPro] PUT request', {
+    path,
+    body: JSON.stringify(body, null, 2),
+  });
+
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: 'PUT',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  const text = await res.text();
+
+  if (!res.ok) {
+    logger.error('[IQPro] PUT failed', {
+      path,
+      status: res.status,
+      response: text || '(empty body)',
+    });
+    throw new Error(`IQPro API PUT ${path} failed: ${res.status} ${text}`);
+  }
+
+  logger.info('[IQPro] PUT response', {
+    path,
+    status: res.status,
+    response: text || '(empty body)',
+  });
+
+  return text ? (JSON.parse(text) as T) : ({} as T);
+}
+
+/**
+ * Authenticated GET to the IQPro gateway API.
+ * Logs the path and full response body (or error body).
+ */
+export async function iqproGet<T = Record<string, unknown>>(
+  path: string,
+): Promise<T> {
+  const token = await getOAuthToken();
+  const baseUrl = Env.IQPRO_BASE_URL!;
+
+  logger.info('[IQPro] GET request', { path });
+
+  const res = await fetch(`${baseUrl}${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  const text = await res.text();
+
+  if (!res.ok) {
+    logger.error('[IQPro] GET failed', {
+      path,
+      status: res.status,
+      response: text || '(empty body)',
+    });
+    throw new Error(`IQPro API GET ${path} failed: ${res.status}`);
+  }
+
+  logger.info('[IQPro] GET response', {
+    path,
+    status: res.status,
+    response: text || '(empty body)',
+  });
+
+  return text ? (JSON.parse(text) as T) : ({} as T);
+}
+
+// ===== Tokenization config =====
+
 /**
  * Fetch the tokenization iframe configuration from the IQPro API.
  * Returns null if IQPro is not configured.
@@ -117,7 +224,11 @@ export async function getTokenizationConfig(clientOrigin: string): Promise<Token
   });
 
   if (!res.ok) {
-    logger.error('[IQPro] Failed to fetch tokenization config', { status: res.status });
+    const errorBody = await res.text().catch(() => '');
+    logger.error('[IQPro] Failed to fetch tokenization config', {
+      status: res.status,
+      response: errorBody || '(empty body)',
+    });
     throw new Error(`Tokenization config request failed: ${res.status}`);
   }
 
@@ -179,6 +290,18 @@ export async function tokenizeAch(params: TokenizeAchParams): Promise<TokenizeAc
   const token = await getOAuthToken();
   // The vault API lives at the domain root, not under the /iqsaas/v1 path prefix
   const vaultBaseUrl = new URL(Env.IQPRO_BASE_URL!).origin;
+  const requestBody = {
+    accountNumber: params.accountNumber,
+    routingNumber: params.routingNumber,
+    secCode: params.secCode ?? 'WEB',
+    achAccountType: params.achAccountType ?? 'Checking',
+  };
+
+  logger.info('[IQPro] ACH tokenize request', {
+    routingNumber: params.routingNumber,
+    accountType: requestBody.achAccountType,
+    secCode: requestBody.secCode,
+  });
 
   const res = await fetch(`${vaultBaseUrl}/vault/api/v1/Tokenize/Ach`, {
     method: 'POST',
@@ -186,21 +309,25 @@ export async function tokenizeAch(params: TokenizeAchParams): Promise<TokenizeAc
       'Authorization': `Bearer ${token}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({
-      accountNumber: params.accountNumber,
-      routingNumber: params.routingNumber,
-      secCode: params.secCode ?? 'WEB',
-      achAccountType: params.achAccountType ?? 'Checking',
-    }),
+    body: JSON.stringify(requestBody),
   });
 
+  const text = await res.text();
+
   if (!res.ok) {
-    const errorBody = await res.text().catch(() => '');
-    logger.error('[IQPro] ACH tokenization failed', { status: res.status, body: errorBody });
+    logger.error('[IQPro] ACH tokenization failed', {
+      status: res.status,
+      response: text || '(empty body)',
+    });
     throw new Error(`ACH tokenization failed: ${res.status}`);
   }
 
-  const json = await res.json();
+  logger.info('[IQPro] ACH tokenize response', {
+    status: res.status,
+    response: text || '(empty body)',
+  });
+
+  const json = text ? JSON.parse(text) : {};
   // The vault API returns { data: { achId, maskedAccount } }
   const achToken = (json?.data?.achId ?? json?.achToken ?? json?.data?.achToken ?? json?.token) as string | undefined;
 
@@ -212,7 +339,6 @@ export async function tokenizeAch(params: TokenizeAchParams): Promise<TokenizeAc
     throw new Error('ACH tokenization response missing achToken');
   }
 
-  logger.info('[IQPro] ACH tokenized successfully');
   return { achToken };
 }
 
@@ -242,16 +368,28 @@ export async function getGatewayProcessors(): Promise<GatewayProcessors> {
   const baseUrl = Env.IQPRO_BASE_URL!;
   const gatewayId = Env.IQPRO_GATEWAY_ID!;
 
+  logger.info('[IQPro] Gateway config request', { gatewayId });
+
   const res = await fetch(`${baseUrl}/api/gateway/${gatewayId}`, {
     headers: { Authorization: `Bearer ${token}` },
   });
 
+  const text = await res.text();
+
   if (!res.ok) {
-    logger.error('[IQPro] Failed to fetch gateway config', { status: res.status });
+    logger.error('[IQPro] Failed to fetch gateway config', {
+      status: res.status,
+      response: text || '(empty body)',
+    });
     throw new Error(`Gateway config request failed: ${res.status}`);
   }
 
-  const json = await res.json();
+  logger.info('[IQPro] Gateway config response', {
+    status: res.status,
+    response: text || '(empty body)',
+  });
+
+  const json = text ? JSON.parse(text) : {};
   const processors = (json?.data?.processors ?? []) as Array<{
     processorId: string;
     isDefaultCard: boolean;
@@ -268,6 +406,75 @@ export async function getGatewayProcessors(): Promise<GatewayProcessors> {
 
   logger.info('[IQPro] Gateway processors loaded', cachedProcessors);
   return cachedProcessors;
+}
+
+// ===== Fee calculation =====
+
+export type CalculateFeesParams = {
+  baseAmount: number;
+  processorId: string;
+  state: string;
+  paymentMethod: 'card' | 'ach';
+  creditCardBin?: string;
+  token?: string;
+  paymentAdjustments?: Array<{
+    type: string;
+    percentage?: number | null;
+    flatAmount?: number | null;
+  }>;
+};
+
+export type CalculateFeesResult = {
+  isSurchargeable: boolean;
+  isPinCapable: boolean;
+  surchargeRate: number;
+  surchargeAmount: number;
+  serviceFeesAmount: number;
+  convenienceFeesAmount: number;
+  baseAmount: number;
+  amount: number;
+  tip: number;
+  taxAmount: number;
+  cardBrand: string | null;
+  cardType: string | null;
+};
+
+/**
+ * Server-authoritative fee calculation. Returns the canonical surcharge,
+ * service-fee, convenience-fee, and tax amounts for a given base amount and
+ * payment method. Used to build the `remit` block on a transaction so amounts
+ * and adjustments reconcile exactly with what IQPro will charge.
+ */
+export async function calculateTransactionFees(
+  params: CalculateFeesParams,
+): Promise<CalculateFeesResult> {
+  const gatewayId = Env.IQPRO_GATEWAY_ID!;
+  const body: Record<string, unknown> = {
+    baseAmount: params.baseAmount,
+    addTaxToTotal: true,
+    taxAmount: 0,
+    processorId: params.processorId,
+    transactionType: 'Sale',
+    state: params.state,
+  };
+
+  // IQPro accepts exactly one of token or creditCardBin, never both. Prefer
+  // token when available — it identifies the specific card, whereas BIN only
+  // identifies the issuing range.
+  if (params.token) {
+    body.token = params.token;
+  } else if (params.creditCardBin) {
+    body.creditCardBin = params.creditCardBin;
+  }
+  if (params.paymentAdjustments && params.paymentAdjustments.length > 0) {
+    body.paymentAdjustments = params.paymentAdjustments;
+  }
+
+  const res = await iqproPost<{ data?: CalculateFeesResult }>(
+    `/api/gateway/${gatewayId}/transaction/calculatefees`,
+    body,
+  );
+  return (res.data ?? res) as CalculateFeesResult;
 }
 
 // Exported for testing – reset cached OAuth token

--- a/src/services/IQProPaymentService.test.ts
+++ b/src/services/IQProPaymentService.test.ts
@@ -1,148 +1,143 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock the IQPro client singleton
+// Mock Env so the service can read IQPRO_GATEWAY_ID and IQPRO_BASE_URL
+vi.mock('@/libs/Env', () => ({
+  Env: {
+    IQPRO_GATEWAY_ID: 'test-gateway-001',
+    IQPRO_BASE_URL: 'https://sandbox.api.basyspro.com',
+  },
+}));
+
+// Mock the IQPro REST helpers — every test asserts the exact path + payload.
 vi.mock('@/libs/IQPro', () => ({
-  getIQProClient: vi.fn(),
+  iqproPost: vi.fn(),
+  iqproGet: vi.fn(),
+  tokenizeAch: vi.fn().mockResolvedValue({ achToken: 'ach-tok-test-001' }),
   getGatewayProcessors: vi.fn().mockResolvedValue({
     cardProcessorId: 'test-card-processor-001',
     achProcessorId: 'test-ach-processor-001',
   }),
-  tokenizeAch: vi.fn().mockResolvedValue({ achToken: 'ach-tok-test-001' }),
 }));
 
-// Mock the logger to suppress output during tests
 vi.mock('@/libs/Logger', () => ({
-  logger: {
-    info: vi.fn(),
-    error: vi.fn(),
-  },
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
 }));
-
-function createMockClient() {
-  return {
-    customers: {
-      create: vi.fn(),
-      createPaymentMethod: vi.fn(),
-    },
-    transactions: {
-      create: vi.fn(),
-      getServiceContext: vi.fn().mockReturnValue({ gatewayContext: { gatewayId: 'test-gateway-001' } }),
-    },
-    subscriptions: {
-      create: vi.fn(),
-    },
-    post: vi.fn(),
-  };
-}
 
 describe('IQProPaymentProvider', () => {
-  let mockClient: ReturnType<typeof createMockClient>;
-
   beforeEach(() => {
-    vi.resetModules();
-    mockClient = createMockClient();
+    vi.clearAllMocks();
   });
 
-  async function getProviderWithClient(client: ReturnType<typeof createMockClient> | null = mockClient) {
-    const { getIQProClient } = await import('@/libs/IQPro');
-    vi.mocked(getIQProClient).mockReturnValue(client as any);
+  async function loadProvider() {
     const { IQProPaymentProvider } = await import('./IQProPaymentService');
-    return new IQProPaymentProvider();
+    const { iqproPost, iqproGet, tokenizeAch, getGatewayProcessors } = await import('@/libs/IQPro');
+    return {
+      provider: new IQProPaymentProvider(),
+      iqproPost: vi.mocked(iqproPost),
+      iqproGet: vi.mocked(iqproGet),
+      tokenizeAch: vi.mocked(tokenizeAch),
+      getGatewayProcessors: vi.mocked(getGatewayProcessors),
+    };
   }
 
   describe('createCustomer', () => {
-    it('passes correct params and returns customer ID', async () => {
-      const provider = await getProviderWithClient();
+    it('POSTs the customer with normalized country and follows up with a GET to resolve the billing-address ID', async () => {
+      const { provider, iqproPost, iqproGet } = await loadProvider();
 
-      mockClient.customers.create.mockResolvedValue({
-        customerId: 'test-customer-123',
-      });
-
-      const result = await provider.createCustomer({
-        organizationId: 'test-org-456',
-        memberId: 'test-member-789',
-        email: 'john@example.com',
-        firstName: 'John',
-        lastName: 'Doe',
-        phone: '(555) 012-3456',
-        address: {
-          street: '123 Main St',
-          apartment: 'Apt 4B',
-          city: 'Springfield',
-          state: 'IL',
-          zipCode: '62701',
-          country: 'US',
+      iqproPost.mockResolvedValueOnce({ data: { customerId: 'cust_123' } });
+      iqproGet.mockResolvedValueOnce({
+        data: {
+          addresses: [{ customerAddressId: 'addr_billing_1', isBilling: true }],
         },
       });
 
-      expect(result).toBe('test-customer-123');
-      expect(mockClient.customers.create).toHaveBeenCalledWith({
-        name: 'John Doe',
-        referenceId: 'test-member-789',
-        addresses: [
-          {
-            addressLine1: '123 Main St',
-            addressLine2: 'Apt 4B',
-            city: 'Springfield',
-            state: 'IL',
-            postalCode: '62701',
-            country: 'US',
-            firstName: 'John',
-            lastName: 'Doe',
-            email: 'john@example.com',
-            phone: '5550123456',
-            isBilling: true,
-          },
-        ],
+      const result = await provider.createCustomer({
+        organizationId: 'org_x',
+        memberId: 'mem_42',
+        email: 'jane@example.com',
+        firstName: 'Jane',
+        lastName: 'Doe',
+        phone: '(555) 012-3456',
+        address: {
+          street: '1 Market St',
+          apartment: 'Apt 4',
+          city: 'San Francisco',
+          state: 'CA',
+          zipCode: '94103',
+          country: 'United States',
+        },
       });
+
+      expect(result).toEqual({ customerId: 'cust_123', billingAddressId: 'addr_billing_1' });
+
+      expect(iqproPost).toHaveBeenCalledWith(
+        '/api/gateway/test-gateway-001/customer',
+        expect.objectContaining({
+          name: 'Jane Doe',
+          referenceId: 'mem_42',
+          addresses: [
+            expect.objectContaining({
+              addressLine1: '1 Market St',
+              addressLine2: 'Apt 4',
+              city: 'San Francisco',
+              state: 'CA',
+              postalCode: '94103',
+              country: 'US', // 'United States' normalized
+              firstName: 'Jane',
+              lastName: 'Doe',
+              email: 'jane@example.com',
+              phone: '5550123456',
+              isBilling: true,
+            }),
+          ],
+        }),
+      );
+
+      expect(iqproGet).toHaveBeenCalledWith('/api/gateway/test-gateway-001/customer/cust_123');
     });
 
-    it('throws if client is not configured', async () => {
-      const provider = await getProviderWithClient(null);
+    it('skips the GET when no address is supplied', async () => {
+      const { provider, iqproPost, iqproGet } = await loadProvider();
 
-      await expect(
-        provider.createCustomer({
-          organizationId: 'test-org-456',
-          memberId: 'test-member-789',
-          email: 'john@example.com',
-          firstName: 'John',
-          lastName: 'Doe',
-        }),
-      ).rejects.toThrow('IQPro client is not configured');
+      iqproPost.mockResolvedValueOnce({ data: { customerId: 'cust_noaddr' } });
+
+      const result = await provider.createCustomer({
+        organizationId: 'org_x',
+        memberId: 'mem_99',
+        email: 'noaddr@example.com',
+        firstName: 'No',
+        lastName: 'Addr',
+      });
+
+      expect(result).toEqual({ customerId: 'cust_noaddr', billingAddressId: undefined });
+      expect(iqproGet).not.toHaveBeenCalled();
     });
   });
 
   describe('createPaymentMethod', () => {
-    it('sends InsertCard with token when cardToken is provided (PCI-compliant path)', async () => {
-      const provider = await getProviderWithClient();
+    it('sends the canonical card payload with tokenized data and BIN-formatted maskedCard', async () => {
+      const { provider, iqproPost } = await loadProvider();
 
-      mockClient.customers.createPaymentMethod.mockResolvedValue({
-        paymentMethodId: 'test-pm-tokenized-001',
-        last4: '4242',
-      });
+      iqproPost.mockResolvedValueOnce({ data: { customerPaymentMethodId: 'pm_card_1', last4: '4242' } });
 
       const result = await provider.createPaymentMethod({
-        customerId: 'test-customer-123',
+        customerId: 'cust_123',
         paymentMethod: 'card',
-        cardholderName: 'John Doe',
-        cardToken: 'tok_test_abc123',
+        cardToken: 'tex-tok-abc',
         cardFirstSix: '424242',
         cardLastFour: '4242',
-        cardExpiry: '12/25',
-        cardCvc: '123',
+        cardExpiry: '12/27',
       });
 
-      expect(result).toEqual({
-        paymentMethodId: 'test-pm-tokenized-001',
-        last4: '4242',
-      });
+      expect(result.paymentMethodId).toBe('pm_card_1');
+      expect(result.last4).toBe('4242');
 
-      expect(mockClient.customers.createPaymentMethod).toHaveBeenCalledWith(
-        'test-customer-123',
+      expect(iqproPost).toHaveBeenCalledWith(
+        '/api/gateway/test-gateway-001/customer/cust_123/payment',
         {
           card: {
-            token: 'tok_test_abc123',
-            expirationDate: '12/25',
+            token: 'tex-tok-abc',
+            expirationDate: '12/27',
             maskedCard: '424242******4242',
           },
           isDefault: true,
@@ -150,102 +145,38 @@ describe('IQProPaymentProvider', () => {
       );
     });
 
-    it('sends InsertCard with raw card number as token when cardToken is not provided (fallback path)', async () => {
-      const provider = await getProviderWithClient();
+    it('tokenizes ACH first then sends the canonical ACH payload', async () => {
+      const { provider, iqproPost, tokenizeAch } = await loadProvider();
 
-      mockClient.customers.createPaymentMethod.mockResolvedValue({
-        paymentMethodId: 'test-pm-raw-001',
-        last4: '1111',
-      });
+      tokenizeAch.mockResolvedValueOnce({ achToken: 'ach-tok-xyz' });
+      iqproPost.mockResolvedValueOnce({ data: { customerPaymentMethodId: 'pm_ach_1' } });
 
       const result = await provider.createPaymentMethod({
-        customerId: 'test-customer-123',
-        paymentMethod: 'card',
-        cardholderName: 'John Doe',
-        cardNumber: '4111111111111111',
-        cardExpiry: '12/25',
-        cardCvc: '123',
-      });
-
-      expect(result).toEqual({
-        paymentMethodId: 'test-pm-raw-001',
-        last4: '1111',
-      });
-
-      // BIN derived from cardNumber: first 6 digits = '411111'
-      expect(mockClient.customers.createPaymentMethod).toHaveBeenCalledWith(
-        'test-customer-123',
-        {
-          card: {
-            token: '4111111111111111',
-            expirationDate: '12/25',
-            maskedCard: '411111******1111',
-          },
-          isDefault: true,
-        },
-      );
-    });
-
-    it('falls back to maskedCard last4 when last4 is not returned', async () => {
-      const provider = await getProviderWithClient();
-
-      mockClient.customers.createPaymentMethod.mockResolvedValue({
-        paymentMethodId: 'test-pm-card-789',
-        card: { maskedCard: '****1234' },
-      });
-
-      const result = await provider.createPaymentMethod({
-        customerId: 'test-customer-123',
-        paymentMethod: 'card',
-        cardholderName: 'John Doe',
-        cardNumber: '4111111111111234',
-        cardExpiry: '12/28',
-        cardCvc: '123',
-      });
-
-      expect(result.last4).toBe('1234');
-    });
-
-    it('tokenizes ACH and passes achToken to payment method creation', async () => {
-      const provider = await getProviderWithClient();
-      const { tokenizeAch } = await import('@/libs/IQPro');
-
-      mockClient.customers.createPaymentMethod.mockResolvedValue({
-        paymentMethodId: 'test-pm-ach-456',
-        last4: '6789',
-      });
-
-      const result = await provider.createPaymentMethod({
-        customerId: 'test-customer-123',
+        customerId: 'cust_123',
         paymentMethod: 'ach',
-        achAccountHolder: 'John Doe',
         achRoutingNumber: '021000021',
-        achAccountNumber: '123456789',
+        achAccountNumber: '987654321',
+        achAccountType: 'Savings',
       });
 
-      expect(result).toEqual({
-        paymentMethodId: 'test-pm-ach-456',
-        last4: '6789',
-        achToken: 'ach-tok-test-001',
-      });
+      expect(result.paymentMethodId).toBe('pm_ach_1');
+      expect(result.achToken).toBe('ach-tok-xyz');
 
-      // Verify tokenizeAch was called with correct params
       expect(tokenizeAch).toHaveBeenCalledWith({
-        accountNumber: '123456789',
+        accountNumber: '987654321',
         routingNumber: '021000021',
         secCode: 'WEB',
-        achAccountType: 'Checking',
+        achAccountType: 'Savings',
       });
 
-      // Verify the tokenized achToken is used in the payment method creation
-      expect(mockClient.customers.createPaymentMethod).toHaveBeenCalledWith(
-        'test-customer-123',
+      expect(iqproPost).toHaveBeenCalledWith(
+        '/api/gateway/test-gateway-001/customer/cust_123/payment',
         {
           ach: {
-            token: 'ach-tok-test-001',
+            token: 'ach-tok-xyz',
             secCode: 'WEB',
             routingNumber: '021000021',
-            accountType: 'Checking',
+            accountType: 'Savings',
             checkNumber: null,
             accountHolderAuth: { dlState: null, dlNumber: null },
           },
@@ -253,473 +184,297 @@ describe('IQProPaymentProvider', () => {
         },
       );
     });
-
-    it('passes Savings account type for ACH when specified', async () => {
-      const provider = await getProviderWithClient();
-      const { tokenizeAch } = await import('@/libs/IQPro');
-
-      mockClient.customers.createPaymentMethod.mockResolvedValue({
-        paymentMethodId: 'test-pm-ach-savings',
-        last4: '6789',
-      });
-
-      await provider.createPaymentMethod({
-        customerId: 'test-customer-123',
-        paymentMethod: 'ach',
-        achAccountHolder: 'John Doe',
-        achRoutingNumber: '021000021',
-        achAccountNumber: '123456789',
-        achAccountType: 'Savings',
-      });
-
-      expect(tokenizeAch).toHaveBeenCalledWith(
-        expect.objectContaining({ achAccountType: 'Savings' }),
-      );
-
-      expect(mockClient.customers.createPaymentMethod).toHaveBeenCalledWith(
-        'test-customer-123',
-        expect.objectContaining({
-          ach: expect.objectContaining({ accountType: 'Savings' }),
-        }),
-      );
-    });
-
-    it('propagates error when ACH tokenization fails', async () => {
-      const provider = await getProviderWithClient();
-      const { tokenizeAch } = await import('@/libs/IQPro');
-      vi.mocked(tokenizeAch).mockRejectedValueOnce(new Error('Tokenization unavailable'));
-
-      await expect(
-        provider.createPaymentMethod({
-          customerId: 'test-customer-123',
-          paymentMethod: 'ach',
-          achAccountHolder: 'John Doe',
-          achRoutingNumber: '021000021',
-          achAccountNumber: '123456789',
-        }),
-      ).rejects.toThrow('Tokenization unavailable');
-
-      // Should NOT call createPaymentMethod when tokenization fails
-      expect(mockClient.customers.createPaymentMethod).not.toHaveBeenCalled();
-    });
-
-    it('falls back to maskedAccount last4 for ACH when last4 is not returned', async () => {
-      const provider = await getProviderWithClient();
-
-      mockClient.customers.createPaymentMethod.mockResolvedValue({
-        paymentMethodId: 'test-pm-ach-789',
-        ach: { maskedAccount: '****5678' },
-      });
-
-      const result = await provider.createPaymentMethod({
-        customerId: 'test-customer-123',
-        paymentMethod: 'ach',
-        achAccountHolder: 'John Doe',
-        achRoutingNumber: '021000021',
-        achAccountNumber: '123455678',
-      });
-
-      expect(result.last4).toBe('5678');
-    });
   });
 
   describe('processPayment', () => {
-    it('converts amount from dollars to cents and includes Remit + customer payment method', async () => {
-      const provider = await getProviderWithClient();
+    it('builds the full Sale payload with feeBreakdown, paymentAdjustments, address and lineItems', async () => {
+      const { provider, iqproPost } = await loadProvider();
 
-      mockClient.transactions.create.mockResolvedValue({
-        id: 'test-tx-123',
-        status: 'captured',
-        processorResponseMessage: undefined,
-      });
-
-      await provider.processPayment({
-        customerId: 'test-customer-123',
-        paymentMethodId: 'test-pm-123',
-        amount: 149.99,
-        currency: 'USD',
-        description: 'Monthly membership',
-      });
-
-      expect(mockClient.transactions.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          amount: 14999,
-          Remit: { totalAmount: 14999 },
-          paymentMethod: {
-            customer: {
-              customerId: 'test-customer-123',
-              customerPaymentMethodId: 'test-pm-123',
-            },
-          },
-        }),
-      );
-    });
-
-    it('maps approved status correctly for captured transactions', async () => {
-      const provider = await getProviderWithClient();
-
-      mockClient.transactions.create.mockResolvedValue({
-        id: 'test-tx-approved',
-        status: 'captured',
-        processorResponseMessage: undefined,
-      });
-
-      const result = await provider.processPayment({
-        customerId: 'test-customer-123',
-        paymentMethodId: 'test-pm-123',
-        amount: 50,
-        currency: 'USD',
-        description: 'Payment',
-      });
-
-      expect(result).toEqual({
-        success: true,
-        transactionId: 'test-tx-approved',
-        status: 'approved',
-        declineReason: undefined,
-      });
-    });
-
-    it('maps declined status correctly for declined transactions', async () => {
-      const provider = await getProviderWithClient();
-
-      mockClient.transactions.create.mockResolvedValue({
-        id: 'test-tx-declined',
-        status: 'declined',
-        processorResponseMessage: 'Insufficient funds',
-      });
-
-      const result = await provider.processPayment({
-        customerId: 'test-customer-123',
-        paymentMethodId: 'test-pm-123',
-        amount: 100,
-        currency: 'USD',
-        description: 'Payment',
-      });
-
-      expect(result).toEqual({
-        success: false,
-        transactionId: 'test-tx-declined',
-        status: 'declined',
-        declineReason: 'Insufficient funds',
-      });
-    });
-
-    it('returns declined with error message when transaction throws', async () => {
-      const provider = await getProviderWithClient();
-
-      mockClient.transactions.create.mockRejectedValue(new Error('Gateway timeout'));
-
-      const result = await provider.processPayment({
-        customerId: 'test-customer-123',
-        paymentMethodId: 'test-pm-123',
-        amount: 50,
-        currency: 'USD',
-        description: 'Payment',
-      });
-
-      expect(result).toEqual({
-        success: false,
-        status: 'declined',
-        error: 'Gateway timeout',
-      });
-    });
-
-    it('bypasses SDK and calls API directly for ACH transactions', async () => {
-      const provider = await getProviderWithClient();
-
-      mockClient.post.mockResolvedValue({
+      iqproPost.mockResolvedValueOnce({
         data: {
           transaction: {
-            transactionId: 'test-tx-ach',
+            transactionId: 'tx_42',
             status: 'Captured',
           },
         },
       });
 
       const result = await provider.processPayment({
-        customerId: 'test-customer-123',
-        paymentMethodId: 'test-pm-ach-123',
-        amount: 149,
+        customerId: 'cust_123',
+        paymentMethodId: 'pm_card_1',
+        amount: 111.5,
         currency: 'USD',
-        description: 'ACH Payment',
-        ach: {
-          achToken: 'ach-tok-123',
-          secCode: 'WEB',
-          routingNumber: '111111111',
-          accountType: 'Checking',
+        description: 'Adult BJJ Membership Monthly',
+        feeBreakdown: {
+          baseAmount: 100,
+          taxAmount: 8.5,
+          surchargeAmount: 3,
+          serviceFeesAmount: 0,
+          convenienceFeesAmount: 0,
+          amount: 111.5,
+        },
+        customerBillingAddressId: 'addr_billing_1',
+        billingAddress: {
+          firstName: 'Jane',
+          lastName: 'Doe',
+          email: 'jane@example.com',
+          phone: '5550123456',
+          addressLine1: '1 Market St',
+          city: 'San Francisco',
+          state: 'CA',
+          postalCode: '94103',
+          country: 'US',
+        },
+        lineItem: {
+          name: 'Adult BJJ',
+          description: 'Monthly membership',
+          unitPrice: 100,
+          discount: 0,
         },
       });
 
-      // Should NOT use SDK transactions.create for ACH
-      expect(mockClient.transactions.create).not.toHaveBeenCalled();
+      expect(result.success).toBe(true);
+      expect(result.status).toBe('approved');
+      expect(result.transactionId).toBe('tx_42');
 
-      // Should call API directly via client.post
-      expect(mockClient.post).toHaveBeenCalledWith(
-        '/api/gateway/test-gateway-001/transaction',
-        expect.objectContaining({
-          type: 'Sale',
-          remit: {
-            baseAmount: 149,
-            totalAmount: 149,
-            currencyCode: 'USD',
-          },
-          paymentMethod: {
-            customer: {
-              customerId: 'test-customer-123',
-              customerPaymentMethodId: 'test-pm-ach-123',
-            },
-          },
-          ach: {
-            achToken: 'ach-tok-123',
-            secCode: 'WEB',
-            routingNumber: '111111111',
-            accountType: 'Checking',
-            checkNumber: null,
-            accountHolderAuth: { dlState: null, dlNumber: null },
-          },
-          caption: 'ACH Payment',
-        }),
-      );
+      const [path, payload] = iqproPost.mock.calls[0]!;
 
-      expect(result).toEqual({
-        success: true,
-        transactionId: 'test-tx-ach',
-        status: 'approved',
-        declineReason: undefined,
+      expect(path).toBe('/api/gateway/test-gateway-001/transaction');
+
+      const p = payload as Record<string, any>;
+
+      expect(p.type).toBe('Sale');
+      // Remit block has tax + adjustments + currency
+      expect(p.remit).toEqual({
+        baseAmount: 100,
+        taxAmount: 8.5,
+        isTaxExempt: false,
+        currencyCode: 'USD',
+        addTaxToTotal: true,
+        paymentAdjustments: [
+          { type: 'Surcharge', percentage: null, flatAmount: 3 },
+        ],
       });
+      // paymentMethod uses customer block only — no card or ach block
+      expect(p.paymentMethod).toEqual({
+        customer: {
+          customerId: 'cust_123',
+          customerPaymentMethodId: 'pm_card_1',
+          customerBillingAddressId: 'addr_billing_1',
+        },
+      });
+      // address[] block
+      expect(p.address).toEqual([
+        expect.objectContaining({
+          isPhysical: true,
+          isBilling: true,
+          isShipping: false,
+          firstName: 'Jane',
+          email: 'jane@example.com',
+          state: 'CA',
+          country: 'US',
+        }),
+      ]);
+      // line items shape
+      expect(p.lineItems).toEqual([
+        expect.objectContaining({
+          name: 'Adult BJJ',
+          description: 'Monthly membership',
+          quantity: 1,
+          unitPrice: 100,
+          discount: 0,
+          freightAmount: 0,
+          unitOfMeasureId: 1,
+        }),
+      ]);
+      // caption truncated to 19 chars
+      expect(p.caption).toBe('Adult BJJ Membershi');
     });
 
-    it('uses SDK transactions.create for card payments (no direct API call)', async () => {
-      const provider = await getProviderWithClient();
+    it('marks the transaction tax-exempt when taxAmount is 0', async () => {
+      const { provider, iqproPost } = await loadProvider();
 
-      mockClient.transactions.create.mockResolvedValue({
-        id: 'test-tx-card',
-        status: 'captured',
+      iqproPost.mockResolvedValueOnce({
+        data: { transaction: { transactionId: 'tx_zero', status: 'Captured' } },
       });
 
       await provider.processPayment({
-        customerId: 'test-customer-123',
-        paymentMethodId: 'test-pm-card-123',
+        customerId: 'cust_123',
+        paymentMethodId: 'pm_card_1',
         amount: 50,
         currency: 'USD',
-        description: 'Card Payment',
+        description: 'Free state',
+        feeBreakdown: {
+          baseAmount: 50,
+          taxAmount: 0,
+          surchargeAmount: 0,
+          serviceFeesAmount: 0,
+          convenienceFeesAmount: 0,
+          amount: 50,
+        },
       });
 
-      // Card payments use SDK
-      expect(mockClient.transactions.create).toHaveBeenCalled();
+      const p = iqproPost.mock.calls[0]![1] as Record<string, any>;
 
-      // Should NOT call API directly for card payments
-      expect(mockClient.post).not.toHaveBeenCalled();
+      expect(p.remit.isTaxExempt).toBe(true);
+      expect(p.remit.paymentAdjustments).toBeUndefined();
+    });
 
-      const callArgs = mockClient.transactions.create.mock.calls[0]![0] as Record<string, unknown>;
+    it('treats sandbox certification errors as approved (pendingsettlement)', async () => {
+      const { provider, iqproPost } = await loadProvider();
 
-      expect(callArgs.ach).toBeUndefined();
+      iqproPost.mockResolvedValueOnce({
+        data: {
+          transaction: {
+            transactionId: 'tx_cert',
+            status: 'Failed',
+            processorResponseText: 'This is not a valid transaction for certification',
+          },
+        },
+      });
+
+      const result = await provider.processPayment({
+        customerId: 'cust_123',
+        paymentMethodId: 'pm_ach_1',
+        amount: 100,
+        currency: 'USD',
+        description: 'ACH sandbox test',
+        ach: {
+          achToken: 'ach-tok-xyz',
+          secCode: 'WEB',
+          routingNumber: '021000021',
+          accountType: 'Checking',
+        },
+        feeBreakdown: {
+          baseAmount: 100,
+          taxAmount: 0,
+          surchargeAmount: 0,
+          serviceFeesAmount: 0,
+          convenienceFeesAmount: 0,
+          amount: 100,
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.status).toBe('approved');
+    });
+
+    it('returns declined with the processor response text', async () => {
+      const { provider, iqproPost } = await loadProvider();
+
+      iqproPost.mockResolvedValueOnce({
+        data: {
+          transaction: {
+            transactionId: 'tx_decline',
+            status: 'Declined',
+            processorResponseText: 'Insufficient funds',
+          },
+        },
+      });
+
+      const result = await provider.processPayment({
+        customerId: 'cust_123',
+        paymentMethodId: 'pm_card_1',
+        amount: 100,
+        currency: 'USD',
+        description: 'Decline',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.status).toBe('declined');
+      expect(result.declineReason).toBe('Insufficient funds');
+    });
+
+    it('returns declined when iqproPost throws', async () => {
+      const { provider, iqproPost } = await loadProvider();
+
+      iqproPost.mockRejectedValueOnce(new Error('boom'));
+
+      const result = await provider.processPayment({
+        customerId: 'cust_123',
+        paymentMethodId: 'pm_card_1',
+        amount: 100,
+        currency: 'USD',
+        description: 'Failure',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.status).toBe('declined');
+      expect(result.error).toBe('boom');
     });
   });
 
   describe('createSubscription', () => {
-    const baseSubscriptionParams = {
-      customerId: 'test-customer-123',
-      paymentMethodId: 'test-pm-123',
-      firstName: 'John',
-      lastName: 'Doe',
-      email: 'john@example.com',
-      phone: '(555) 012-3456',
-      address: {
-        street: '123 Main St',
-        apartment: 'Apt 4B',
-        city: 'Springfield',
-        state: 'IL',
-        zipCode: '62701',
-        country: 'US',
-      },
-    };
+    it('posts the subscription with billing+remittance addresses, MBR prefix, and YEAR/MONTH unit', async () => {
+      const { provider, iqproPost } = await loadProvider();
 
-    it('builds correct payload for monthly frequency via direct API call', async () => {
-      const provider = await getProviderWithClient();
-
-      mockClient.post.mockResolvedValue({
-        data: { subscriptionId: 'test-sub-monthly-123' },
-      });
-
-      const startDate = new Date(2025, 2, 15); // March 15, 2025
+      iqproPost.mockResolvedValueOnce({ data: { subscriptionId: 'sub_1' } });
 
       const result = await provider.createSubscription({
-        ...baseSubscriptionParams,
-        amount: 79,
+        customerId: 'cust_123',
+        paymentMethodId: 'pm_card_1',
+        amount: 99,
         frequency: 'monthly',
-        startDate,
-        description: 'Monthly BJJ Membership',
-      });
-
-      expect(result).toEqual({
-        success: true,
-        subscriptionId: 'test-sub-monthly-123',
-      });
-
-      // Should bypass SDK and call API directly
-      expect(mockClient.subscriptions.create).not.toHaveBeenCalled();
-      expect(mockClient.post).toHaveBeenCalledWith(
-        '/api/gateway/test-gateway-001/subscription',
-        expect.any(Object),
-      );
-
-      const callArgs = mockClient.post.mock.calls[0]![1] as Record<string, any>;
-
-      // Required top-level fields
-      expect(callArgs.prefix).toBe('MBR');
-      expect(callArgs.subscriptionStatusId).toBe(1);
-
-      // Recurrence — monthly uses billingPeriodId=4, no monthsOfYear
-      expect(callArgs.recurrence.billingPeriodId).toBe(4);
-      expect(callArgs.recurrence.schedule.minutes).toEqual([0]);
-      expect(callArgs.recurrence.schedule.hours).toEqual([0]);
-      expect(callArgs.recurrence.schedule.daysOfMonth).toEqual([15]);
-      expect(callArgs.recurrence.schedule.monthsOfYear).toBeUndefined();
-      expect(callArgs.recurrence.isAutoRenewed).toBe(true);
-      expect(callArgs.recurrence.allowProration).toBe(false);
-      expect(callArgs.recurrence.trialLengthInDays).toBe(0);
-      expect(callArgs.recurrence.invoiceLengthInDays).toBe(1);
-
-      // Two addresses: billing + remittance (must be separate)
-      expect(callArgs.addresses).toHaveLength(2);
-      expect(callArgs.addresses[0]).toEqual({
-        isBilling: true,
-        isShipping: false,
-        isRemittance: false,
-        firstName: 'John',
+        startDate: new Date('2026-04-15T12:00:00Z'),
+        description: 'Adult BJJ',
+        firstName: 'Jane',
         lastName: 'Doe',
-        email: 'john@example.com',
+        email: 'jane@example.com',
         phone: '5550123456',
-        state: 'IL',
-        country: 'US',
-        addressLine1: '123 Main St',
-        addressLine2: 'Apt 4B',
-        city: 'Springfield',
-        postalCode: '62701',
-      });
-      expect(callArgs.addresses[1]).toEqual({
-        isBilling: false,
-        isShipping: false,
-        isRemittance: true,
-        firstName: 'John',
-        lastName: 'Doe',
-        email: 'john@example.com',
-        country: 'US',
-      });
-
-      // Payment method includes processor IDs
-      expect(callArgs.paymentMethod.cardProcessorId).toBe('test-card-processor-001');
-      expect(callArgs.paymentMethod.achProcessorId).toBe('test-ach-processor-001');
-
-      // Line item — unitPrice in dollars (not cents), discount required
-      expect(callArgs.lineItems[0].unitPrice).toBe(79);
-      expect(callArgs.lineItems[0].discount).toBe(0);
-      expect(callArgs.lineItems[0].unitOfMeasureId).toBe(3);
-      expect(callArgs.lineItems[0].description).toBe('monthly membership payment');
-    });
-
-    it('builds correct payload for annual frequency', async () => {
-      const provider = await getProviderWithClient();
-
-      mockClient.post.mockResolvedValue({
-        data: { subscriptionId: 'test-sub-annual-456' },
-      });
-
-      const startDate = new Date(2025, 5, 1); // June 1, 2025
-
-      const result = await provider.createSubscription({
-        ...baseSubscriptionParams,
-        amount: 790,
-        frequency: 'annual',
-        startDate,
-        description: 'Annual BJJ Membership',
-      });
-
-      expect(result).toEqual({
-        success: true,
-        subscriptionId: 'test-sub-annual-456',
-      });
-
-      const callArgs = mockClient.post.mock.calls[0]![1] as Record<string, any>;
-
-      // Annual uses billingPeriodId=6, includes monthsOfYear with start month only
-      expect(callArgs.recurrence.billingPeriodId).toBe(6);
-      expect(callArgs.recurrence.schedule.monthsOfYear).toEqual([6]);
-      expect(callArgs.recurrence.schedule.daysOfMonth).toEqual([1]);
-      expect(callArgs.recurrence.schedule.minutes).toEqual([0]);
-      expect(callArgs.recurrence.schedule.hours).toEqual([0]);
-
-      // Line item — unitPrice in dollars (not cents), discount required
-      expect(callArgs.lineItems[0].unitPrice).toBe(790);
-      expect(callArgs.lineItems[0].discount).toBe(0);
-      expect(callArgs.lineItems[0].unitOfMeasureId).toBe(4);
-      expect(callArgs.lineItems[0].description).toBe('annual membership payment');
-    });
-
-    it('defaults country and state when no address is provided', async () => {
-      const provider = await getProviderWithClient();
-
-      mockClient.post.mockResolvedValue({
-        data: { subscriptionId: 'test-sub-no-addr' },
-      });
-
-      const result = await provider.createSubscription({
-        ...baseSubscriptionParams,
-        phone: undefined,
-        address: undefined,
-        amount: 79,
-        frequency: 'monthly',
-        startDate: new Date(2025, 0, 1),
-        description: 'Monthly Membership',
+        address: {
+          street: '1 Market St',
+          city: 'San Francisco',
+          state: 'CA',
+          zipCode: '94103',
+          country: 'US',
+        },
+        paymentAdjustments: [{ type: 'Surcharge', percentage: null, flatAmount: 3 }],
       });
 
       expect(result.success).toBe(true);
+      expect(result.subscriptionId).toBe('sub_1');
 
-      const callArgs = mockClient.post.mock.calls[0]![1] as Record<string, any>;
+      const [path, payload] = iqproPost.mock.calls[0]!;
 
-      // Billing address defaults country to US and state to N/A
-      expect(callArgs.addresses[0]).toEqual({
-        isBilling: true,
-        isShipping: false,
-        isRemittance: false,
-        firstName: 'John',
-        lastName: 'Doe',
-        email: 'john@example.com',
-        state: 'N/A',
-        country: 'US',
-      });
+      expect(path).toBe('/api/gateway/test-gateway-001/subscription');
 
-      // Remittance address
-      expect(callArgs.addresses[1]).toEqual({
-        isBilling: false,
-        isShipping: false,
-        isRemittance: true,
-        firstName: 'John',
-        lastName: 'Doe',
-        email: 'john@example.com',
-        country: 'US',
-      });
+      const p = payload as Record<string, any>;
+
+      expect(p.prefix).toBe('MBR');
+      expect(p.subscriptionStatusId).toBe(1);
+      expect(p.recurrence.billingPeriodId).toBe(4); // monthly
+      expect(p.recurrence.schedule).toEqual({ minutes: [0], hours: [0], daysOfMonth: [15] }); // no monthsOfYear
+      expect(p.lineItems[0].unitOfMeasureId).toBe(3); // MONTH
+      expect(p.paymentMethod.cardProcessorId).toBe('test-card-processor-001');
+      expect(p.paymentMethod.achProcessorId).toBe('test-ach-processor-001');
+      expect(p.addresses).toHaveLength(2);
+      expect(p.addresses[0].isBilling).toBe(true);
+      expect(p.addresses[1].isRemittance).toBe(true);
+      expect(p.paymentAdjustments).toEqual([{ type: 'Surcharge', percentage: null, flatAmount: 3 }]);
     });
 
-    it('returns error when subscription creation fails', async () => {
-      const provider = await getProviderWithClient();
+    it('sets billingPeriodId 6 + monthsOfYear for annual subscriptions', async () => {
+      const { provider, iqproPost } = await loadProvider();
 
-      mockClient.post.mockRejectedValue(new Error('Subscription API error'));
+      iqproPost.mockResolvedValueOnce({ data: { subscriptionId: 'sub_annual' } });
 
-      const result = await provider.createSubscription({
-        ...baseSubscriptionParams,
-        amount: 79,
-        frequency: 'monthly',
-        startDate: new Date(),
-        description: 'Monthly Membership',
+      await provider.createSubscription({
+        customerId: 'cust_123',
+        paymentMethodId: 'pm_card_1',
+        amount: 999,
+        frequency: 'annual',
+        startDate: new Date('2026-04-15T12:00:00Z'),
+        description: 'Adult BJJ Annual',
+        firstName: 'Jane',
+        lastName: 'Doe',
+        email: 'jane@example.com',
       });
 
-      expect(result).toEqual({
-        success: false,
-        error: 'Subscription API error',
-      });
+      const p = iqproPost.mock.calls[0]![1] as Record<string, any>;
+
+      expect(p.recurrence.billingPeriodId).toBe(6);
+      expect(p.recurrence.schedule).toEqual({ minutes: [0], hours: [0], daysOfMonth: [15], monthsOfYear: [4] });
+      expect(p.lineItems[0].unitOfMeasureId).toBe(4); // YEAR
     });
   });
 });

--- a/src/services/IQProPaymentService.ts
+++ b/src/services/IQProPaymentService.ts
@@ -1,15 +1,21 @@
 /**
  * IQPro implementation of the payment provider interface.
  *
- * Handles all communication with the IQ Pro+ API for:
- * - Customer creation
- * - Payment method registration (card / ACH)
- * - One-time transaction processing
- * - Recurring subscription creation
+ * All calls go directly through the IQPro REST API (no SDK) via the helpers
+ * in `src/libs/IQPro.ts`. Handles:
+ * - Customer creation (returns both the customerId and the billing-address ID)
+ * - Payment method registration (card via TokenEx token, ACH via vault token)
+ * - One-time transaction processing (full `remit` block with tax + adjustments)
+ * - Recurring subscription creation (with an immediate initial Sale handled by
+ *   the orchestrator, not here)
+ *
+ * Ported from the kiosk app's canonical payloads in
+ * `dojo-planner-kiosk/src/app/api/payment/{process,membership}/route.ts`.
  */
 
 import type {
   CreateCustomerParams,
+  CreateCustomerResult,
   CreatePaymentMethodParams,
   CreatePaymentMethodResult,
   CreateSubscriptionParams,
@@ -19,42 +25,9 @@ import type {
   SubscriptionResult,
 } from './PaymentProviderService';
 
-import { getGatewayProcessors, getIQProClient, tokenizeAch } from '@/libs/IQPro';
+import { Env } from '@/libs/Env';
+import { getGatewayProcessors, iqproGet, iqproPost, tokenizeAch } from '@/libs/IQPro';
 import { logger } from '@/libs/Logger';
-
-// Minimal shape of the IQPro client used by this service.
-// The actual client is loaded dynamically to avoid bundler errors
-// when the optional @dojo-planner/iqpro-client package is absent.
-type IQProClientShape = {
-  customers: {
-    create: (params: Record<string, unknown>, idempotencyKey?: string) => Promise<{ customerId: string }>;
-    createPaymentMethod: (customerId: string, params: Record<string, unknown>) => Promise<{
-      paymentMethodId?: string;
-      customerPaymentMethodId?: string;
-      customerPaymentId?: string;
-      last4?: string;
-      card?: { maskedCard?: string };
-      ach?: { maskedAccount?: string };
-    }>;
-  };
-  transactions: {
-    create: (params: Record<string, unknown>) => Promise<{ id: string; status?: string; processorResponseMessage?: string; amount?: number }>;
-    getServiceContext: () => { gatewayContext?: { gatewayId: string } };
-  };
-  subscriptions: {
-    create: (params: Record<string, unknown>) => Promise<{ subscriptionId?: string }>;
-  };
-  // Raw HTTP method for direct API calls (bypassing SDK service layer)
-  post: <T = Record<string, unknown>>(path: string, body?: unknown) => Promise<T>;
-};
-
-async function requireClient(): Promise<IQProClientShape> {
-  const client = await getIQProClient();
-  if (!client) {
-    throw new Error('IQPro client is not configured');
-  }
-  return client as IQProClientShape;
-}
 
 /** Strip a phone string to digits only, max 10 characters (IQPro limit). */
 function sanitizePhone(phone?: string): string | undefined {
@@ -67,40 +40,67 @@ function sanitizePhone(phone?: string): string | undefined {
   return trimmed.slice(0, 10) || undefined;
 }
 
+/** Normalize country names — IQPro expects ISO-2 codes. */
+function normalizeCountry(country?: string): string {
+  if (!country || country === 'United States') {
+    return 'US';
+  }
+  return country;
+}
+
 export class IQProPaymentProvider implements IPaymentProvider {
-  async createCustomer(params: CreateCustomerParams): Promise<string> {
-    const client = await requireClient();
+  async createCustomer(params: CreateCustomerParams): Promise<CreateCustomerResult> {
+    const gatewayId = Env.IQPRO_GATEWAY_ID!;
 
     logger.info('[IQPro] Creating customer', { memberId: params.memberId });
 
-    const customer = await client.customers.create({
-      name: `${params.firstName} ${params.lastName}`,
-      referenceId: params.memberId,
-      ...(params.address && {
-        addresses: [
-          {
-            addressLine1: params.address.street,
-            addressLine2: params.address.apartment,
-            city: params.address.city,
-            state: params.address.state,
-            postalCode: params.address.zipCode,
-            country: params.address.country,
-            firstName: params.firstName,
-            lastName: params.lastName,
-            email: params.email,
-            ...(sanitizePhone(params.phone) && { phone: sanitizePhone(params.phone) }),
-            isBilling: true,
-          },
-        ],
-      }),
-    });
+    const customerRes = await iqproPost<{ data?: Record<string, unknown> }>(
+      `/api/gateway/${gatewayId}/customer`,
+      {
+        name: `${params.firstName} ${params.lastName}`,
+        referenceId: params.memberId,
+        ...(params.address && {
+          addresses: [
+            {
+              addressLine1: params.address.street,
+              ...(params.address.apartment && { addressLine2: params.address.apartment }),
+              city: params.address.city,
+              state: params.address.state,
+              postalCode: params.address.zipCode,
+              country: normalizeCountry(params.address.country),
+              firstName: params.firstName,
+              lastName: params.lastName,
+              email: params.email,
+              ...(sanitizePhone(params.phone) && { phone: sanitizePhone(params.phone) }),
+              isBilling: true,
+            },
+          ],
+        }),
+      },
+    );
 
-    logger.info('[IQPro] Customer created', { customerId: customer.customerId });
-    return customer.customerId;
+    const customerData = (customerRes.data ?? customerRes) as Record<string, unknown>;
+    const customerId = customerData.customerId as string;
+
+    // Resolve the billing-address ID by fetching the customer detail. The ACH
+    // processor uses this to look up the cardholder name from the vault.
+    let billingAddressId: string | undefined;
+    if (params.address) {
+      const detailRes = await iqproGet<{ data?: Record<string, unknown> }>(
+        `/api/gateway/${gatewayId}/customer/${customerId}`,
+      );
+      const detailData = (detailRes.data ?? detailRes) as Record<string, unknown>;
+      const addresses = (detailData.addresses ?? []) as Array<Record<string, unknown>>;
+      const billing = addresses.find(a => a.isBilling) ?? addresses[0];
+      billingAddressId = (billing?.customerAddressId ?? billing?.id) as string | undefined;
+    }
+
+    logger.info('[IQPro] Customer created', { customerId, billingAddressId });
+    return { customerId, billingAddressId };
   }
 
   async createPaymentMethod(params: CreatePaymentMethodParams): Promise<CreatePaymentMethodResult> {
-    const client = await requireClient();
+    const gatewayId = Env.IQPRO_GATEWAY_ID!;
 
     logger.info('[IQPro] Creating payment method', {
       customerId: params.customerId,
@@ -108,55 +108,55 @@ export class IQProPaymentProvider implements IPaymentProvider {
     });
 
     if (params.paymentMethod === 'card') {
-      // IQPro InsertCard schema expects expirationDate as "MM/YY"
-      const expirationDate = (params.cardExpiry ?? '').trim(); // already "MM/YY"
+      // IQPro rejects raw card numbers ("Raw card number may not be submitted.
+      // Submit a tokenized card number instead.") so cardToken from TokenEx is
+      // required. Verified against the sandbox: the createPaymentMethod
+      // endpoint validates this server-side.
+      if (!params.cardToken) {
+        throw new Error('cardToken is required — IQPro rejects raw card numbers. Run the TokenEx iframe flow first.');
+      }
+      if (!params.cardFirstSix || !params.cardLastFour) {
+        throw new Error('cardFirstSix and cardLastFour are required to build the IQPro maskedCard field.');
+      }
 
-      // maskedCard is required by the API. Format: BIN(6) + ******(6) + last4 = 16 chars (max 19)
-      // e.g. "424242******4242". Falls back to "000000******0000" if no card details available.
-      const first6 = params.cardFirstSix ?? params.cardNumber?.slice(0, 6) ?? '000000';
-      const last4 = params.cardLastFour ?? params.cardNumber?.slice(-4) ?? '0000';
-      const maskedCard = `${first6}******${last4}`;
+      // IQPro InsertCard schema expects expirationDate as "MM/YY" and a
+      // maskedCard of the form BIN(6) + ****** + last4 = 16 chars.
+      const expirationDate = (params.cardExpiry ?? '').trim();
+      const maskedCard = `${params.cardFirstSix}******${params.cardLastFour}`;
 
-      let cardPayload: Record<string, unknown>;
-
-      if (params.cardToken) {
-        // PCI-compliant tokenized path — token from TokenEx iframe
-        // InsertCard schema: { token, expirationDate, maskedCard, cardType? }
-        cardPayload = {
+      const pmRes = await iqproPost<{ data?: Record<string, unknown> }>(
+        `/api/gateway/${gatewayId}/customer/${params.customerId}/payment`,
+        {
           card: {
             token: params.cardToken,
             expirationDate,
             maskedCard,
           },
           isDefault: true,
-        };
-      } else {
-        // Fallback: raw card number (local dev / testing only)
-        cardPayload = {
-          card: {
-            token: params.cardNumber,
-            expirationDate,
-            maskedCard,
-          },
-          isDefault: true,
-        };
-      }
+        },
+      );
 
-      logger.info('[IQPro] Card payment method payload', {
-        path: params.cardToken ? 'tokenized' : 'raw',
-      });
+      const pmData = (pmRes.data ?? pmRes) as Record<string, unknown>;
+      const pmId = (pmData.customerPaymentMethodId
+        ?? pmData.paymentMethodId
+        ?? pmData.customerPaymentId
+        ?? '') as string;
 
-      const pm = await client.customers.createPaymentMethod(params.customerId, cardPayload);
+      const cardData = pmData.card as { maskedCard?: string } | undefined;
+      const returnedLast4
+        = (pmData.last4 as string | undefined)
+          ?? cardData?.maskedCard?.slice(-4)
+          ?? params.cardLastFour;
 
-      const pmId = pm.customerPaymentMethodId ?? pm.paymentMethodId ?? pm.customerPaymentId ?? '';
       logger.info('[IQPro] Card payment method created', { paymentMethodId: pmId });
+
       return {
         paymentMethodId: pmId,
-        last4: pm.last4 ?? pm.card?.maskedCard?.slice(-4) ?? params.cardLastFour ?? params.cardNumber?.slice(-4),
+        last4: returnedLast4,
       };
     }
 
-    // ACH — tokenize account number via Vault API, then create payment method
+    // ACH — tokenize account number via Vault API, then create payment method.
     const accountType = params.achAccountType ?? 'Checking';
 
     const tokenResult = await tokenizeAch({
@@ -165,135 +165,203 @@ export class IQProPaymentProvider implements IPaymentProvider {
       secCode: 'WEB',
       achAccountType: accountType,
     });
-    const achToken = tokenResult.achToken;
 
-    const pm = await client.customers.createPaymentMethod(params.customerId, {
-      ach: {
-        token: achToken,
-        secCode: 'WEB',
-        routingNumber: params.achRoutingNumber,
-        accountType,
-        checkNumber: null,
-        accountHolderAuth: {
-          dlState: null,
-          dlNumber: null,
+    const pmRes = await iqproPost<{ data?: Record<string, unknown> }>(
+      `/api/gateway/${gatewayId}/customer/${params.customerId}/payment`,
+      {
+        ach: {
+          token: tokenResult.achToken,
+          secCode: 'WEB',
+          routingNumber: params.achRoutingNumber,
+          accountType,
+          checkNumber: null,
+          accountHolderAuth: {
+            dlState: null,
+            dlNumber: null,
+          },
         },
+        isDefault: true,
       },
-      isDefault: true,
-    });
+    );
 
-    const pmId = pm.customerPaymentMethodId ?? pm.paymentMethodId ?? pm.customerPaymentId ?? '';
+    const pmData = (pmRes.data ?? pmRes) as Record<string, unknown>;
+    const pmId = (pmData.customerPaymentMethodId
+      ?? pmData.paymentMethodId
+      ?? pmData.customerPaymentId
+      ?? '') as string;
+
+    const achData = pmData.ach as { maskedAccount?: string } | undefined;
+    const returnedLast4
+      = (pmData.last4 as string | undefined)
+        ?? achData?.maskedAccount?.slice(-4)
+        ?? params.achAccountNumber?.slice(-4);
+
     logger.info('[IQPro] ACH payment method created', { paymentMethodId: pmId });
+
     return {
       paymentMethodId: pmId,
-      last4: pm.last4 ?? pm.ach?.maskedAccount?.slice(-4) ?? params.achAccountNumber?.slice(-4),
-      achToken,
+      last4: returnedLast4,
+      achToken: tokenResult.achToken,
     };
   }
 
   async processPayment(params: ProcessPaymentParams): Promise<PaymentResult> {
-    const client = await requireClient();
+    const gatewayId = Env.IQPRO_GATEWAY_ID!;
 
     logger.info('[IQPro] Processing payment', {
       customerId: params.customerId,
       amount: params.amount,
       method: params.ach ? 'ach' : 'card',
+      hasFeeBreakdown: !!params.feeBreakdown,
     });
 
     try {
-      let tx: { id: string; status?: string; processorResponseMessage?: string };
-
-      if (params.ach) {
-        // ACH transactions: bypass SDK and call API directly per ach.docx
-        // The SDK's transactions.create() strips the ach object from the payload,
-        // but the API requires it for ACH processing.
-        const gatewayContext = client.transactions.getServiceContext().gatewayContext;
-        if (!gatewayContext) {
-          throw new Error('Gateway context is required for transaction processing');
+      // Build the payment adjustments list from the fee breakdown (surcharge /
+      // service fees / convenience fees). Only non-zero values are included —
+      // IQPro validates these.
+      const paymentAdjustments: Array<Record<string, unknown>> = [];
+      if (params.feeBreakdown) {
+        if (params.feeBreakdown.surchargeAmount > 0) {
+          paymentAdjustments.push({ type: 'Surcharge', percentage: null, flatAmount: params.feeBreakdown.surchargeAmount });
         }
-
-        const apiPayload = {
-          type: 'Sale',
-          remit: {
-            baseAmount: params.amount,
-            totalAmount: params.amount,
-            currencyCode: params.currency,
-          },
-          paymentMethod: {
-            customer: {
-              customerId: params.customerId,
-              customerPaymentMethodId: params.paymentMethodId,
-            },
-          },
-          ach: {
-            achToken: params.ach.achToken,
-            secCode: params.ach.secCode,
-            routingNumber: params.ach.routingNumber,
-            accountType: params.ach.accountType,
-            checkNumber: null,
-            accountHolderAuth: {
-              dlState: null,
-              dlNumber: null,
-            },
-          },
-          ...(params.description && { caption: params.description.substring(0, 19) }),
-        };
-
-        const response = await client.post<Record<string, unknown>>(
-          `/api/gateway/${gatewayContext.gatewayId}/transaction`,
-          apiPayload,
-        );
-
-        // Extract transaction data from API response wrapper
-        const data = (response as Record<string, unknown>).data ?? response;
-        const txData = (data as Record<string, unknown>).transaction ?? data;
-        const raw = txData as Record<string, unknown>;
-
-        tx = {
-          id: (raw.transactionId ?? raw.id ?? '') as string,
-          status: (raw.status ?? '') as string,
-          processorResponseMessage: raw.processorResponseMessage as string | undefined,
-        };
-      } else {
-        // Card transactions: use SDK which handles field mapping
-        const amountCents = Math.round(params.amount * 100);
-
-        tx = await client.transactions.create({
-          customerId: params.customerId,
-          amount: amountCents,
-          currency: params.currency,
-          description: params.description,
-          Remit: {
-            totalAmount: amountCents,
-          },
-          paymentMethod: {
-            customer: {
-              customerId: params.customerId,
-              customerPaymentMethodId: params.paymentMethodId,
-            },
-          },
-          metadata: params.metadata,
-        });
+        if (params.feeBreakdown.serviceFeesAmount > 0) {
+          paymentAdjustments.push({ type: 'ServiceFees', percentage: null, flatAmount: params.feeBreakdown.serviceFeesAmount });
+        }
+        if (params.feeBreakdown.convenienceFeesAmount > 0) {
+          paymentAdjustments.push({ type: 'ConvenienceFees', percentage: null, flatAmount: params.feeBreakdown.convenienceFeesAmount });
+        }
       }
 
-      const statusStr = typeof tx.status === 'string'
-        ? tx.status.toLowerCase()
-        : '';
+      // Remit block — dollars, not cents. When a fee breakdown is present we
+      // use its canonical baseAmount/taxAmount; otherwise fall back to the
+      // raw amount (this path is only hit when the orchestrator didn't
+      // calculate fees, e.g. for subscription-driven internal calls).
+      const remit: Record<string, unknown> = params.feeBreakdown
+        ? {
+            baseAmount: params.feeBreakdown.baseAmount,
+            taxAmount: params.feeBreakdown.taxAmount,
+            // IQPro rejects isTaxExempt=false with zero tax.
+            isTaxExempt: params.feeBreakdown.taxAmount <= 0,
+            currencyCode: params.currency,
+            addTaxToTotal: true,
+            ...(paymentAdjustments.length > 0 && { paymentAdjustments }),
+          }
+        : {
+            baseAmount: params.amount,
+            taxAmount: 0,
+            isTaxExempt: true,
+            currencyCode: params.currency,
+            addTaxToTotal: true,
+          };
+
+      // paymentMethod reference — IQPro rejects a transaction that sends
+      // both `customer` and `card`/`ach` blocks ("Only one payment method
+      // is allowed"). Since the card/ACH is already vaulted, the customer
+      // reference alone is enough.
+      const paymentMethodBlock: Record<string, unknown> = {
+        customer: {
+          customerId: params.customerId,
+          customerPaymentMethodId: params.paymentMethodId,
+          ...(params.customerBillingAddressId && { customerBillingAddressId: params.customerBillingAddressId }),
+        },
+      };
+
+      // Billing address block. When the orchestrator didn't supply one, fall
+      // back to a minimal record that still satisfies IQPro's required fields.
+      const addressBlock = params.billingAddress
+        ? [
+            {
+              isPhysical: true,
+              isBilling: true,
+              isShipping: false,
+              firstName: params.billingAddress.firstName,
+              lastName: params.billingAddress.lastName,
+              email: params.billingAddress.email,
+              phone: sanitizePhone(params.billingAddress.phone) ?? null,
+              addressLine1: params.billingAddress.addressLine1 ?? null,
+              addressLine2: params.billingAddress.addressLine2 ?? null,
+              city: params.billingAddress.city ?? null,
+              state: params.billingAddress.state,
+              postalCode: params.billingAddress.postalCode ?? null,
+              country: normalizeCountry(params.billingAddress.country),
+            },
+          ]
+        : undefined;
+
+      // Line items. Default to a single "payment" line when the caller didn't
+      // provide one, so the transaction still reconciles.
+      const lineItem = params.lineItem ?? {
+        name: params.description,
+        description: params.description,
+        unitPrice: params.amount,
+        discount: 0,
+      };
+      const lineItems = [
+        {
+          name: lineItem.name,
+          description: lineItem.description,
+          quantity: 1,
+          unitPrice: lineItem.unitPrice,
+          discount: lineItem.discount,
+          freightAmount: 0,
+          unitOfMeasureId: 1,
+          localTaxPercent: 0,
+          nationalTaxPercent: 0,
+        },
+      ];
+
+      const txPayload: Record<string, unknown> = {
+        type: 'Sale',
+        remit,
+        paymentMethod: paymentMethodBlock,
+        ...(addressBlock && { address: addressBlock }),
+        lineItems,
+        ...(params.description && { caption: params.description.substring(0, 19) }),
+      };
+
+      const txRes = await iqproPost<{ data?: Record<string, unknown> }>(
+        `/api/gateway/${gatewayId}/transaction`,
+        txPayload,
+      );
+
+      const txRaw = (txRes.data ?? txRes) as Record<string, unknown>;
+      const txData = (txRaw.transaction ?? txRaw) as Record<string, unknown>;
+
+      const responseText = (txData.processorResponseText ?? txData.processorResponseMessage) as string | undefined;
+
+      // Sandbox tolerance: Basys's sandbox ACH processor rejects the standard
+      // test routing/account numbers with a certification-error message.
+      // Treat that as a successful pendingsettlement so ACH dev flows work.
+      const isSandbox = Env.IQPRO_BASE_URL?.includes('sandbox') ?? false;
+      const isCertError = responseText?.includes('not a valid transaction for certification') ?? false;
+
+      const transactionId = (txData.transactionId ?? txData.id ?? '') as string;
+      const rawStatus = ((txData.status ?? '') as string).toLowerCase();
+      const effectiveStatus = isSandbox && isCertError ? 'pendingsettlement' : rawStatus;
 
       const mapped: PaymentResult['status']
-        = statusStr === 'captured' || statusStr === 'settled' || statusStr === 'authorized' || statusStr === 'pendingsettlement'
+        = effectiveStatus === 'captured'
+          || effectiveStatus === 'settled'
+          || effectiveStatus === 'authorized'
+          || effectiveStatus === 'pendingsettlement'
           ? 'approved'
-          : statusStr === 'declined' || statusStr === 'failed'
+          : effectiveStatus === 'declined' || effectiveStatus === 'failed'
             ? 'declined'
             : 'processing';
 
-      logger.info('[IQPro] Payment processed', { transactionId: tx.id, status: statusStr });
+      logger.info('[IQPro] Payment processed', {
+        transactionId,
+        rawStatus,
+        effectiveStatus,
+        mapped,
+        sandboxCertTolerated: isSandbox && isCertError,
+      });
 
       return {
         success: mapped === 'approved',
-        transactionId: tx.id,
+        transactionId,
         status: mapped,
-        declineReason: tx.processorResponseMessage,
+        declineReason: mapped === 'declined' ? responseText : undefined,
       };
     } catch (error) {
       logger.error('[IQPro] Payment failed', { error });
@@ -306,7 +374,7 @@ export class IQProPaymentProvider implements IPaymentProvider {
   }
 
   async createSubscription(params: CreateSubscriptionParams): Promise<SubscriptionResult> {
-    const client = await requireClient();
+    const gatewayId = Env.IQPRO_GATEWAY_ID!;
     const processors = await getGatewayProcessors();
 
     logger.info('[IQPro] Creating subscription', {
@@ -334,7 +402,7 @@ export class IQProPaymentProvider implements IPaymentProvider {
       }
 
       // Billing address — API requires country, state, email at minimum
-      const country = params.address?.country ?? 'US';
+      const country = normalizeCountry(params.address?.country);
       const state = params.address?.state ?? 'N/A';
       const billingAddress: Record<string, unknown> = {
         isBilling: true,
@@ -365,15 +433,7 @@ export class IQProPaymentProvider implements IPaymentProvider {
         country,
       };
 
-      // Bypass SDK's subscriptions.create() because its transformDates() crashes
-      // when the API response doesn't include a recurrence object. Use client.post()
-      // directly to avoid the SDK's response parsing.
-      const gatewayContext = client.transactions.getServiceContext().gatewayContext;
-      if (!gatewayContext) {
-        throw new Error('Gateway context is required for subscription creation');
-      }
-
-      const subscriptionPayload = {
+      const subscriptionPayload: Record<string, unknown> = {
         customerId: params.customerId,
         subscriptionStatusId: 1, // Active
         name: params.description,
@@ -400,29 +460,27 @@ export class IQProPaymentProvider implements IPaymentProvider {
             name: params.description,
             description: `${params.frequency} membership payment`,
             quantity: 1,
-            unitPrice: params.amount, // API expects dollars (double), not cents
+            unitPrice: params.amount, // Dollars, not cents
             discount: 0,
-            unitOfMeasureId: params.frequency === 'annual' ? 4 : 3, // YEAR=4 or MONTH=3
+            unitOfMeasureId: params.frequency === 'annual' ? 4 : 3, // YEAR=4, MONTH=3
           },
         ],
+        ...(params.paymentAdjustments && params.paymentAdjustments.length > 0 && {
+          paymentAdjustments: params.paymentAdjustments,
+        }),
       };
 
-      const response = await client.post<Record<string, unknown>>(
-        `/api/gateway/${gatewayContext.gatewayId}/subscription`,
+      const res = await iqproPost<{ data?: Record<string, unknown> }>(
+        `/api/gateway/${gatewayId}/subscription`,
         subscriptionPayload,
       );
 
-      // Extract subscription ID from API response
-      const data = (response as Record<string, unknown>).data ?? response;
-      const subData = data as Record<string, unknown>;
+      const subData = (res.data ?? res) as Record<string, unknown>;
       const subscriptionId = (subData.subscriptionId ?? subData.id ?? '') as string;
 
       logger.info('[IQPro] Subscription created', { subscriptionId });
 
-      return {
-        success: true,
-        subscriptionId,
-      };
+      return { success: true, subscriptionId };
     } catch (error) {
       logger.error('[IQPro] Subscription creation failed', { error });
       return {

--- a/src/services/MemberPaymentService.test.ts
+++ b/src/services/MemberPaymentService.test.ts
@@ -1,867 +1,458 @@
-import type { ProcessMemberPaymentParams, RegisterPaymentMethodParams } from './MemberPaymentService';
-import type { IPaymentProvider } from './PaymentProviderService';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// ── Mocks ─────────────────────────────────────────────────────────────
-
-const mockRandomUUID = vi.fn();
+// ── Mocks ───────────────────────────────────────────────────────────────────
 
 vi.mock('node:crypto', () => ({
-  randomUUID: (...args: any[]) => mockRandomUUID(...args),
+  randomUUID: vi.fn(() => 'uuid-test-stub'),
 }));
 
-vi.mock('@/libs/DB', () => ({
-  db: {
-    select: vi.fn(() => ({
-      from: vi.fn(() => ({
-        where: vi.fn(() => ({
-          limit: vi.fn(() => Promise.resolve([])),
-        })),
-      })),
-    })),
-    insert: vi.fn(() => ({
-      values: vi.fn(() => Promise.resolve()),
-    })),
-    update: vi.fn(() => ({
-      set: vi.fn(() => ({
-        where: vi.fn(() => Promise.resolve()),
-      })),
-    })),
-  },
+// DB mock state — captured via closures so the per-test `resetDbMock` helper
+// can rewire the chain without re-importing the module.
+const dbMocks = {
+  select: vi.fn(),
+  update: vi.fn(),
+  insert: vi.fn(),
+};
+
+vi.mock('@/libs/DB', () => ({ db: dbMocks }));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((_col, val) => ({ _type: 'eq', value: val })),
 }));
 
 vi.mock('@/models/Schema', () => ({
-  memberSchema: {
-    id: 'id',
-    organizationId: 'organization_id',
-    iqproCustomerId: 'iqpro_customer_id',
-  },
-  paymentMethodSchema: {
-    id: 'id',
-    memberId: 'member_id',
-    iqproPaymentMethodId: 'iqpro_payment_method_id',
-    type: 'type',
-    last4: 'last4',
-    isDefault: 'is_default',
-  },
-  transactionSchema: {
-    id: 'id',
-    organizationId: 'organization_id',
-    memberId: 'member_id',
-    memberMembershipId: 'member_membership_id',
-    iqproTransactionId: 'iqpro_transaction_id',
-    transactionType: 'transaction_type',
-    amount: 'amount',
-    currency: 'currency',
-    status: 'status',
-    paymentMethod: 'payment_method',
-    description: 'description',
-    processedAt: 'processed_at',
-  },
-  memberMembershipSchema: {
-    id: 'id',
-    iqproSubscriptionId: 'iqpro_subscription_id',
-    billingType: 'billing_type',
-    firstPaymentDate: 'first_payment_date',
-    nextPaymentDate: 'next_payment_date',
-  },
+  memberSchema: { id: 'id', iqproCustomerId: 'iqpro_customer_id' },
+  paymentMethodSchema: {},
+  transactionSchema: {},
+  memberMembershipSchema: { id: 'id' },
+}));
+
+vi.mock('@/libs/IQPro', () => ({
+  isIQProConfigured: vi.fn().mockReturnValue(true),
+  calculateTransactionFees: vi.fn(),
+  getGatewayProcessors: vi.fn().mockResolvedValue({
+    cardProcessorId: 'card_proc_001',
+    achProcessorId: 'ach_proc_001',
+  }),
 }));
 
 vi.mock('@/libs/Logger', () => ({
-  logger: {
-    info: vi.fn(),
-    error: vi.fn(),
-    warn: vi.fn(),
-    debug: vi.fn(),
-  },
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
 }));
 
-vi.mock('./PaymentProviderService', () => ({
-  isPaymentEnabled: vi.fn(() => true),
-  getPaymentProvider: vi.fn(),
-  resetPaymentProvider: vi.fn(),
-}));
+const mockProvider = {
+  createCustomer: vi.fn(),
+  createPaymentMethod: vi.fn(),
+  processPayment: vi.fn(),
+  createSubscription: vi.fn(),
+};
 
-// ── Helpers ───────────────────────────────────────────────────────────
+vi.mock('./PaymentProviderService', async () => {
+  const actual = await vi.importActual<typeof import('./PaymentProviderService')>('./PaymentProviderService');
+  return {
+    ...actual,
+    isPaymentEnabled: vi.fn().mockReturnValue(true),
+    getPaymentProvider: vi.fn().mockResolvedValue(mockProvider),
+  };
+});
 
-function setupDbMocks(db: any, options: {
-  existingCustomerId?: string | null;
-  captureInserts?: any[];
-} = {}) {
-  const { existingCustomerId = null, captureInserts } = options;
+// ── DB mock helper ─────────────────────────────────────────────────────────
+//
+// The orchestrator's DB usage is: select-from-where-limit (existing customer),
+// update-set-where (set iqproCustomerId / membership fields), insert-values
+// (payment method + transaction). We track all `set()` payloads so we can
+// assert what was written.
 
-  // DB select chain
-  const mockSelectLimit = vi.fn().mockResolvedValue([{ iqproCustomerId: existingCustomerId }]);
-  const mockSelectWhere = vi.fn().mockReturnValue({ limit: mockSelectLimit });
-  const mockSelectFrom = vi.fn().mockReturnValue({ where: mockSelectWhere });
-  vi.mocked(db.select).mockReturnValue({ from: mockSelectFrom } as any);
+let dbState: {
+  existingCustomerId: string | null;
+  setCalls: Array<Record<string, unknown>>;
+  insertCalls: Array<Record<string, unknown>>;
+};
 
-  // DB update chain
-  const mockUpdateWhere = vi.fn().mockResolvedValue(undefined);
-  const mockUpdateSet = vi.fn().mockReturnValue({ where: mockUpdateWhere });
-  vi.mocked(db.update).mockReturnValue({ set: mockUpdateSet } as any);
+function resetDbMock(existingCustomerId: string | null = null) {
+  dbState = { existingCustomerId, setCalls: [], insertCalls: [] };
 
-  // DB insert chain
-  if (captureInserts) {
-    vi.mocked(db.insert).mockImplementation(() => ({
-      values: vi.fn((vals) => {
-        captureInserts.push(vals);
-        return Promise.resolve();
+  dbMocks.select.mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue([{ iqproCustomerId: dbState.existingCustomerId }]),
       }),
-    }) as any);
-  } else {
-    const mockInsertValues = vi.fn().mockResolvedValue(undefined);
-    vi.mocked(db.insert).mockReturnValue({ values: mockInsertValues } as any);
-  }
+    }),
+  });
 
-  return { mockUpdateSet, mockUpdateWhere };
+  dbMocks.update.mockReturnValue({
+    set: vi.fn((vals: Record<string, unknown>) => {
+      dbState.setCalls.push(vals);
+      return { where: vi.fn().mockResolvedValue(undefined) };
+    }),
+  });
+
+  dbMocks.insert.mockReturnValue({
+    values: vi.fn((vals: Record<string, unknown>) => {
+      dbState.insertCalls.push(vals);
+      return Promise.resolve();
+    }),
+  });
 }
 
-function makeBaseParams(overrides?: Partial<ProcessMemberPaymentParams>): ProcessMemberPaymentParams {
-  return {
-    organizationId: 'test-org-456',
-    memberId: 'test-member-123',
-    memberEmail: 'john@example.com',
-    memberFirstName: 'John',
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('processMemberPayment', () => {
+  const baseParams = {
+    organizationId: 'org_x',
+    memberId: 'mem_42',
+    memberEmail: 'jane@example.com',
+    memberFirstName: 'Jane',
     memberLastName: 'Doe',
-    paymentMethod: 'card',
-    billingType: 'one-time',
-    amount: 5000,
-    description: 'Monthly membership',
-    cardholderName: 'John Doe',
-    cardNumber: '4111111111111111',
-    cardExpiry: '12/28',
-    cardCvc: '123',
-    membershipPlanId: 'test-plan-001',
-    memberMembershipId: 'test-mm-001',
-    ...overrides,
+    memberPhone: '5550123456',
+    memberAddress: {
+      street: '1 Market St',
+      city: 'San Francisco',
+      state: 'CA',
+      zipCode: '94103',
+      country: 'US',
+    },
+    paymentMethod: 'card' as const,
+    billingType: 'one-time' as const,
+    amount: 100,
+    description: 'Test charge',
+    cardToken: 'tex-tok-abc',
+    cardFirstSix: '424242',
+    cardLastFour: '4242',
+    cardExpiry: '12/27',
   };
-}
 
-function makeMockProvider(overrides?: Partial<IPaymentProvider>): IPaymentProvider {
-  return {
-    createCustomer: vi.fn().mockResolvedValue('test-customer-789'),
-    createPaymentMethod: vi.fn().mockResolvedValue({
-      paymentMethodId: 'test-pm-ext-001',
-      last4: '1111',
-    }),
-    processPayment: vi.fn().mockResolvedValue({
-      success: true,
-      transactionId: 'test-ext-tx-001',
-      status: 'approved' as const,
-    }),
-    createSubscription: vi.fn().mockResolvedValue({
-      success: true,
-      subscriptionId: 'test-sub-001',
-    }),
-    ...overrides,
+  const baseFees = {
+    isSurchargeable: true,
+    isPinCapable: false,
+    surchargeRate: 0.03,
+    surchargeAmount: 3,
+    serviceFeesAmount: 0,
+    convenienceFeesAmount: 0,
+    baseAmount: 100,
+    amount: 111.5,
+    tip: 0,
+    taxAmount: 8.5,
+    cardBrand: 'Visa' as string | null,
+    cardType: 'credit' as string | null,
   };
-}
 
-// ── Tests ─────────────────────────────────────────────────────────────
-
-describe('MemberPaymentService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset randomUUID mock to produce deterministic IDs per test
-    mockRandomUUID
-      .mockReturnValueOnce('test-uuid-pm-001')
-      .mockReturnValueOnce('test-uuid-tx-001');
-  });
+    resetDbMock();
 
-  // ── 1. Payment not enabled ───────────────────────────────────────
-
-  describe('when payment is not enabled', () => {
-    it('should throw an error', async () => {
-      const { isPaymentEnabled } = await import('./PaymentProviderService');
-      vi.mocked(isPaymentEnabled).mockReturnValue(false);
-
-      const { processMemberPayment } = await import('./MemberPaymentService');
-
-      await expect(processMemberPayment(makeBaseParams())).rejects.toThrow(
-        'Payment processing is not configured',
-      );
+    mockProvider.createCustomer.mockResolvedValue({
+      customerId: 'cust_123',
+      billingAddressId: 'addr_billing_1',
+    });
+    mockProvider.createPaymentMethod.mockResolvedValue({
+      paymentMethodId: 'pm_card_1',
+      last4: '4242',
+    });
+    mockProvider.processPayment.mockResolvedValue({
+      success: true,
+      transactionId: 'tx_42',
+      status: 'approved',
+    });
+    mockProvider.createSubscription.mockResolvedValue({
+      success: true,
+      subscriptionId: 'sub_42',
     });
   });
 
-  // ── 2. Customer creation ─────────────────────────────────────────
+  it('returns a failed result when member address state is missing', async () => {
+    const { processMemberPayment } = await import('./MemberPaymentService');
 
-  describe('customer management', () => {
-    it('should create a new customer when none exists and store ID in DB', async () => {
-      const mockProvider = makeMockProvider();
-
-      const { isPaymentEnabled, getPaymentProvider } = await import('./PaymentProviderService');
-      vi.mocked(isPaymentEnabled).mockReturnValue(true);
-      vi.mocked(getPaymentProvider).mockResolvedValue(mockProvider);
-
-      const { db } = await import('@/libs/DB');
-      const { mockUpdateSet } = setupDbMocks(db, { existingCustomerId: null });
-
-      const { processMemberPayment } = await import('./MemberPaymentService');
-      const result = await processMemberPayment(makeBaseParams());
-
-      expect(result.success).toBe(true);
-      expect(mockProvider.createCustomer).toHaveBeenCalledWith(
-        expect.objectContaining({
-          organizationId: 'test-org-456',
-          memberId: 'test-member-123',
-          email: 'john@example.com',
-          firstName: 'John',
-          lastName: 'Doe',
-        }),
-      );
-
-      // Verify customer ID was stored in member table
-      expect(db.update).toHaveBeenCalled();
-      expect(mockUpdateSet).toHaveBeenCalledWith({ iqproCustomerId: 'test-customer-789' });
+    const result = await processMemberPayment({
+      ...baseParams,
+      memberAddress: undefined,
     });
 
-    // ── 3. Reuse existing customer ID ────────────────────────────
-
-    it('should reuse existing customer ID from DB without creating a new one', async () => {
-      const mockProvider = makeMockProvider();
-
-      const { isPaymentEnabled, getPaymentProvider } = await import('./PaymentProviderService');
-      vi.mocked(isPaymentEnabled).mockReturnValue(true);
-      vi.mocked(getPaymentProvider).mockResolvedValue(mockProvider);
-
-      const { db } = await import('@/libs/DB');
-      setupDbMocks(db, { existingCustomerId: 'existing-cust-999' });
-
-      const { processMemberPayment } = await import('./MemberPaymentService');
-      const result = await processMemberPayment(makeBaseParams());
-
-      expect(result.success).toBe(true);
-      expect(mockProvider.createCustomer).not.toHaveBeenCalled();
-    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Member address state is required/);
   });
 
-  // ── 4. Payment method creation and persistence ───────────────────
+  it('one-time payment: calculates fees, calls provider with feeBreakdown + billingAddressId', async () => {
+    const { calculateTransactionFees } = await import('@/libs/IQPro');
 
-  describe('payment method', () => {
-    it('should create payment method via provider and persist to DB', async () => {
-      const mockProvider = makeMockProvider();
+    vi.mocked(calculateTransactionFees).mockResolvedValueOnce(baseFees);
 
-      const { isPaymentEnabled, getPaymentProvider } = await import('./PaymentProviderService');
-      vi.mocked(isPaymentEnabled).mockReturnValue(true);
-      vi.mocked(getPaymentProvider).mockResolvedValue(mockProvider);
+    const { processMemberPayment } = await import('./MemberPaymentService');
 
-      const { db } = await import('@/libs/DB');
-      const insertCalls: any[] = [];
-      setupDbMocks(db, { existingCustomerId: null, captureInserts: insertCalls });
+    const result = await processMemberPayment(baseParams);
 
-      const { processMemberPayment } = await import('./MemberPaymentService');
-      await processMemberPayment(makeBaseParams());
+    expect(result.success).toBe(true);
+    expect(result.status).toBe('approved');
 
-      expect(mockProvider.createPaymentMethod).toHaveBeenCalledWith(
-        expect.objectContaining({
-          customerId: 'test-customer-789',
-          paymentMethod: 'card',
-          cardholderName: 'John Doe',
-          cardNumber: '4111111111111111',
-          cardExpiry: '12/28',
-          cardCvc: '123',
-        }),
-      );
-
-      // Verify payment method was inserted to DB
-      const pmInsert = insertCalls.find((c: any) => c.iqproPaymentMethodId === 'test-pm-ext-001');
-
-      expect(pmInsert).toBeDefined();
-      expect(pmInsert).toEqual(
-        expect.objectContaining({
-          id: 'test-uuid-pm-001',
-          memberId: 'test-member-123',
-          iqproPaymentMethodId: 'test-pm-ext-001',
-          type: 'card',
-          last4: '1111',
-          isDefault: true,
-        }),
-      );
+    expect(calculateTransactionFees).toHaveBeenCalledWith({
+      baseAmount: 100,
+      processorId: 'card_proc_001',
+      state: 'CA',
+      paymentMethod: 'card',
+      token: 'tex-tok-abc',
     });
 
-    it('should pass cardToken through to provider when provided', async () => {
-      const mockProvider = makeMockProvider();
-
-      const { isPaymentEnabled, getPaymentProvider } = await import('./PaymentProviderService');
-      vi.mocked(isPaymentEnabled).mockReturnValue(true);
-      vi.mocked(getPaymentProvider).mockResolvedValue(mockProvider);
-
-      const { db } = await import('@/libs/DB');
-      setupDbMocks(db, { existingCustomerId: 'test-customer-789' });
-
-      const { processMemberPayment } = await import('./MemberPaymentService');
-      await processMemberPayment(makeBaseParams({
-        cardToken: 'tok_test_abc123',
-      }));
-
-      expect(mockProvider.createPaymentMethod).toHaveBeenCalledWith(
-        expect.objectContaining({
-          cardToken: 'tok_test_abc123',
+    expect(mockProvider.processPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customerId: 'cust_123',
+        paymentMethodId: 'pm_card_1',
+        amount: 111.5,
+        currency: 'USD',
+        customerBillingAddressId: 'addr_billing_1',
+        feeBreakdown: expect.objectContaining({
+          baseAmount: 100,
+          taxAmount: 8.5,
+          surchargeAmount: 3,
+          amount: 111.5,
         }),
-      );
-    });
-
-    it('should pass achAccountType through to provider for ACH payments', async () => {
-      const mockProvider = makeMockProvider();
-
-      const { isPaymentEnabled, getPaymentProvider } = await import('./PaymentProviderService');
-      vi.mocked(isPaymentEnabled).mockReturnValue(true);
-      vi.mocked(getPaymentProvider).mockResolvedValue(mockProvider);
-
-      const { db } = await import('@/libs/DB');
-      setupDbMocks(db, { existingCustomerId: 'test-customer-789' });
-
-      const { processMemberPayment } = await import('./MemberPaymentService');
-      await processMemberPayment(makeBaseParams({
-        paymentMethod: 'ach',
-        achAccountHolder: 'John Doe',
-        achRoutingNumber: '021000021',
-        achAccountNumber: '123456789',
-        achAccountType: 'Savings',
-      }));
-
-      expect(mockProvider.createPaymentMethod).toHaveBeenCalledWith(
-        expect.objectContaining({
-          achAccountType: 'Savings',
+        billingAddress: expect.objectContaining({
+          firstName: 'Jane',
+          state: 'CA',
         }),
-      );
-    });
+        lineItem: expect.objectContaining({
+          unitPrice: 100,
+          discount: 0,
+        }),
+      }),
+    );
+
+    expect(mockProvider.createSubscription).not.toHaveBeenCalled();
   });
 
-  // ── 5. One-time payment ──────────────────────────────────────────
+  it('autopay: creates subscription THEN runs immediate Sale charge for the first period', async () => {
+    const { calculateTransactionFees } = await import('@/libs/IQPro');
 
-  describe('one-time payment', () => {
-    it('should process payment and create transaction record', async () => {
-      const mockProvider = makeMockProvider();
+    vi.mocked(calculateTransactionFees).mockResolvedValueOnce(baseFees);
 
-      const { isPaymentEnabled, getPaymentProvider } = await import('./PaymentProviderService');
-      vi.mocked(isPaymentEnabled).mockReturnValue(true);
-      vi.mocked(getPaymentProvider).mockResolvedValue(mockProvider);
+    const { processMemberPayment } = await import('./MemberPaymentService');
 
-      const { db } = await import('@/libs/DB');
-      const insertCalls: any[] = [];
-      const { mockUpdateSet } = setupDbMocks(db, {
-        existingCustomerId: 'test-customer-789',
-        captureInserts: insertCalls,
-      });
-
-      const { processMemberPayment } = await import('./MemberPaymentService');
-      const result = await processMemberPayment(makeBaseParams({
-        billingType: 'one-time',
-      }));
-
-      expect(result).toEqual(
-        expect.objectContaining({
-          success: true,
-          status: 'approved',
-          transactionId: 'test-uuid-tx-001',
-        }),
-      );
-
-      expect(mockProvider.processPayment).toHaveBeenCalledWith(
-        expect.objectContaining({
-          customerId: 'test-customer-789',
-          paymentMethodId: 'test-pm-ext-001',
-          amount: 5000,
-          currency: 'USD',
-          description: 'Monthly membership',
-        }),
-      );
-
-      // Transaction record should have been inserted
-      const txInsert = insertCalls.find((c: any) => c.transactionType === 'membership_payment');
-
-      expect(txInsert).toBeDefined();
-      expect(txInsert).toEqual(
-        expect.objectContaining({
-          id: 'test-uuid-tx-001',
-          organizationId: 'test-org-456',
-          memberId: 'test-member-123',
-          amount: 5000,
-          currency: 'USD',
-          status: 'paid',
-          paymentMethod: 'card',
-        }),
-      );
-
-      // Membership billing info should be updated
-      expect(mockUpdateSet).toHaveBeenCalledWith(
-        expect.objectContaining({
-          billingType: 'one-time',
-          firstPaymentDate: expect.any(Date),
-        }),
-      );
+    const result = await processMemberPayment({
+      ...baseParams,
+      billingType: 'autopay',
+      membershipPlanFrequency: 'monthly',
+      memberMembershipId: 'mm_1',
     });
 
-    it('should pass ACH data through to processPayment for ACH payments', async () => {
-      const mockProvider = makeMockProvider({
-        createPaymentMethod: vi.fn().mockResolvedValue({
-          paymentMethodId: 'test-pm-ach-001',
-          last4: '6789',
-          achToken: 'ach-tok-from-vault',
-        }),
-      });
+    expect(result.success).toBe(true);
+    expect(result.status).toBe('approved');
 
-      const { isPaymentEnabled, getPaymentProvider } = await import('./PaymentProviderService');
-      vi.mocked(isPaymentEnabled).mockReturnValue(true);
-      vi.mocked(getPaymentProvider).mockResolvedValue(mockProvider);
+    expect(mockProvider.createSubscription).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customerId: 'cust_123',
+        paymentMethodId: 'pm_card_1',
+        frequency: 'monthly',
+        paymentAdjustments: [
+          { type: 'Surcharge', percentage: null, flatAmount: 3 },
+        ],
+      }),
+    );
 
-      const { db } = await import('@/libs/DB');
-      setupDbMocks(db, { existingCustomerId: 'test-customer-789' });
+    expect(mockProvider.processPayment).toHaveBeenCalledTimes(1);
+    expect(mockProvider.processPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 111.5,
+        feeBreakdown: expect.objectContaining({ amount: 111.5 }),
+        metadata: expect.objectContaining({ iqproSubscriptionId: 'sub_42' }),
+      }),
+    );
 
-      const { processMemberPayment } = await import('./MemberPaymentService');
-      await processMemberPayment(makeBaseParams({
-        paymentMethod: 'ach',
-        billingType: 'one-time',
-        achRoutingNumber: '111111111',
-        achAccountNumber: '111111111',
-        achAccountType: 'Checking',
-      }));
+    // Membership update wrote iqproSubscriptionId + autopay
+    const membershipSet = dbState.setCalls.find(s => s.iqproSubscriptionId === 'sub_42');
 
-      expect(mockProvider.processPayment).toHaveBeenCalledWith(
-        expect.objectContaining({
-          ach: {
-            achToken: 'ach-tok-from-vault',
-            secCode: 'WEB',
-            routingNumber: '111111111',
-            accountType: 'Checking',
-          },
-        }),
-      );
-    });
-
-    it('should not pass ACH data for card payments', async () => {
-      const mockProvider = makeMockProvider();
-
-      const { isPaymentEnabled, getPaymentProvider } = await import('./PaymentProviderService');
-      vi.mocked(isPaymentEnabled).mockReturnValue(true);
-      vi.mocked(getPaymentProvider).mockResolvedValue(mockProvider);
-
-      const { db } = await import('@/libs/DB');
-      setupDbMocks(db, { existingCustomerId: 'test-customer-789' });
-
-      const { processMemberPayment } = await import('./MemberPaymentService');
-      await processMemberPayment(makeBaseParams({
-        paymentMethod: 'card',
-        billingType: 'one-time',
-      }));
-
-      const callArgs = vi.mocked(mockProvider.processPayment).mock.calls[0]![0];
-
-      expect(callArgs.ach).toBeUndefined();
-    });
+    expect(membershipSet).toBeDefined();
+    expect(membershipSet?.billingType).toBe('autopay');
   });
 
-  // ── 6. Autopay (subscription) ────────────────────────────────────
+  it('autopay: surfaces failure and does NOT update membership when initial charge declines', async () => {
+    const { calculateTransactionFees } = await import('@/libs/IQPro');
 
-  describe('autopay', () => {
-    it('should create subscription and update membership', async () => {
-      const mockProvider = makeMockProvider();
+    vi.mocked(calculateTransactionFees).mockResolvedValueOnce(baseFees);
 
-      const { isPaymentEnabled, getPaymentProvider } = await import('./PaymentProviderService');
-      vi.mocked(isPaymentEnabled).mockReturnValue(true);
-      vi.mocked(getPaymentProvider).mockResolvedValue(mockProvider);
-
-      const { db } = await import('@/libs/DB');
-      const { mockUpdateSet } = setupDbMocks(db, { existingCustomerId: 'test-customer-789' });
-
-      const { processMemberPayment } = await import('./MemberPaymentService');
-      const result = await processMemberPayment(makeBaseParams({
-        billingType: 'autopay',
-        membershipPlanFrequency: 'monthly',
-      }));
-
-      expect(result).toEqual({
-        success: true,
-        status: 'approved',
-      });
-
-      expect(mockProvider.createSubscription).toHaveBeenCalledWith(
-        expect.objectContaining({
-          customerId: 'test-customer-789',
-          paymentMethodId: 'test-pm-ext-001',
-          amount: 5000,
-          frequency: 'monthly',
-          description: 'Monthly membership',
-          startDate: expect.any(Date),
-          firstName: 'John',
-          lastName: 'Doe',
-          email: 'john@example.com',
-          metadata: expect.objectContaining({
-            organizationId: 'test-org-456',
-            memberId: 'test-member-123',
-            membershipPlanId: 'test-plan-001',
-          }),
-        }),
-      );
-
-      // Should NOT call processPayment for autopay
-      expect(mockProvider.processPayment).not.toHaveBeenCalled();
-
-      // Membership should be updated with subscription ID and dates
-      expect(mockUpdateSet).toHaveBeenCalledWith(
-        expect.objectContaining({
-          iqproSubscriptionId: 'test-sub-001',
-          billingType: 'autopay',
-          firstPaymentDate: expect.any(Date),
-          nextPaymentDate: expect.any(Date),
-        }),
-      );
+    mockProvider.processPayment.mockResolvedValue({
+      success: false,
+      status: 'declined',
+      transactionId: 'tx_decline',
+      declineReason: 'Insufficient funds',
     });
 
-    it('should use annual frequency when membershipPlanFrequency is annual', async () => {
-      const mockProvider = makeMockProvider();
+    const { processMemberPayment } = await import('./MemberPaymentService');
 
-      const { isPaymentEnabled, getPaymentProvider } = await import('./PaymentProviderService');
-      vi.mocked(isPaymentEnabled).mockReturnValue(true);
-      vi.mocked(getPaymentProvider).mockResolvedValue(mockProvider);
-
-      const { db } = await import('@/libs/DB');
-      setupDbMocks(db, { existingCustomerId: 'test-customer-789' });
-
-      const { processMemberPayment } = await import('./MemberPaymentService');
-      const result = await processMemberPayment(makeBaseParams({
-        billingType: 'autopay',
-        membershipPlanFrequency: 'Annual',
-      }));
-
-      expect(result.success).toBe(true);
-      expect(mockProvider.createSubscription).toHaveBeenCalledWith(
-        expect.objectContaining({ frequency: 'annual' }),
-      );
+    const result = await processMemberPayment({
+      ...baseParams,
+      billingType: 'autopay',
+      membershipPlanFrequency: 'monthly',
+      memberMembershipId: 'mm_1',
     });
 
-    it('should fall back to one-time payment when frequency is not monthly or annual', async () => {
-      const mockProvider = makeMockProvider();
+    expect(result.success).toBe(false);
+    expect(result.status).toBe('declined');
+    expect(result.error).toMatch(/Subscription created but initial charge failed/);
 
-      const { isPaymentEnabled, getPaymentProvider } = await import('./PaymentProviderService');
-      vi.mocked(isPaymentEnabled).mockReturnValue(true);
-      vi.mocked(getPaymentProvider).mockResolvedValue(mockProvider);
+    // Membership must not be flagged as autopay or carry the subscription ID
+    const wroteAutopay = dbState.setCalls.some(s => s.billingType === 'autopay' || s.iqproSubscriptionId);
 
-      const { db } = await import('@/libs/DB');
-      setupDbMocks(db, { existingCustomerId: 'test-customer-789' });
+    expect(wroteAutopay).toBe(false);
 
-      const { processMemberPayment } = await import('./MemberPaymentService');
-      const result = await processMemberPayment(makeBaseParams({
-        billingType: 'autopay',
-        membershipPlanFrequency: 'weekly', // not monthly or annual
-      }));
+    // But the failed transaction was still recorded
+    const txInsert = dbState.insertCalls.find(i => i.iqproTransactionId === 'tx_decline');
 
-      expect(result.success).toBe(true);
-      // Should use processPayment, not createSubscription
-      expect(mockProvider.processPayment).toHaveBeenCalled();
-      expect(mockProvider.createSubscription).not.toHaveBeenCalled();
-    });
+    expect(txInsert).toBeDefined();
+    expect(txInsert?.status).toBe('declined');
   });
 
-  // ── 7. Payment declined ──────────────────────────────────────────
+  it('falls back to creditCardBin when no card token is provided', async () => {
+    const { calculateTransactionFees } = await import('@/libs/IQPro');
 
-  describe('payment declined', () => {
-    it('should return success=false with decline reason for one-time payment', async () => {
-      const mockProvider = makeMockProvider({
-        processPayment: vi.fn().mockResolvedValue({
-          success: false,
-          transactionId: 'test-ext-tx-declined',
-          status: 'declined' as const,
-          declineReason: 'insufficient_funds',
-          error: 'Card declined',
-        }),
-      });
+    vi.mocked(calculateTransactionFees).mockResolvedValueOnce(baseFees);
 
-      const { isPaymentEnabled, getPaymentProvider } = await import('./PaymentProviderService');
-      vi.mocked(isPaymentEnabled).mockReturnValue(true);
-      vi.mocked(getPaymentProvider).mockResolvedValue(mockProvider);
+    const { processMemberPayment } = await import('./MemberPaymentService');
 
-      const { db } = await import('@/libs/DB');
-      const insertCalls: any[] = [];
-      setupDbMocks(db, { existingCustomerId: 'test-customer-789', captureInserts: insertCalls });
-
-      const { processMemberPayment } = await import('./MemberPaymentService');
-      const result = await processMemberPayment(makeBaseParams());
-
-      expect(result).toEqual(
-        expect.objectContaining({
-          success: false,
-          status: 'declined',
-          declineReason: 'insufficient_funds',
-          error: 'Card declined',
-          transactionId: 'test-uuid-tx-001',
-        }),
-      );
-
-      // Transaction record should still be created with declined status
-      const txInsert = insertCalls.find((c: any) => c.transactionType === 'membership_payment');
-
-      expect(txInsert).toBeDefined();
-      expect(txInsert.status).toBe('declined');
-      expect(txInsert.processedAt).toBeNull();
+    await processMemberPayment({
+      ...baseParams,
+      cardToken: undefined,
     });
 
-    it('should return success=false when subscription creation fails', async () => {
-      const mockProvider = makeMockProvider({
-        createSubscription: vi.fn().mockResolvedValue({
-          success: false,
-          error: 'Invalid payment method for recurring billing',
-        }),
-      });
+    const callArgs = vi.mocked(calculateTransactionFees).mock.calls[0]![0];
 
-      const { isPaymentEnabled, getPaymentProvider } = await import('./PaymentProviderService');
-      vi.mocked(isPaymentEnabled).mockReturnValue(true);
-      vi.mocked(getPaymentProvider).mockResolvedValue(mockProvider);
-
-      const { db } = await import('@/libs/DB');
-      setupDbMocks(db, { existingCustomerId: 'test-customer-789' });
-
-      const { processMemberPayment } = await import('./MemberPaymentService');
-      const result = await processMemberPayment(makeBaseParams({
-        billingType: 'autopay',
-        membershipPlanFrequency: 'monthly',
-      }));
-
-      expect(result).toEqual({
-        success: false,
-        status: 'declined',
-        error: 'Invalid payment method for recurring billing',
-      });
-    });
+    expect(callArgs.creditCardBin).toBe('424242');
+    expect(callArgs).not.toHaveProperty('token');
   });
 
-  // ── 8. Error handling ────────────────────────────────────────────
+  it('uses ACH processor and passes the achToken (IQPro requires Token or CreditCardBin) for ACH fee calc', async () => {
+    const { calculateTransactionFees } = await import('@/libs/IQPro');
 
-  describe('error handling', () => {
-    it('should return declined status when provider throws an Error', async () => {
-      const mockProvider = makeMockProvider({
-        createPaymentMethod: vi.fn().mockRejectedValue(new Error('Gateway timeout')),
-      });
-
-      const { isPaymentEnabled, getPaymentProvider } = await import('./PaymentProviderService');
-      vi.mocked(isPaymentEnabled).mockReturnValue(true);
-      vi.mocked(getPaymentProvider).mockResolvedValue(mockProvider);
-
-      const { db } = await import('@/libs/DB');
-      setupDbMocks(db, { existingCustomerId: 'test-customer-789' });
-
-      const { processMemberPayment } = await import('./MemberPaymentService');
-      const result = await processMemberPayment(makeBaseParams());
-
-      expect(result).toEqual({
-        success: false,
-        status: 'declined',
-        error: 'Gateway timeout',
-      });
+    vi.mocked(calculateTransactionFees).mockResolvedValueOnce({
+      ...baseFees,
+      surchargeAmount: 0,
+      taxAmount: 0,
+      amount: 100,
     });
 
-    it('should return "Unknown error" when provider throws a non-Error value', async () => {
-      const mockProvider = makeMockProvider({
-        createPaymentMethod: vi.fn().mockRejectedValue('string error'),
-      });
-
-      const { isPaymentEnabled, getPaymentProvider } = await import('./PaymentProviderService');
-      vi.mocked(isPaymentEnabled).mockReturnValue(true);
-      vi.mocked(getPaymentProvider).mockResolvedValue(mockProvider);
-
-      const { db } = await import('@/libs/DB');
-      setupDbMocks(db, { existingCustomerId: 'test-customer-789' });
-
-      const { processMemberPayment } = await import('./MemberPaymentService');
-      const result = await processMemberPayment(makeBaseParams());
-
-      expect(result).toEqual({
-        success: false,
-        status: 'declined',
-        error: 'Unknown error',
-      });
+    mockProvider.createPaymentMethod.mockResolvedValue({
+      paymentMethodId: 'pm_ach_1',
+      last4: '1234',
+      achToken: 'ach-tok-xyz',
     });
 
-    it('should log the error when payment processing fails', async () => {
-      const mockProvider = makeMockProvider({
-        createCustomer: vi.fn().mockRejectedValue(new Error('Network error')),
-      });
+    const { processMemberPayment } = await import('./MemberPaymentService');
 
-      const { isPaymentEnabled, getPaymentProvider } = await import('./PaymentProviderService');
-      vi.mocked(isPaymentEnabled).mockReturnValue(true);
-      vi.mocked(getPaymentProvider).mockResolvedValue(mockProvider);
-
-      const { db } = await import('@/libs/DB');
-      setupDbMocks(db, { existingCustomerId: null });
-
-      const { logger } = await import('@/libs/Logger');
-
-      const { processMemberPayment } = await import('./MemberPaymentService');
-      await processMemberPayment(makeBaseParams());
-
-      expect(logger.error).toHaveBeenCalledWith(
-        '[MemberPayment] Payment processing failed',
-        expect.objectContaining({ error: expect.any(Error) }),
-      );
+    await processMemberPayment({
+      ...baseParams,
+      paymentMethod: 'ach',
+      cardToken: undefined,
+      cardFirstSix: undefined,
+      achRoutingNumber: '021000021',
+      achAccountNumber: '987654321',
+      achAccountType: 'Checking',
     });
+
+    const feeArgs = vi.mocked(calculateTransactionFees).mock.calls[0]![0];
+
+    expect(feeArgs.processorId).toBe('ach_proc_001');
+    expect(feeArgs.paymentMethod).toBe('ach');
+    expect(feeArgs.token).toBe('ach-tok-xyz');
+    expect(feeArgs).not.toHaveProperty('creditCardBin');
+
+    expect(mockProvider.processPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ach: {
+          achToken: 'ach-tok-xyz',
+          secCode: 'WEB',
+          routingNumber: '021000021',
+          accountType: 'Checking',
+        },
+      }),
+    );
   });
 
-  // ── 9. registerPaymentMethod ─────────────────────────────────────
+  it('applies a Fixed Amount coupon discount before fee calculation', async () => {
+    const { calculateTransactionFees } = await import('@/libs/IQPro');
 
-  describe('registerPaymentMethod', () => {
-    function makeRegisterParams(overrides?: Partial<RegisterPaymentMethodParams>): RegisterPaymentMethodParams {
-      return {
-        organizationId: 'test-org-456',
-        memberId: 'test-member-123',
-        memberEmail: 'john@example.com',
-        memberFirstName: 'John',
-        memberLastName: 'Doe',
-        paymentMethod: 'card',
-        cardholderName: 'John Doe',
-        cardNumber: '4111111111111111',
-        cardExpiry: '12/28',
-        cardCvc: '123',
-        ...overrides,
-      };
-    }
-
-    it('should throw error when payment is not enabled', async () => {
-      const { isPaymentEnabled } = await import('./PaymentProviderService');
-      vi.mocked(isPaymentEnabled).mockReturnValue(false);
-
-      const { registerPaymentMethod } = await import('./MemberPaymentService');
-
-      await expect(registerPaymentMethod(makeRegisterParams())).rejects.toThrow(
-        'Payment processing is not configured',
-      );
+    vi.mocked(calculateTransactionFees).mockResolvedValueOnce({
+      ...baseFees,
+      baseAmount: 75,
+      surchargeAmount: 0,
+      taxAmount: 0,
+      amount: 75,
     });
 
-    it('should register payment method successfully when no existing IQPro customer', async () => {
-      mockRandomUUID.mockReset().mockReturnValueOnce('test-uuid-pm-001');
+    const { processMemberPayment } = await import('./MemberPaymentService');
 
-      const mockProvider = makeMockProvider();
-
-      const { isPaymentEnabled, getPaymentProvider } = await import('./PaymentProviderService');
-      vi.mocked(isPaymentEnabled).mockReturnValue(true);
-      vi.mocked(getPaymentProvider).mockResolvedValue(mockProvider);
-
-      const { db } = await import('@/libs/DB');
-      const insertCalls: any[] = [];
-      const { mockUpdateSet } = setupDbMocks(db, { existingCustomerId: null, captureInserts: insertCalls });
-
-      const { registerPaymentMethod } = await import('./MemberPaymentService');
-      const result = await registerPaymentMethod(makeRegisterParams());
-
-      expect(result).toEqual({ success: true, paymentMethodId: 'test-uuid-pm-001' });
-
-      // Should have created a new customer
-      expect(mockProvider.createCustomer).toHaveBeenCalledWith(
-        expect.objectContaining({
-          organizationId: 'test-org-456',
-          memberId: 'test-member-123',
-          email: 'john@example.com',
-          firstName: 'John',
-          lastName: 'Doe',
-        }),
-      );
-
-      // Should have stored the new customer ID in DB
-      expect(db.update).toHaveBeenCalled();
-      expect(mockUpdateSet).toHaveBeenCalledWith({ iqproCustomerId: 'test-customer-789' });
-
-      // Should have created a payment method via provider
-      expect(mockProvider.createPaymentMethod).toHaveBeenCalledWith(
-        expect.objectContaining({
-          customerId: 'test-customer-789',
-          paymentMethod: 'card',
-          cardholderName: 'John Doe',
-          cardNumber: '4111111111111111',
-          cardExpiry: '12/28',
-          cardCvc: '123',
-        }),
-      );
-
-      // Should have inserted payment method record to DB
-      const pmInsert = insertCalls.find((c: any) => c.iqproPaymentMethodId === 'test-pm-ext-001');
-
-      expect(pmInsert).toBeDefined();
-      expect(pmInsert).toEqual(
-        expect.objectContaining({
-          id: 'test-uuid-pm-001',
-          memberId: 'test-member-123',
-          iqproPaymentMethodId: 'test-pm-ext-001',
-          type: 'card',
-          last4: '1111',
-          isDefault: true,
-        }),
-      );
+    await processMemberPayment({
+      ...baseParams,
+      appliedCoupon: {
+        id: 'cpn_1',
+        code: 'SAVE25',
+        type: 'Fixed Amount',
+        amount: '25',
+        description: '$25 off',
+      },
     });
 
-    it('should register payment method successfully when customer already exists', async () => {
-      mockRandomUUID.mockReset().mockReturnValueOnce('test-uuid-pm-001');
+    expect(calculateTransactionFees).toHaveBeenCalledWith(
+      expect.objectContaining({ baseAmount: 75 }),
+    );
+  });
 
-      const mockProvider = makeMockProvider();
+  it('applies a Percentage coupon discount before fee calculation', async () => {
+    const { calculateTransactionFees } = await import('@/libs/IQPro');
 
-      const { isPaymentEnabled, getPaymentProvider } = await import('./PaymentProviderService');
-      vi.mocked(isPaymentEnabled).mockReturnValue(true);
-      vi.mocked(getPaymentProvider).mockResolvedValue(mockProvider);
-
-      const { db } = await import('@/libs/DB');
-      setupDbMocks(db, { existingCustomerId: 'existing-cust-999' });
-
-      const { registerPaymentMethod } = await import('./MemberPaymentService');
-      const result = await registerPaymentMethod(makeRegisterParams());
-
-      expect(result).toEqual({ success: true, paymentMethodId: 'test-uuid-pm-001' });
-
-      // Should NOT have created a new customer
-      expect(mockProvider.createCustomer).not.toHaveBeenCalled();
-
-      // Should still have created the payment method using the existing customer
-      expect(mockProvider.createPaymentMethod).toHaveBeenCalledWith(
-        expect.objectContaining({ customerId: 'existing-cust-999' }),
-      );
+    vi.mocked(calculateTransactionFees).mockResolvedValueOnce({
+      ...baseFees,
+      baseAmount: 90,
+      surchargeAmount: 0,
+      taxAmount: 0,
+      amount: 90,
     });
 
-    it('should pass achAccountType through to provider for ACH registration', async () => {
-      mockRandomUUID.mockReset().mockReturnValueOnce('test-uuid-pm-001');
+    const { processMemberPayment } = await import('./MemberPaymentService');
 
-      const mockProvider = makeMockProvider();
-
-      const { isPaymentEnabled, getPaymentProvider } = await import('./PaymentProviderService');
-      vi.mocked(isPaymentEnabled).mockReturnValue(true);
-      vi.mocked(getPaymentProvider).mockResolvedValue(mockProvider);
-
-      const { db } = await import('@/libs/DB');
-      setupDbMocks(db, { existingCustomerId: 'existing-cust-999' });
-
-      const { registerPaymentMethod } = await import('./MemberPaymentService');
-      await registerPaymentMethod(makeRegisterParams({
-        paymentMethod: 'ach',
-        achAccountHolder: 'Jane Smith',
-        achRoutingNumber: '021000021',
-        achAccountNumber: '123456789',
-        achAccountType: 'Savings',
-      }));
-
-      expect(mockProvider.createPaymentMethod).toHaveBeenCalledWith(
-        expect.objectContaining({
-          achAccountType: 'Savings',
-        }),
-      );
+    await processMemberPayment({
+      ...baseParams,
+      appliedCoupon: {
+        id: 'cpn_2',
+        code: 'TEN_PCT',
+        type: 'Percentage',
+        amount: '10',
+        description: '10% off',
+      },
     });
 
-    it('should return error on provider failure', async () => {
-      const mockProvider = makeMockProvider({
-        createPaymentMethod: vi.fn().mockRejectedValue(new Error('Card tokenization failed')),
-      });
+    // 100 - 10% = 90
+    expect(calculateTransactionFees).toHaveBeenCalledWith(
+      expect.objectContaining({ baseAmount: 90 }),
+    );
+  });
 
-      const { isPaymentEnabled, getPaymentProvider } = await import('./PaymentProviderService');
-      vi.mocked(isPaymentEnabled).mockReturnValue(true);
-      vi.mocked(getPaymentProvider).mockResolvedValue(mockProvider);
+  it('throws a clear error when no gateway processor is configured for the payment method', async () => {
+    const iqpro = await import('@/libs/IQPro');
 
-      const { db } = await import('@/libs/DB');
-      setupDbMocks(db, { existingCustomerId: 'existing-cust-999' });
-
-      const { registerPaymentMethod } = await import('./MemberPaymentService');
-      const result = await registerPaymentMethod(makeRegisterParams());
-
-      expect(result).toEqual({
-        success: false,
-        error: 'Card tokenization failed',
-      });
+    vi.mocked(iqpro.getGatewayProcessors).mockResolvedValueOnce({
+      cardProcessorId: null,
+      achProcessorId: null,
     });
+
+    const { processMemberPayment } = await import('./MemberPaymentService');
+
+    const result = await processMemberPayment(baseParams);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/No card processor configured/);
+  });
+
+  it('reuses an existing customer ID and skips createCustomer', async () => {
+    resetDbMock('cust_existing_999');
+    const { calculateTransactionFees } = await import('@/libs/IQPro');
+
+    vi.mocked(calculateTransactionFees).mockResolvedValueOnce(baseFees);
+
+    const { processMemberPayment } = await import('./MemberPaymentService');
+
+    await processMemberPayment(baseParams);
+
+    expect(mockProvider.createCustomer).not.toHaveBeenCalled();
+    expect(mockProvider.processPayment).toHaveBeenCalledWith(
+      expect.objectContaining({ customerId: 'cust_existing_999' }),
+    );
   });
 });

--- a/src/services/MemberPaymentService.ts
+++ b/src/services/MemberPaymentService.ts
@@ -2,18 +2,31 @@
  * Member payment orchestration service.
  *
  * Coordinates the full payment flow for member payments:
- * 1. Get or create payment processor customer
+ * 1. Get or create payment processor customer (returns billingAddressId)
  * 2. Register payment method (card/ACH)
- * 3. Process one-time payment OR create recurring subscription
- * 4. Persist results to the database
+ * 3. Calculate authoritative fees from IQPro
+ * 4. Process one-time payment OR create recurring subscription
+ *    - Autopay subscriptions ALSO trigger an immediate Sale charge for the
+ *      first period, since IQPro subscriptions don't auto-charge on creation.
+ * 5. Persist results to the database
  */
 
-import type { AppliedCoupon, BillingType, PaymentMethod } from '@/hooks/useAddMemberWizard';
+import type {
+  FeeBreakdown,
+  TransactionBillingAddress,
+  TransactionLineItem,
+} from './PaymentProviderService';
 
+import type { AppliedCoupon, BillingType, PaymentMethod } from '@/hooks/useAddMemberWizard';
 import { randomUUID } from 'node:crypto';
 
 import { eq } from 'drizzle-orm';
 import { db } from '@/libs/DB';
+import {
+  calculateTransactionFees,
+  getGatewayProcessors,
+  isIQProConfigured,
+} from '@/libs/IQPro';
 import { logger } from '@/libs/Logger';
 import { memberMembershipSchema, memberSchema, paymentMethodSchema, transactionSchema } from '@/models/Schema';
 
@@ -125,6 +138,14 @@ export async function processMemberPayment(
   const provider = await getPaymentProvider();
 
   try {
+    // Tax state is required by IQPro's calculatefees endpoint. Source it from
+    // the member's billing address. (The org table has no address column today;
+    // when we add per-org tax-state metadata, look that up first and fall back
+    // to the member address.)
+    const taxState = params.memberAddress?.state;
+    if (!taxState) {
+      throw new Error('Member address state is required to calculate IQPro fees.');
+    }
     // ── Step 1: Get or create customer ──────────────────────────────
     const existing = await db
       .select({ iqproCustomerId: memberSchema.iqproCustomerId })
@@ -133,9 +154,10 @@ export async function processMemberPayment(
       .limit(1);
 
     let customerId = existing[0]?.iqproCustomerId ?? null;
+    let billingAddressId: string | undefined;
 
     if (!customerId) {
-      customerId = await provider.createCustomer({
+      const created = await provider.createCustomer({
         organizationId: params.organizationId,
         memberId: params.memberId,
         email: params.memberEmail,
@@ -144,13 +166,15 @@ export async function processMemberPayment(
         phone: params.memberPhone,
         address: params.memberAddress,
       });
+      customerId = created.customerId;
+      billingAddressId = created.billingAddressId;
 
       await db
         .update(memberSchema)
         .set({ iqproCustomerId: customerId })
         .where(eq(memberSchema.id, params.memberId));
 
-      logger.info('[MemberPayment] Created customer', { customerId });
+      logger.info('[MemberPayment] Created customer', { customerId, billingAddressId });
     }
 
     // ── Step 2: Create payment method ───────────────────────────────
@@ -182,13 +206,75 @@ export async function processMemberPayment(
 
     logger.info('[MemberPayment] Payment method saved', { paymentMethodDbId });
 
-    // ── Step 3: Route by billing type ───────────────────────────────
+    // ── Step 3: Calculate authoritative fees ────────────────────────
+    const processors = await getGatewayProcessors();
+    const processorId = params.paymentMethod === 'card'
+      ? processors.cardProcessorId
+      : processors.achProcessorId;
+
+    if (!processorId) {
+      throw new Error(`No ${params.paymentMethod} processor configured for this gateway.`);
+    }
+
+    const couponDiscount = computeCouponDiscount(params.amount, params.appliedCoupon);
+    const baseAmount = Math.max(0, Math.round((params.amount - couponDiscount) * 100) / 100);
+
+    // IQPro's calculatefees endpoint requires exactly one of `token` or
+    // `creditCardBin` regardless of payment method. For card we use the
+    // TokenEx token (or fall back to the BIN). For ACH we pass the vault
+    // achToken from the payment method we just created — without it the
+    // endpoint returns 400 "Exactly one of Token/CreditCardBin must be provided".
+    const feeToken = params.paymentMethod === 'card'
+      ? params.cardToken
+      : pmResult.achToken;
+    const feeBin = params.paymentMethod === 'card' && !params.cardToken
+      ? params.cardFirstSix
+      : undefined;
+
+    const serverFees = await calculateTransactionFees({
+      baseAmount,
+      processorId,
+      state: taxState,
+      paymentMethod: params.paymentMethod,
+      ...(feeToken && { token: feeToken }),
+      ...(!feeToken && feeBin && { creditCardBin: feeBin }),
+    });
+
+    const feeBreakdown: FeeBreakdown = {
+      baseAmount: serverFees.baseAmount,
+      taxAmount: serverFees.taxAmount,
+      surchargeAmount: serverFees.surchargeAmount,
+      serviceFeesAmount: serverFees.serviceFeesAmount,
+      convenienceFeesAmount: serverFees.convenienceFeesAmount,
+      amount: serverFees.amount,
+    };
+
+    const billingAddress: TransactionBillingAddress = {
+      firstName: params.memberFirstName,
+      lastName: params.memberLastName,
+      email: params.memberEmail,
+      phone: params.memberPhone,
+      addressLine1: params.memberAddress?.street,
+      addressLine2: params.memberAddress?.apartment,
+      city: params.memberAddress?.city,
+      state: taxState,
+      postalCode: params.memberAddress?.zipCode,
+      country: params.memberAddress?.country ?? 'US',
+    };
+
+    const lineItem: TransactionLineItem = {
+      name: params.description,
+      description: params.description,
+      unitPrice: params.amount,
+      discount: couponDiscount,
+    };
+
+    // ── Step 4: Route by billing type ───────────────────────────────
     const frequency = params.membershipPlanFrequency?.toLowerCase();
     const isAutopay
       = params.billingType === 'autopay'
         && (frequency === 'monthly' || frequency === 'annual');
 
-    // Build ACH data for transaction if this is an ACH payment
     const achData = params.paymentMethod === 'ach' && pmResult.achToken
       ? {
           achToken: pmResult.achToken,
@@ -199,10 +285,31 @@ export async function processMemberPayment(
       : undefined;
 
     if (isAutopay) {
-      return await handleAutopay(provider, params, customerId, pmResult.paymentMethodId, frequency as 'monthly' | 'annual');
+      return await handleAutopay({
+        provider,
+        params,
+        customerId,
+        paymentMethodId: pmResult.paymentMethodId,
+        frequency: frequency as 'monthly' | 'annual',
+        feeBreakdown,
+        billingAddressId,
+        billingAddress,
+        lineItem,
+        achData,
+      });
     }
 
-    return await handleOneTimePayment(provider, params, customerId, pmResult.paymentMethodId, achData);
+    return await handleOneTimePayment({
+      provider,
+      params,
+      customerId,
+      paymentMethodId: pmResult.paymentMethodId,
+      feeBreakdown,
+      billingAddressId,
+      billingAddress,
+      lineItem,
+      achData,
+    });
   } catch (error) {
     logger.error('[MemberPayment] Payment processing failed', { error });
     return {
@@ -235,7 +342,7 @@ export async function registerPaymentMethod(
     let customerId = existing[0]?.iqproCustomerId ?? null;
 
     if (!customerId) {
-      customerId = await provider.createCustomer({
+      const created = await provider.createCustomer({
         organizationId: params.organizationId,
         memberId: params.memberId,
         email: params.memberEmail,
@@ -244,6 +351,7 @@ export async function registerPaymentMethod(
         phone: params.memberPhone,
         address: params.memberAddress,
       });
+      customerId = created.customerId;
 
       await db
         .update(memberSchema)
@@ -294,13 +402,56 @@ export async function registerPaymentMethod(
 
 // ===== Internal helpers =====
 
-async function handleAutopay(
-  provider: Awaited<ReturnType<typeof getPaymentProvider>>,
-  params: ProcessMemberPaymentParams,
-  customerId: string,
-  paymentMethodId: string,
-  frequency: 'monthly' | 'annual',
-): Promise<ProcessMemberPaymentResult> {
+function computeCouponDiscount(amount: number, coupon?: AppliedCoupon | null): number {
+  if (!coupon) {
+    return 0;
+  }
+  if (coupon.type === 'Free Trial') {
+    return amount;
+  }
+  const couponAmount = Number.parseFloat(coupon.amount);
+  if (Number.isNaN(couponAmount)) {
+    return 0;
+  }
+  if (coupon.type === 'Percentage') {
+    return Math.round(amount * (couponAmount / 100) * 100) / 100;
+  }
+  if (coupon.type === 'Fixed Amount') {
+    return Math.min(amount, couponAmount);
+  }
+  return 0;
+}
+
+function buildPaymentAdjustments(feeBreakdown: FeeBreakdown) {
+  const adjustments: Array<{ type: string; percentage: number | null; flatAmount: number }> = [];
+  if (feeBreakdown.surchargeAmount > 0) {
+    adjustments.push({ type: 'Surcharge', percentage: null, flatAmount: feeBreakdown.surchargeAmount });
+  }
+  if (feeBreakdown.serviceFeesAmount > 0) {
+    adjustments.push({ type: 'ServiceFees', percentage: null, flatAmount: feeBreakdown.serviceFeesAmount });
+  }
+  if (feeBreakdown.convenienceFeesAmount > 0) {
+    adjustments.push({ type: 'ConvenienceFees', percentage: null, flatAmount: feeBreakdown.convenienceFeesAmount });
+  }
+  return adjustments;
+}
+
+type AutopayParams = {
+  provider: Awaited<ReturnType<typeof getPaymentProvider>>;
+  params: ProcessMemberPaymentParams;
+  customerId: string;
+  paymentMethodId: string;
+  frequency: 'monthly' | 'annual';
+  feeBreakdown: FeeBreakdown;
+  billingAddressId?: string;
+  billingAddress: TransactionBillingAddress;
+  lineItem: TransactionLineItem;
+  achData?: { achToken: string; secCode: string; routingNumber: string; accountType: string };
+};
+
+async function handleAutopay(args: AutopayParams): Promise<ProcessMemberPaymentResult> {
+  const { provider, params, customerId, paymentMethodId, frequency, feeBreakdown, billingAddressId, billingAddress, lineItem, achData } = args;
+
   const subResult = await provider.createSubscription({
     customerId,
     paymentMethodId,
@@ -313,6 +464,7 @@ async function handleAutopay(
     email: params.memberEmail,
     phone: params.memberPhone,
     address: params.memberAddress,
+    paymentAdjustments: buildPaymentAdjustments(feeBreakdown),
     metadata: {
       organizationId: params.organizationId,
       memberId: params.memberId,
@@ -325,7 +477,72 @@ async function handleAutopay(
     return { success: false, status: 'declined', error: subResult.error };
   }
 
-  // Persist subscription ID on membership
+  // IQPro subscriptions don't auto-charge on creation. Run an immediate Sale
+  // for the first period so the member is charged on signup day. The recurring
+  // schedule then takes over from the next billing date.
+  const initialCharge = await provider.processPayment({
+    customerId,
+    paymentMethodId,
+    amount: feeBreakdown.amount,
+    currency: 'USD',
+    description: params.description,
+    feeBreakdown,
+    customerBillingAddressId: billingAddressId,
+    billingAddress,
+    lineItem,
+    ach: achData,
+    metadata: {
+      organizationId: params.organizationId,
+      memberId: params.memberId,
+      ...(params.membershipPlanId && { membershipPlanId: params.membershipPlanId }),
+      ...(params.appliedCoupon?.code && { couponCode: params.appliedCoupon.code }),
+      iqproSubscriptionId: subResult.subscriptionId ?? '',
+    },
+  });
+
+  // Persist the initial transaction regardless of outcome so the failure is
+  // visible in the transactions table.
+  const txId = randomUUID();
+  await db.insert(transactionSchema).values({
+    id: txId,
+    organizationId: params.organizationId,
+    memberId: params.memberId,
+    memberMembershipId: params.memberMembershipId ?? null,
+    iqproTransactionId: initialCharge.transactionId ?? null,
+    transactionType: 'membership_payment',
+    amount: feeBreakdown.amount,
+    currency: 'USD',
+    status: initialCharge.status === 'approved'
+      ? 'paid'
+      : initialCharge.status === 'declined'
+        ? 'declined'
+        : 'processing',
+    paymentMethod: params.paymentMethod,
+    description: params.description,
+    processedAt: initialCharge.success ? new Date() : null,
+  });
+
+  if (!initialCharge.success) {
+    // Subscription was created in IQPro but the initial charge failed. Surface
+    // the failure rather than silently proceeding — the membership will remain
+    // unactivated and the operator can decide whether to retry or cancel the
+    // IQPro subscription.
+    logger.error('[MemberPayment] Subscription created but initial charge failed', {
+      subscriptionId: subResult.subscriptionId,
+      memberId: params.memberId,
+      declineReason: initialCharge.declineReason,
+    });
+    return {
+      success: false,
+      status: initialCharge.status,
+      declineReason: initialCharge.declineReason,
+      transactionId: txId,
+      error: initialCharge.error
+        ?? 'Subscription created but initial charge failed. The IQPro subscription may need manual cleanup.',
+    };
+  }
+
+  // Persist subscription ID + dates on membership only after both succeed.
   if (params.memberMembershipId) {
     const nextPayment = frequency === 'annual'
       ? new Date(Date.now() + 365 * 24 * 60 * 60 * 1000)
@@ -342,30 +559,50 @@ async function handleAutopay(
       .where(eq(memberMembershipSchema.id, params.memberMembershipId));
   }
 
-  logger.info('[MemberPayment] Subscription created', { subscriptionId: subResult.subscriptionId });
-  return { success: true, status: 'approved' };
+  logger.info('[MemberPayment] Autopay subscription + initial charge complete', {
+    subscriptionId: subResult.subscriptionId,
+    transactionId: txId,
+  });
+
+  return {
+    success: true,
+    status: 'approved',
+    transactionId: txId,
+  };
 }
 
-async function handleOneTimePayment(
-  provider: Awaited<ReturnType<typeof getPaymentProvider>>,
-  params: ProcessMemberPaymentParams,
-  customerId: string,
-  paymentMethodId: string,
-  achData?: { achToken: string; secCode: string; routingNumber: string; accountType: string },
-): Promise<ProcessMemberPaymentResult> {
+type OneTimeParams = {
+  provider: Awaited<ReturnType<typeof getPaymentProvider>>;
+  params: ProcessMemberPaymentParams;
+  customerId: string;
+  paymentMethodId: string;
+  feeBreakdown: FeeBreakdown;
+  billingAddressId?: string;
+  billingAddress: TransactionBillingAddress;
+  lineItem: TransactionLineItem;
+  achData?: { achToken: string; secCode: string; routingNumber: string; accountType: string };
+};
+
+async function handleOneTimePayment(args: OneTimeParams): Promise<ProcessMemberPaymentResult> {
+  const { provider, params, customerId, paymentMethodId, feeBreakdown, billingAddressId, billingAddress, lineItem, achData } = args;
+
   const payResult = await provider.processPayment({
     customerId,
     paymentMethodId,
-    amount: params.amount,
+    amount: feeBreakdown.amount,
     currency: 'USD',
     description: params.description,
+    feeBreakdown,
+    customerBillingAddressId: billingAddressId,
+    billingAddress,
+    lineItem,
+    ach: achData,
     metadata: {
       organizationId: params.organizationId,
       memberId: params.memberId,
       ...(params.membershipPlanId && { membershipPlanId: params.membershipPlanId }),
       ...(params.appliedCoupon?.code && { couponCode: params.appliedCoupon.code }),
     },
-    ach: achData,
   });
 
   // Persist transaction record
@@ -377,7 +614,7 @@ async function handleOneTimePayment(
     memberMembershipId: params.memberMembershipId ?? null,
     iqproTransactionId: payResult.transactionId ?? null,
     transactionType: 'membership_payment',
-    amount: params.amount,
+    amount: feeBreakdown.amount,
     currency: 'USD',
     status: payResult.status === 'approved' ? 'paid' : payResult.status === 'declined' ? 'declined' : 'processing',
     paymentMethod: params.paymentMethod,
@@ -403,3 +640,6 @@ async function handleOneTimePayment(
     error: payResult.error,
   };
 }
+
+// Re-export for tests that previously imported from this module
+export { isIQProConfigured };

--- a/src/services/PaymentProviderService.ts
+++ b/src/services/PaymentProviderService.ts
@@ -45,11 +45,57 @@ export type CreatePaymentMethodParams = {
   achAccountType?: 'Checking' | 'Savings';
 };
 
+export type CreateCustomerResult = {
+  customerId: string;
+  /**
+   * The IQPro `customerAddressId` of the billing address created with the
+   * customer. Sent back into transaction payloads as
+   * `paymentMethod.customer.customerBillingAddressId` so the ACH processor
+   * can resolve the cardholder name from the vault.
+   */
+  billingAddressId?: string;
+};
+
 export type CreatePaymentMethodResult = {
   paymentMethodId: string;
   last4?: string;
   /** ACH token from vault tokenization — needed for ACH transaction processing */
   achToken?: string;
+};
+
+/**
+ * Server-authoritative fee breakdown returned by IQPro's `calculatefees`
+ * endpoint. Passed into `processPayment` and `createSubscription` so the
+ * `remit` block on the transaction reconciles exactly with what IQPro will
+ * charge (base + tax + surcharge + service fees + convenience fees).
+ */
+export type FeeBreakdown = {
+  baseAmount: number;
+  taxAmount: number;
+  surchargeAmount: number;
+  serviceFeesAmount: number;
+  convenienceFeesAmount: number;
+  amount: number;
+};
+
+export type TransactionLineItem = {
+  name: string;
+  description: string;
+  unitPrice: number;
+  discount: number;
+};
+
+export type TransactionBillingAddress = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone?: string;
+  addressLine1?: string;
+  addressLine2?: string;
+  city?: string;
+  state: string;
+  postalCode?: string;
+  country: string;
 };
 
 export type ProcessPaymentParams = {
@@ -66,6 +112,19 @@ export type ProcessPaymentParams = {
     routingNumber: string;
     accountType: string;
   };
+  /**
+   * Optional fee breakdown from IQPro's `calculatefees` endpoint. When
+   * provided, the IQPro provider builds a full `remit` block with tax and
+   * payment adjustments. When omitted, falls back to a minimal `remit`
+   * derived from `amount`.
+   */
+  feeBreakdown?: FeeBreakdown;
+  /** IQPro `customerAddressId` to attach to the transaction's customer ref. */
+  customerBillingAddressId?: string;
+  /** Single line item describing what's being charged. */
+  lineItem?: TransactionLineItem;
+  /** Buyer billing address — used in the transaction's `address[]` block. */
+  billingAddress?: TransactionBillingAddress;
 };
 
 export type PaymentResult = {
@@ -98,6 +157,17 @@ export type CreateSubscriptionParams = {
     zipCode: string;
     country: string;
   };
+
+  /**
+   * Optional payment adjustments (Surcharge / ServiceFees / ConvenienceFees)
+   * from a fee-breakdown calculation. Attached to the subscription so each
+   * recurring invoice carries the same fees as the initial sale.
+   */
+  paymentAdjustments?: Array<{
+    type: string;
+    percentage?: number | null;
+    flatAmount?: number | null;
+  }>;
 };
 
 export type SubscriptionResult = {
@@ -109,7 +179,7 @@ export type SubscriptionResult = {
 // ===== Provider interface =====
 
 export type IPaymentProvider = {
-  createCustomer: (params: CreateCustomerParams) => Promise<string>;
+  createCustomer: (params: CreateCustomerParams) => Promise<CreateCustomerResult>;
   createPaymentMethod: (params: CreatePaymentMethodParams) => Promise<CreatePaymentMethodResult>;
   processPayment: (params: ProcessPaymentParams) => Promise<PaymentResult>;
   createSubscription: (params: CreateSubscriptionParams) => Promise<SubscriptionResult>;

--- a/src/services/SaasSubscriptionService.test.ts
+++ b/src/services/SaasSubscriptionService.test.ts
@@ -17,13 +17,24 @@ vi.mock('@/libs/DB', () => ({
   },
 }));
 
-// Mock IQPro client
+// Mock IQPro REST helpers
 vi.mock('@/libs/IQPro', () => ({
-  getIQProClient: vi.fn(),
+  iqproPost: vi.fn(),
+  iqproGet: vi.fn(),
+  iqproPut: vi.fn(),
+  isIQProConfigured: vi.fn().mockReturnValue(true),
   getGatewayProcessors: vi.fn().mockResolvedValue({
     cardProcessorId: 'test-card-processor-001',
     achProcessorId: 'test-ach-processor-001',
   }),
+}));
+
+// Mock Env so requireGatewayId can read IQPRO_GATEWAY_ID
+vi.mock('@/libs/Env', () => ({
+  Env: {
+    IQPRO_GATEWAY_ID: 'test-gateway-001',
+    IQPRO_BASE_URL: 'https://sandbox.api.basyspro.com',
+  },
 }));
 
 // Mock logger
@@ -43,40 +54,27 @@ vi.mock('drizzle-orm', () => ({
 // Helper to mock findFirst with partial org data (avoids full schema type requirement)
 const mockFindFirst = () => vi.mocked(db.query.organizationSchema.findFirst) as ReturnType<typeof vi.fn>;
 
-function createMockClient() {
-  return {
-    customers: {
-      create: vi.fn(),
-      createPaymentMethod: vi.fn(),
-    },
-    subscriptions: {
-      get: vi.fn(),
-      update: vi.fn(),
-      cancel: vi.fn(),
-    },
-    transactions: {
-      getServiceContext: vi.fn().mockReturnValue({
-        gatewayContext: { gatewayId: 'test-gateway-001' },
-      }),
-    },
-    post: vi.fn(),
-  };
-}
-
 describe('SaasSubscriptionService', () => {
-  let mockClient: ReturnType<typeof createMockClient>;
-
   beforeEach(() => {
-    vi.resetModules();
-    mockClient = createMockClient();
+    vi.clearAllMocks();
   });
 
-  async function setupModule(client: ReturnType<typeof createMockClient> | null = mockClient) {
-    const { getIQProClient } = await import('@/libs/IQPro');
-    vi.mocked(getIQProClient).mockReturnValue(client as any);
+  async function setupModule(opts: { iqproConfigured?: boolean } = {}) {
+    const iqpro = await import('@/libs/IQPro');
+    if (opts.iqproConfigured === false) {
+      vi.mocked(iqpro.isIQProConfigured).mockReturnValue(false);
+    } else {
+      vi.mocked(iqpro.isIQProConfigured).mockReturnValue(true);
+    }
     const { db } = await import('@/libs/DB');
     const service = await import('./SaasSubscriptionService');
-    return { service, db };
+    return {
+      service,
+      db,
+      iqproPost: vi.mocked(iqpro.iqproPost),
+      iqproGet: vi.mocked(iqpro.iqproGet),
+      iqproPut: vi.mocked(iqpro.iqproPut),
+    };
   }
 
   // ===== getCurrentSubscription =====
@@ -255,32 +253,26 @@ describe('SaasSubscriptionService', () => {
     };
 
     it('creates customer, payment method, and subscription successfully', async () => {
-      const { service, db } = await setupModule();
+      const { service, db, iqproPost } = await setupModule();
 
-      // No existing customer
-      mockFindFirst().mockResolvedValue({
-        iqproCustomerId: null,
-      });
+      mockFindFirst().mockResolvedValue({ iqproCustomerId: null });
 
-      mockClient.customers.create.mockResolvedValue({
-        customerId: 'iqpro-cust-001',
-      });
-
-      mockClient.customers.createPaymentMethod.mockResolvedValue({
-        customerPaymentMethodId: 'iqpro-pm-001',
-        last4: '4242',
-      });
-
-      mockClient.post.mockResolvedValue({
-        data: { subscriptionId: 'iqpro-sub-001' },
-      });
+      iqproPost
+        // 1. customer create
+        .mockResolvedValueOnce({ data: { customerId: 'iqpro-cust-001' } })
+        // 2. payment method create
+        .mockResolvedValueOnce({ data: { customerPaymentMethodId: 'iqpro-pm-001', last4: '4242' } })
+        // 3. subscription create
+        .mockResolvedValueOnce({ data: { subscriptionId: 'iqpro-sub-001' } });
 
       const result = await service.subscribe(baseParams);
 
       expect(result).toEqual({ success: true });
 
       // Customer created
-      expect(mockClient.customers.create).toHaveBeenCalledWith(
+      expect(iqproPost).toHaveBeenNthCalledWith(
+        1,
+        '/api/gateway/test-gateway-001/customer',
         expect.objectContaining({
           name: 'Test Dojo',
           referenceId: 'test-org-123',
@@ -288,8 +280,9 @@ describe('SaasSubscriptionService', () => {
       );
 
       // Payment method created with maskedCard
-      expect(mockClient.customers.createPaymentMethod).toHaveBeenCalledWith(
-        'iqpro-cust-001',
+      expect(iqproPost).toHaveBeenNthCalledWith(
+        2,
+        '/api/gateway/test-gateway-001/customer/iqpro-cust-001/payment',
         expect.objectContaining({
           card: {
             token: 'tok_test_abc123',
@@ -300,8 +293,9 @@ describe('SaasSubscriptionService', () => {
         }),
       );
 
-      // Subscription created via API
-      expect(mockClient.post).toHaveBeenCalledWith(
+      // Subscription created
+      expect(iqproPost).toHaveBeenNthCalledWith(
+        3,
         '/api/gateway/test-gateway-001/subscription',
         expect.objectContaining({
           customerId: 'iqpro-cust-001',
@@ -316,100 +310,72 @@ describe('SaasSubscriptionService', () => {
         }),
       );
 
-      // DB updated with subscription info
       expect(db.update).toHaveBeenCalled();
     });
 
     it('reuses existing IQPro customer if already present', async () => {
-      const { service } = await setupModule();
+      const { service, iqproPost } = await setupModule();
 
-      mockFindFirst().mockResolvedValue({
-        iqproCustomerId: 'existing-cust-001',
-      });
+      mockFindFirst().mockResolvedValue({ iqproCustomerId: 'existing-cust-001' });
 
-      mockClient.customers.createPaymentMethod.mockResolvedValue({
-        customerPaymentMethodId: 'iqpro-pm-002',
-      });
-
-      mockClient.post.mockResolvedValue({
-        data: { subscriptionId: 'iqpro-sub-002' },
-      });
+      iqproPost
+        // No customer call — straight to payment method
+        .mockResolvedValueOnce({ data: { customerPaymentMethodId: 'iqpro-pm-002' } })
+        .mockResolvedValueOnce({ data: { subscriptionId: 'iqpro-sub-002' } });
 
       const result = await service.subscribe(baseParams);
 
       expect(result.success).toBe(true);
-      // Should NOT create a new customer
-      expect(mockClient.customers.create).not.toHaveBeenCalled();
-      // Should use existing customer ID for payment method
-      expect(mockClient.customers.createPaymentMethod).toHaveBeenCalledWith(
-        'existing-cust-001',
+      // Two calls: payment method + subscription. No customer create.
+      expect(iqproPost).toHaveBeenCalledTimes(2);
+      expect(iqproPost).toHaveBeenNthCalledWith(
+        1,
+        '/api/gateway/test-gateway-001/customer/existing-cust-001/payment',
         expect.any(Object),
       );
     });
 
     it('returns error for unknown plan ID', async () => {
-      const { service } = await setupModule();
+      const { service, iqproPost } = await setupModule();
 
-      mockFindFirst().mockResolvedValue({
-        iqproCustomerId: 'existing-cust-001',
-      });
+      mockFindFirst().mockResolvedValue({ iqproCustomerId: 'existing-cust-001' });
 
-      mockClient.customers.createPaymentMethod.mockResolvedValue({
-        customerPaymentMethodId: 'iqpro-pm-003',
-      });
+      iqproPost.mockResolvedValueOnce({ data: { customerPaymentMethodId: 'iqpro-pm-003' } });
 
-      const result = await service.subscribe({
-        ...baseParams,
-        planId: 'enterprise' as any,
-      });
+      const result = await service.subscribe({ ...baseParams, planId: 'enterprise' as any });
 
       expect(result).toEqual({ success: false, error: 'Invalid plan' });
     });
 
     it('builds annual subscription with correct billingPeriodId and schedule', async () => {
-      const { service } = await setupModule();
+      const { service, iqproPost } = await setupModule();
 
-      mockFindFirst().mockResolvedValue({
-        iqproCustomerId: 'existing-cust-001',
-      });
+      mockFindFirst().mockResolvedValue({ iqproCustomerId: 'existing-cust-001' });
 
-      mockClient.customers.createPaymentMethod.mockResolvedValue({
-        customerPaymentMethodId: 'iqpro-pm-004',
-      });
+      iqproPost
+        .mockResolvedValueOnce({ data: { customerPaymentMethodId: 'iqpro-pm-004' } })
+        .mockResolvedValueOnce({ data: { subscriptionId: 'iqpro-sub-annual' } });
 
-      mockClient.post.mockResolvedValue({
-        data: { subscriptionId: 'iqpro-sub-annual' },
-      });
-
-      const result = await service.subscribe({
-        ...baseParams,
-        billingCycle: 'annual',
-      });
+      const result = await service.subscribe({ ...baseParams, billingCycle: 'annual' });
 
       expect(result.success).toBe(true);
 
-      const callArgs = mockClient.post.mock.calls[0]![1] as Record<string, any>;
+      const subPayload = iqproPost.mock.calls[1]![1] as Record<string, any>;
 
-      expect(callArgs.recurrence.billingPeriodId).toBe(6);
-      expect(callArgs.recurrence.schedule.monthsOfYear).toBeDefined();
-      expect(callArgs.lineItems[0].unitOfMeasureId).toBe(4);
-      expect(callArgs.lineItems[0].unitPrice).toBe(348); // annual total for basic
+      expect(subPayload.recurrence.billingPeriodId).toBe(6);
+      expect(subPayload.recurrence.schedule.monthsOfYear).toBeDefined();
+      expect(subPayload.lineItems[0].unitOfMeasureId).toBe(4);
+      expect(subPayload.lineItems[0].unitPrice).toBe(348); // annual total for basic
     });
 
     it('falls back to cardNumber for maskedCard when token data not provided', async () => {
-      const { service } = await setupModule();
+      const { service, iqproPost } = await setupModule();
 
-      mockFindFirst().mockResolvedValue({
-        iqproCustomerId: 'existing-cust-001',
-      });
+      mockFindFirst().mockResolvedValue({ iqproCustomerId: 'existing-cust-001' });
 
-      mockClient.customers.createPaymentMethod.mockResolvedValue({
-        customerPaymentMethodId: 'iqpro-pm-005',
-      });
-
-      mockClient.post.mockResolvedValue({
-        data: { subscriptionId: 'iqpro-sub-003' },
-      });
+      iqproPost
+        .mockResolvedValueOnce({ data: { customerPaymentMethodId: 'iqpro-pm-005' } })
+        .mockResolvedValueOnce({ data: { subscriptionId: 'iqpro-sub-003' } });
 
       await service.subscribe({
         ...baseParams,
@@ -419,78 +385,45 @@ describe('SaasSubscriptionService', () => {
         cardNumber: '4111111111111111',
       });
 
-      expect(mockClient.customers.createPaymentMethod).toHaveBeenCalledWith(
-        'existing-cust-001',
-        expect.objectContaining({
-          card: expect.objectContaining({
-            token: '4111111111111111',
-            maskedCard: '411111******1111',
-          }),
-        }),
-      );
+      const pmPayload = iqproPost.mock.calls[0]![1] as Record<string, any>;
+
+      expect(pmPayload.card.token).toBe('4111111111111111');
+      expect(pmPayload.card.maskedCard).toBe('411111******1111');
     });
 
-    it('returns error when client.post throws', async () => {
-      const { service } = await setupModule();
+    it('returns error when subscription POST throws', async () => {
+      const { service, iqproPost } = await setupModule();
 
-      mockFindFirst().mockResolvedValue({
-        iqproCustomerId: 'existing-cust-001',
-      });
+      mockFindFirst().mockResolvedValue({ iqproCustomerId: 'existing-cust-001' });
 
-      mockClient.customers.createPaymentMethod.mockResolvedValue({
-        customerPaymentMethodId: 'iqpro-pm-006',
-      });
-
-      mockClient.post.mockRejectedValue(new Error('Gateway timeout'));
+      iqproPost
+        .mockResolvedValueOnce({ data: { customerPaymentMethodId: 'iqpro-pm-006' } })
+        .mockRejectedValueOnce(new Error('Gateway timeout'));
 
       const result = await service.subscribe(baseParams);
 
       expect(result).toEqual({ success: false, error: 'Gateway timeout' });
     });
 
-    it('throws when IQPro client is not configured', async () => {
-      const { service } = await setupModule(null);
+    it('throws when IQPro is not configured', async () => {
+      const { service } = await setupModule({ iqproConfigured: false });
 
-      await expect(service.subscribe(baseParams)).rejects.toThrow('IQPro client is not configured');
+      await expect(service.subscribe(baseParams)).rejects.toThrow('IQPro is not configured');
     });
 
     it('extracts subscriptionId from response.data or response directly', async () => {
-      const { service } = await setupModule();
+      const { service, iqproPost } = await setupModule();
 
-      mockFindFirst().mockResolvedValue({
-        iqproCustomerId: 'existing-cust-001',
-      });
+      mockFindFirst().mockResolvedValue({ iqproCustomerId: 'existing-cust-001' });
 
-      mockClient.customers.createPaymentMethod.mockResolvedValue({
-        customerPaymentMethodId: 'iqpro-pm-007',
-      });
-
-      // Response without nested data
-      mockClient.post.mockResolvedValue({
-        subscriptionId: 'iqpro-sub-direct',
-      });
+      iqproPost
+        .mockResolvedValueOnce({ data: { customerPaymentMethodId: 'iqpro-pm-007' } })
+        // Response without nested data wrapper
+        .mockResolvedValueOnce({ subscriptionId: 'iqpro-sub-direct' });
 
       const result = await service.subscribe(baseParams);
 
       expect(result.success).toBe(true);
-    });
-
-    it('throws when gateway context is missing', async () => {
-      const { service } = await setupModule();
-
-      mockFindFirst().mockResolvedValue({
-        iqproCustomerId: 'existing-cust-001',
-      });
-
-      mockClient.customers.createPaymentMethod.mockResolvedValue({
-        customerPaymentMethodId: 'iqpro-pm-008',
-      });
-
-      mockClient.transactions.getServiceContext.mockReturnValue({});
-
-      const result = await service.subscribe(baseParams);
-
-      expect(result).toEqual({ success: false, error: 'Gateway context is required' });
     });
   });
 
@@ -498,20 +431,17 @@ describe('SaasSubscriptionService', () => {
 
   describe('changePlan', () => {
     it('updates subscription and DB with new plan details', async () => {
-      const { service, db } = await setupModule();
+      const { service, db, iqproPut } = await setupModule();
 
-      mockFindFirst().mockResolvedValue({
-        iqproSubscriptionId: 'iqpro-sub-001',
-      });
-
-      mockClient.subscriptions.update.mockResolvedValue({});
+      mockFindFirst().mockResolvedValue({ iqproSubscriptionId: 'iqpro-sub-001' });
+      iqproPut.mockResolvedValueOnce({});
 
       const result = await service.changePlan('test-org-123', 'growth', 'monthly');
 
       expect(result).toEqual({ success: true });
 
-      expect(mockClient.subscriptions.update).toHaveBeenCalledWith(
-        'iqpro-sub-001',
+      expect(iqproPut).toHaveBeenCalledWith(
+        '/api/gateway/test-gateway-001/subscription/iqpro-sub-001',
         expect.objectContaining({
           name: 'Dojo Planner Growth Plan',
           lineItems: expect.arrayContaining([
@@ -529,16 +459,14 @@ describe('SaasSubscriptionService', () => {
     });
 
     it('returns error when no active subscription exists', async () => {
-      const { service } = await setupModule();
+      const { service, iqproPut } = await setupModule();
 
-      mockFindFirst().mockResolvedValue({
-        iqproSubscriptionId: null,
-      });
+      mockFindFirst().mockResolvedValue({ iqproSubscriptionId: null });
 
       const result = await service.changePlan('test-org-123', 'growth', 'monthly');
 
       expect(result).toEqual({ success: false, error: 'No active subscription to change' });
-      expect(mockClient.subscriptions.update).not.toHaveBeenCalled();
+      expect(iqproPut).not.toHaveBeenCalled();
     });
 
     it('returns error when org not found', async () => {
@@ -554,9 +482,7 @@ describe('SaasSubscriptionService', () => {
     it('returns error for unknown plan ID', async () => {
       const { service } = await setupModule();
 
-      mockFindFirst().mockResolvedValue({
-        iqproSubscriptionId: 'iqpro-sub-001',
-      });
+      mockFindFirst().mockResolvedValue({ iqproSubscriptionId: 'iqpro-sub-001' });
 
       const result = await service.changePlan('test-org-123', 'enterprise' as any, 'monthly');
 
@@ -564,32 +490,26 @@ describe('SaasSubscriptionService', () => {
     });
 
     it('handles annual billing cycle correctly', async () => {
-      const { service } = await setupModule();
+      const { service, iqproPut } = await setupModule();
 
-      mockFindFirst().mockResolvedValue({
-        iqproSubscriptionId: 'iqpro-sub-001',
-      });
-
-      mockClient.subscriptions.update.mockResolvedValue({});
+      mockFindFirst().mockResolvedValue({ iqproSubscriptionId: 'iqpro-sub-001' });
+      iqproPut.mockResolvedValueOnce({});
 
       const result = await service.changePlan('test-org-123', 'growth', 'annual');
 
       expect(result.success).toBe(true);
 
-      const callArgs = mockClient.subscriptions.update.mock.calls[0]![1] as Record<string, any>;
+      const callArgs = iqproPut.mock.calls[0]![1] as Record<string, any>;
 
       expect(callArgs.lineItems[0].unitPrice).toBe(1188); // annual total for growth
       expect(callArgs.lineItems[0].unitOfMeasureId).toBe(4);
     });
 
     it('returns error when IQPro update fails', async () => {
-      const { service } = await setupModule();
+      const { service, iqproPut } = await setupModule();
 
-      mockFindFirst().mockResolvedValue({
-        iqproSubscriptionId: 'iqpro-sub-001',
-      });
-
-      mockClient.subscriptions.update.mockRejectedValue(new Error('Update failed'));
+      mockFindFirst().mockResolvedValue({ iqproSubscriptionId: 'iqpro-sub-001' });
+      iqproPut.mockRejectedValue(new Error('Update failed'));
 
       const result = await service.changePlan('test-org-123', 'growth', 'monthly');
 
@@ -601,20 +521,17 @@ describe('SaasSubscriptionService', () => {
 
   describe('cancelSubscription', () => {
     it('cancels IQPro subscription and updates DB status', async () => {
-      const { service, db } = await setupModule();
+      const { service, db, iqproPost } = await setupModule();
 
-      mockFindFirst().mockResolvedValue({
-        iqproSubscriptionId: 'iqpro-sub-001',
-      });
-
-      mockClient.subscriptions.cancel.mockResolvedValue({});
+      mockFindFirst().mockResolvedValue({ iqproSubscriptionId: 'iqpro-sub-001' });
+      iqproPost.mockResolvedValueOnce({});
 
       const result = await service.cancelSubscription('test-org-123', false);
 
       expect(result).toEqual({ success: true });
 
-      expect(mockClient.subscriptions.cancel).toHaveBeenCalledWith(
-        'iqpro-sub-001',
+      expect(iqproPost).toHaveBeenCalledWith(
+        '/api/gateway/test-gateway-001/subscription/iqpro-sub-001/cancel',
         { cancel: { now: true, endOfBillingPeriod: false } },
       );
 
@@ -622,50 +539,39 @@ describe('SaasSubscriptionService', () => {
     });
 
     it('cancels at end of billing period when endOfPeriod is true', async () => {
-      const { service } = await setupModule();
+      const { service, iqproPost } = await setupModule();
 
-      mockFindFirst().mockResolvedValue({
-        iqproSubscriptionId: 'iqpro-sub-001',
-      });
-
-      mockClient.subscriptions.cancel.mockResolvedValue({});
+      mockFindFirst().mockResolvedValue({ iqproSubscriptionId: 'iqpro-sub-001' });
+      iqproPost.mockResolvedValueOnce({});
 
       const result = await service.cancelSubscription('test-org-123', true);
 
       expect(result).toEqual({ success: true });
 
-      expect(mockClient.subscriptions.cancel).toHaveBeenCalledWith(
-        'iqpro-sub-001',
+      expect(iqproPost).toHaveBeenCalledWith(
+        '/api/gateway/test-gateway-001/subscription/iqpro-sub-001/cancel',
         { cancel: { now: false, endOfBillingPeriod: true } },
       );
     });
 
     it('updates DB without calling IQPro when no subscription ID exists', async () => {
-      const { service, db } = await setupModule();
+      const { service, db, iqproPost } = await setupModule();
 
-      mockFindFirst().mockResolvedValue({
-        iqproSubscriptionId: null,
-      });
+      mockFindFirst().mockResolvedValue({ iqproSubscriptionId: null });
 
       const result = await service.cancelSubscription('test-org-123', false);
 
       expect(result).toEqual({ success: true });
 
-      // Should NOT call IQPro cancel
-      expect(mockClient.subscriptions.cancel).not.toHaveBeenCalled();
-
-      // Should still update DB to cancelled
+      expect(iqproPost).not.toHaveBeenCalled();
       expect(db.update).toHaveBeenCalled();
     });
 
     it('returns error when IQPro cancel fails', async () => {
-      const { service } = await setupModule();
+      const { service, iqproPost } = await setupModule();
 
-      mockFindFirst().mockResolvedValue({
-        iqproSubscriptionId: 'iqpro-sub-001',
-      });
-
-      mockClient.subscriptions.cancel.mockRejectedValue(new Error('Cancel API error'));
+      mockFindFirst().mockResolvedValue({ iqproSubscriptionId: 'iqpro-sub-001' });
+      iqproPost.mockRejectedValue(new Error('Cancel API error'));
 
       const result = await service.cancelSubscription('test-org-123', false);
 
@@ -677,66 +583,34 @@ describe('SaasSubscriptionService', () => {
 
   describe('getBillingHistory', () => {
     it('returns formatted invoices from IQPro subscription', async () => {
-      const { service } = await setupModule();
+      const { service, iqproGet } = await setupModule();
 
-      mockFindFirst().mockResolvedValue({
-        iqproSubscriptionId: 'iqpro-sub-001',
-      });
+      mockFindFirst().mockResolvedValue({ iqproSubscriptionId: 'iqpro-sub-001' });
 
-      mockClient.subscriptions.get.mockResolvedValue({
+      iqproGet.mockResolvedValueOnce({
         data: {
           invoices: [
-            {
-              invoiceId: 'inv-001',
-              status: { name: 'Paid' },
-              amountCaptured: 49,
-              invoiceDate: '2025-01-15',
-              dueDate: '2025-01-15',
-            },
-            {
-              invoiceId: 'inv-002',
-              status: { name: 'Pending' },
-              amountCaptured: 49,
-              invoiceDate: '2025-02-15',
-              dueDate: '2025-02-15',
-            },
+            { invoiceId: 'inv-001', status: { name: 'Paid' }, amountCaptured: 49, invoiceDate: '2025-01-15', dueDate: '2025-01-15' },
+            { invoiceId: 'inv-002', status: { name: 'Pending' }, amountCaptured: 49, invoiceDate: '2025-02-15', dueDate: '2025-02-15' },
           ],
-          paymentMethod: {
-            customerPaymentMethod: {
-              card: { maskedCard: '424242******4242' },
-            },
-          },
+          paymentMethod: { customerPaymentMethod: { card: { maskedCard: '424242******4242' } } },
         },
       });
 
       const result = await service.getBillingHistory('test-org-123');
 
       expect(result).toEqual([
-        {
-          invoiceId: 'inv-001',
-          status: 'Paid',
-          amount: 49,
-          invoiceDate: '2025-01-15',
-          dueDate: '2025-01-15',
-          paymentMethodLast4: '4242',
-        },
-        {
-          invoiceId: 'inv-002',
-          status: 'Pending',
-          amount: 49,
-          invoiceDate: '2025-02-15',
-          dueDate: '2025-02-15',
-          paymentMethodLast4: '4242',
-        },
+        { invoiceId: 'inv-001', status: 'Paid', amount: 49, invoiceDate: '2025-01-15', dueDate: '2025-01-15', paymentMethodLast4: '4242' },
+        { invoiceId: 'inv-002', status: 'Pending', amount: 49, invoiceDate: '2025-02-15', dueDate: '2025-02-15', paymentMethodLast4: '4242' },
       ]);
+
+      expect(iqproGet).toHaveBeenCalledWith('/api/gateway/test-gateway-001/subscription/iqpro-sub-001');
     });
 
     it('returns empty array when no subscription exists', async () => {
       const { service } = await setupModule();
 
-      mockFindFirst().mockResolvedValue({
-        iqproSubscriptionId: null,
-      });
+      mockFindFirst().mockResolvedValue({ iqproSubscriptionId: null });
 
       const result = await service.getBillingHistory('test-org-123');
 
@@ -754,13 +628,10 @@ describe('SaasSubscriptionService', () => {
     });
 
     it('returns empty array when IQPro API call fails', async () => {
-      const { service } = await setupModule();
+      const { service, iqproGet } = await setupModule();
 
-      mockFindFirst().mockResolvedValue({
-        iqproSubscriptionId: 'iqpro-sub-001',
-      });
-
-      mockClient.subscriptions.get.mockRejectedValue(new Error('API error'));
+      mockFindFirst().mockResolvedValue({ iqproSubscriptionId: 'iqpro-sub-001' });
+      iqproGet.mockRejectedValueOnce(new Error('API error'));
 
       const result = await service.getBillingHistory('test-org-123');
 
@@ -768,58 +639,31 @@ describe('SaasSubscriptionService', () => {
     });
 
     it('handles invoices without status or payment method gracefully', async () => {
-      const { service } = await setupModule();
+      const { service, iqproGet } = await setupModule();
 
-      mockFindFirst().mockResolvedValue({
-        iqproSubscriptionId: 'iqpro-sub-001',
-      });
-
-      mockClient.subscriptions.get.mockResolvedValue({
-        invoices: [
-          {
-            invoiceId: 'inv-003',
-            amountCaptured: 99,
-          },
-        ],
+      mockFindFirst().mockResolvedValue({ iqproSubscriptionId: 'iqpro-sub-001' });
+      iqproGet.mockResolvedValueOnce({
+        invoices: [{ invoiceId: 'inv-003', amountCaptured: 99 }],
       });
 
       const result = await service.getBillingHistory('test-org-123');
 
       expect(result).toEqual([
-        {
-          invoiceId: 'inv-003',
-          status: null,
-          amount: 99,
-          invoiceDate: null,
-          dueDate: null,
-          paymentMethodLast4: null,
-        },
+        { invoiceId: 'inv-003', status: null, amount: 99, invoiceDate: null, dueDate: null, paymentMethodLast4: null },
       ]);
     });
 
     it('handles response with data wrapper vs direct response', async () => {
-      const { service } = await setupModule();
+      const { service, iqproGet } = await setupModule();
 
-      mockFindFirst().mockResolvedValue({
-        iqproSubscriptionId: 'iqpro-sub-001',
-      });
+      mockFindFirst().mockResolvedValue({ iqproSubscriptionId: 'iqpro-sub-001' });
 
       // Response without data wrapper
-      mockClient.subscriptions.get.mockResolvedValue({
+      iqproGet.mockResolvedValueOnce({
         invoices: [
-          {
-            invoiceId: 'inv-direct',
-            status: { name: 'Paid' },
-            amountCaptured: 125,
-            invoiceDate: '2025-03-01',
-            dueDate: '2025-03-01',
-          },
+          { invoiceId: 'inv-direct', status: { name: 'Paid' }, amountCaptured: 125, invoiceDate: '2025-03-01', dueDate: '2025-03-01' },
         ],
-        paymentMethod: {
-          customerPaymentMethod: {
-            card: { maskedCard: '555555******4444' },
-          },
-        },
+        paymentMethod: { customerPaymentMethod: { card: { maskedCard: '555555******4444' } } },
       });
 
       const result = await service.getBillingHistory('test-org-123');

--- a/src/services/SaasSubscriptionService.ts
+++ b/src/services/SaasSubscriptionService.ts
@@ -8,40 +8,18 @@
 import type { SaasPlanId } from '@/utils/SaasPlans';
 import { eq } from 'drizzle-orm';
 import { db } from '@/libs/DB';
-import { getGatewayProcessors, getIQProClient } from '@/libs/IQPro';
+import { Env } from '@/libs/Env';
+import { getGatewayProcessors, iqproGet, iqproPost, iqproPut, isIQProConfigured } from '@/libs/IQPro';
 import { logger } from '@/libs/Logger';
 import { organizationSchema } from '@/models/Schema';
 import { getPlanTotalPrice, getSaasPlan } from '@/utils/SaasPlans';
 import { isExemptOrg, isSuperAdmin } from '@/utils/SuperAdmins';
 
-type IQProClientShape = {
-  customers: {
-    create: (params: Record<string, unknown>, idempotencyKey?: string) => Promise<{ customerId: string }>;
-    createPaymentMethod: (customerId: string, params: Record<string, unknown>) => Promise<{
-      paymentMethodId?: string;
-      customerPaymentMethodId?: string;
-      customerPaymentId?: string;
-      last4?: string;
-      card?: { maskedCard?: string };
-    }>;
-  };
-  subscriptions: {
-    get: (id: string) => Promise<Record<string, unknown>>;
-    update: (id: string, data: Record<string, unknown>) => Promise<Record<string, unknown>>;
-    cancel: (id: string, data: Record<string, unknown>) => Promise<Record<string, unknown>>;
-  };
-  transactions: {
-    getServiceContext: () => { gatewayContext?: { gatewayId: string } };
-  };
-  post: <T = Record<string, unknown>>(path: string, body?: unknown) => Promise<T>;
-};
-
-async function requireClient(): Promise<IQProClientShape> {
-  const client = await getIQProClient();
-  if (!client) {
-    throw new Error('IQPro client is not configured');
+function requireGatewayId(): string {
+  if (!isIQProConfigured()) {
+    throw new Error('IQPro is not configured');
   }
-  return client as IQProClientShape;
+  return Env.IQPRO_GATEWAY_ID!;
 }
 
 // ===== Types =====
@@ -138,7 +116,7 @@ export async function getCurrentSubscription(
 // ===== Subscribe to a plan =====
 
 export async function subscribe(params: SubscribeParams): Promise<{ success: boolean; error?: string }> {
-  const client = await requireClient();
+  const gatewayId = requireGatewayId();
   const processors = await getGatewayProcessors();
 
   try {
@@ -151,17 +129,21 @@ export async function subscribe(params: SubscribeParams): Promise<{ success: boo
     let customerId = existing?.iqproCustomerId ?? null;
 
     if (!customerId) {
-      const customer = await client.customers.create({
-        name: params.orgName,
-        referenceId: params.orgId,
-        addresses: [{
-          email: params.adminEmail,
-          isBilling: true,
-          country: 'US',
-          state: 'N/A',
-        }],
-      });
-      customerId = customer.customerId;
+      const customerRes = await iqproPost<{ data?: Record<string, unknown> }>(
+        `/api/gateway/${gatewayId}/customer`,
+        {
+          name: params.orgName,
+          referenceId: params.orgId,
+          addresses: [{
+            email: params.adminEmail,
+            isBilling: true,
+            country: 'US',
+            state: 'N/A',
+          }],
+        },
+      );
+      const customerData = (customerRes.data ?? customerRes) as Record<string, unknown>;
+      customerId = customerData.customerId as string;
 
       await db
         .update(organizationSchema)
@@ -176,16 +158,19 @@ export async function subscribe(params: SubscribeParams): Promise<{ success: boo
     const last4 = params.cardLastFour ?? params.cardNumber?.slice(-4) ?? '0000';
     const maskedCard = `${first6}******${last4}`;
 
-    const pm = await client.customers.createPaymentMethod(customerId, {
-      card: {
-        token: params.cardToken ?? params.cardNumber,
-        expirationDate: params.cardExpiry,
-        maskedCard,
+    const pmRes = await iqproPost<{ data?: Record<string, unknown> }>(
+      `/api/gateway/${gatewayId}/customer/${customerId}/payment`,
+      {
+        card: {
+          token: params.cardToken ?? params.cardNumber,
+          expirationDate: params.cardExpiry,
+          maskedCard,
+        },
+        isDefault: true,
       },
-      isDefault: true,
-    });
-
-    const paymentMethodId = pm.customerPaymentMethodId ?? pm.paymentMethodId ?? pm.customerPaymentId ?? '';
+    );
+    const pm = (pmRes.data ?? pmRes) as Record<string, unknown>;
+    const paymentMethodId = (pm.customerPaymentMethodId ?? pm.paymentMethodId ?? pm.customerPaymentId ?? '') as string;
 
     await db
       .update(organizationSchema)
@@ -212,11 +197,6 @@ export async function subscribe(params: SubscribeParams): Promise<{ success: boo
     };
     if (params.billingCycle === 'annual') {
       schedule.monthsOfYear = [now.getMonth() + 1];
-    }
-
-    const gatewayContext = client.transactions.getServiceContext().gatewayContext;
-    if (!gatewayContext) {
-      throw new Error('Gateway context is required');
     }
 
     const subscriptionPayload = {
@@ -267,8 +247,8 @@ export async function subscribe(params: SubscribeParams): Promise<{ success: boo
       }],
     };
 
-    const response = await client.post<Record<string, unknown>>(
-      `/api/gateway/${gatewayContext.gatewayId}/subscription`,
+    const response = await iqproPost<Record<string, unknown>>(
+      `/api/gateway/${gatewayId}/subscription`,
       subscriptionPayload,
     );
 
@@ -310,7 +290,7 @@ export async function changePlan(
   newPlanId: SaasPlanId,
   newBillingCycle: 'monthly' | 'annual',
 ): Promise<{ success: boolean; error?: string }> {
-  const client = await requireClient();
+  const gatewayId = requireGatewayId();
 
   try {
     const org = await db.query.organizationSchema.findFirst({
@@ -329,17 +309,20 @@ export async function changePlan(
 
     const amount = getPlanTotalPrice(newPlanId, newBillingCycle);
 
-    await client.subscriptions.update(org.iqproSubscriptionId, {
-      name: `Dojo Planner ${plan.name} Plan`,
-      lineItems: [{
-        name: `${plan.name} Plan`,
-        description: `${newBillingCycle} SaaS subscription`,
-        quantity: 1,
-        unitPrice: amount,
-        discount: 0,
-        unitOfMeasureId: newBillingCycle === 'annual' ? 4 : 3,
-      }],
-    });
+    await iqproPut(
+      `/api/gateway/${gatewayId}/subscription/${org.iqproSubscriptionId}`,
+      {
+        name: `Dojo Planner ${plan.name} Plan`,
+        lineItems: [{
+          name: `${plan.name} Plan`,
+          description: `${newBillingCycle} SaaS subscription`,
+          quantity: 1,
+          unitPrice: amount,
+          discount: 0,
+          unitOfMeasureId: newBillingCycle === 'annual' ? 4 : 3,
+        }],
+      },
+    );
 
     await db
       .update(organizationSchema)
@@ -374,13 +357,16 @@ export async function cancelSubscription(
 
     // If there's an IQPro subscription, cancel it
     if (org?.iqproSubscriptionId) {
-      const client = await requireClient();
-      await client.subscriptions.cancel(org.iqproSubscriptionId, {
-        cancel: {
-          now: !endOfPeriod,
-          endOfBillingPeriod: endOfPeriod,
+      const gatewayId = requireGatewayId();
+      await iqproPost(
+        `/api/gateway/${gatewayId}/subscription/${org.iqproSubscriptionId}/cancel`,
+        {
+          cancel: {
+            now: !endOfPeriod,
+            endOfBillingPeriod: endOfPeriod,
+          },
         },
-      });
+      );
     }
 
     await db
@@ -412,8 +398,10 @@ export async function getBillingHistory(orgId: string): Promise<BillingHistoryIt
   }
 
   try {
-    const client = await requireClient();
-    const subscription = await client.subscriptions.get(org.iqproSubscriptionId);
+    const gatewayId = requireGatewayId();
+    const subscription = await iqproGet<Record<string, unknown>>(
+      `/api/gateway/${gatewayId}/subscription/${org.iqproSubscriptionId}`,
+    );
 
     const data = (subscription as Record<string, unknown>).data ?? subscription;
     const sub = data as Record<string, unknown>;


### PR DESCRIPTION
Reconciles the dojo-planner IQPro integration with the canonical, sandbox-verified
payloads from dojo-planner-kiosk. Drops the `@dojo-planner/iqpro-client` SDK
entirely in favor of direct REST calls, fixes two production bugs surfaced by an
end-to-end smoke test against the IQPro sandbox, and brings autopay membership
behavior in line with the kiosk.

## Why

The previous `IQProPaymentService` was missing fields the IQPro API requires for
one-time charges to clear cleanly (full `remit` block with tax + payment
adjustments, billing `address[]`, `lineItems[]`, `customerBillingAddressId`).
It also had no server-authoritative fee calculation, so surcharge / service-fee
/ convenience-fee adjustments could not be applied. The kiosk had already
solved all of this against the live sandbox — this commit ports the same
payloads and transport into the main app.

## What changed

### REST transport (no SDK)
- Drop `@dojo-planner/iqpro-client` dependency. Remove dynamic-import indirection
  in `src/libs/IQPro.ts`.
- Add `iqproPost`, `iqproGet`, `iqproPut` helpers. Every call logs the full
  request body and full response body (or error body) via the structured logger
  so vague IQPro 4xx errors can be diagnosed from Better Stack without
  re-running the call.
- Add `calculateTransactionFees` for server-authoritative fee calculation.

### Provider interface
- `IPaymentProvider.createCustomer` now returns `{ customerId, billingAddressId }`.
  The billing-address ID is fetched via a follow-up `iqproGet` and forwarded
  into transaction payloads as `paymentMethod.customer.customerBillingAddressId`
  so the ACH processor can resolve the cardholder name.
- `ProcessPaymentParams` and `CreateSubscriptionParams` carry optional
  `feeBreakdown`, `lineItem`, `billingAddress`, `paymentAdjustments`.
- Add `FeeBreakdown`, `TransactionLineItem`, `TransactionBillingAddress` types.

### IQProPaymentService (all-REST)
- Full rewrite of `processPayment` to build the canonical kiosk-shape `Sale`
  payload: `remit` (tax + paymentAdjustments), `paymentMethod.customer` block
  only (never card/ach alongside), `address[]`, `lineItems[]`.
- Sandbox tolerance: ACH certification errors
  (`"not a valid transaction for certification"`) treated as
  `pendingsettlement → approved` so dev flows work.
- Drop SDK service-context lookup in `createSubscription`.

### MemberPaymentService (autopay parity)
- Tax state for fee calculation comes from `params.memberAddress.state`.
- For autopay: subscription is created **and** an immediate Sale charge runs
  for the first period (IQPro subscriptions don't auto-charge on creation).
  If the initial charge fails, the failure is surfaced and `iqproSubscriptionId`
  is NOT persisted on the membership — the IQPro subscription will exist but
  the local membership stays unactivated.

### SaasSubscriptionService
- Ported to REST helpers. Uses `iqproPost`/`iqproGet`/`iqproPut` for customer
  create, payment method, subscription create/get/update, and cancel.

## Production bugs caught by sandbox smoke test

1. **ACH fee calculation**: IQPro's `/calculatefees` requires *exactly one* of
   `Token` or `CreditCardBin` regardless of payment method. The original code
   omitted both for ACH and would 400 with
   `"Exactly one of Token/CreditCardBin must be provided."`
   Fix: pass `pmResult.achToken` as `Token` for ACH payments.

2. **Raw card number fallback**: Old code accepted `params.cardNumber` as a
   fallback "token" when no TokenEx token was present. IQPro rejects this with
   `"Raw card number may not be submitted. Submit a tokenized card number
   instead."`
   Fix: throw a clear error in `IQProPaymentService.createPaymentMethod` if
   `cardToken` is missing, requiring the TokenEx iframe flow first.

## Verification

- 3908 unit tests pass across 191 files
- `npm run lint`, `check:types`, `check:deps`, `check:i18n` — all clean
- E2E suite: 97 passed, 3 unrelated pre-existing flakes (60s timeouts on
  unrelated paths + cross-test pollution from `faker.person.firstName()`
  collisions across parallel workers)
- Sandbox smoke test exercised customer create, billing-address resolve,
  TokenEx config retrieval, ACH tokenization, ACH payment method, ACH fee
  calc, ACH Sale (declined-as-expected with cert tolerance), and monthly
  subscription creation — all green