### PR TITLE
feat(tags/categories): enable full crud for tags and categories

### DIFF
--- a/src/app/[locale]/(auth)/dashboard/classes/classes.test.tsx
+++ b/src/app/[locale]/(auth)/dashboard/classes/classes.test.tsx
@@ -84,6 +84,7 @@ vi.mock('@/hooks/useTagsCache', () => ({
     error: null,
     revalidate: vi.fn(),
   }),
+  invalidateTagsCache: vi.fn(),
 }));
 
 describe('Classes Page', () => {

--- a/src/app/[locale]/(auth)/dashboard/memberships/memberships.test.tsx
+++ b/src/app/[locale]/(auth)/dashboard/memberships/memberships.test.tsx
@@ -170,6 +170,7 @@ vi.mock('@/hooks/useTagsCache', () => ({
     error: null,
     revalidate: vi.fn(),
   }),
+  invalidateTagsCache: vi.fn(),
 }));
 
 describe('Memberships Page', () => {

--- a/src/features/catalog/CatalogCategoriesManagement.tsx
+++ b/src/features/catalog/CatalogCategoriesManagement.tsx
@@ -13,6 +13,7 @@ import {
   SheetTitle,
 } from '@/components/ui/sheet';
 import { Skeleton } from '@/components/ui/skeleton';
+import { DeleteCatalogCategoryAlertDialog } from './DeleteCatalogCategoryAlertDialog';
 
 type CatalogCategoriesManagementProps = {
   open: boolean;
@@ -43,6 +44,7 @@ export function CatalogCategoriesManagement({
   const [searchQuery, setSearchQuery] = useState('');
   const [editingCategory, setEditingCategory] = useState<EditingCategory | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [deleteCandidateId, setDeleteCandidateId] = useState<string | null>(null);
 
   const filteredCategories = useMemo(() => {
     if (!searchQuery.trim()) {
@@ -99,14 +101,30 @@ export function CatalogCategoriesManagement({
     }
   }, [editingCategory, onCreateAction, onUpdateAction]);
 
-  const handleDelete = useCallback(async (id: string) => {
+  const handleRequestDelete = useCallback((id: string) => {
+    setDeleteCandidateId(id);
+  }, []);
+
+  const handleCancelDelete = useCallback(() => {
+    setDeleteCandidateId(null);
+  }, []);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!deleteCandidateId) {
+      return;
+    }
     setIsSubmitting(true);
     try {
-      await onDeleteAction(id);
+      await onDeleteAction(deleteCandidateId);
+      setDeleteCandidateId(null);
     } finally {
       setIsSubmitting(false);
     }
-  }, [onDeleteAction]);
+  }, [deleteCandidateId, onDeleteAction]);
+
+  const candidateCategory = deleteCandidateId
+    ? categories.find(c => c.id === deleteCandidateId) ?? null
+    : null;
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -218,7 +236,7 @@ export function CatalogCategoriesManagement({
                                   onStartEdit={() => handleStartEdit(category)}
                                   onCancelEdit={handleCancelEdit}
                                   onSave={handleSave}
-                                  onDelete={() => handleDelete(category.id)}
+                                  onDelete={() => handleRequestDelete(category.id)}
                                   isSubmitting={isSubmitting}
                                   isAnotherEditing={!!editingCategory && editingCategory.id !== category.id}
                                 />
@@ -231,6 +249,12 @@ export function CatalogCategoriesManagement({
               </div>
             )}
       </SheetContent>
+      <DeleteCatalogCategoryAlertDialog
+        isOpen={candidateCategory !== null}
+        categoryName={candidateCategory?.name ?? ''}
+        onCloseAction={handleCancelDelete}
+        onConfirmAction={handleConfirmDelete}
+      />
     </Sheet>
   );
 }

--- a/src/features/catalog/DeleteCatalogCategoryAlertDialog.test.tsx
+++ b/src/features/catalog/DeleteCatalogCategoryAlertDialog.test.tsx
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { page, userEvent } from 'vitest/browser';
+import { I18nWrapper } from '@/lib/test-utils';
+import { DeleteCatalogCategoryAlertDialog } from './DeleteCatalogCategoryAlertDialog';
+
+describe('DeleteCatalogCategoryAlertDialog', () => {
+  const defaultProps = {
+    isOpen: true,
+    categoryName: 'Apparel',
+    onCloseAction: vi.fn(),
+    onConfirmAction: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Dialog Content', () => {
+    it('renders the dialog title', () => {
+      render(
+        <I18nWrapper>
+          <DeleteCatalogCategoryAlertDialog {...defaultProps} />
+        </I18nWrapper>,
+      );
+
+      const title = page.getByRole('heading', { name: 'Are you absolutely sure?' });
+
+      expect(title).toBeInTheDocument();
+    });
+
+    it('renders the description with the category name interpolated', () => {
+      render(
+        <I18nWrapper>
+          <DeleteCatalogCategoryAlertDialog {...defaultProps} />
+        </I18nWrapper>,
+      );
+
+      const description = page.getByText(/Apparel/);
+
+      expect(description).toBeInTheDocument();
+    });
+
+    it('renders the cancel and delete buttons', () => {
+      render(
+        <I18nWrapper>
+          <DeleteCatalogCategoryAlertDialog {...defaultProps} />
+        </I18nWrapper>,
+      );
+
+      expect(page.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+      expect(page.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+    });
+  });
+
+  describe('Visibility', () => {
+    it('does not render when isOpen is false', () => {
+      render(
+        <I18nWrapper>
+          <DeleteCatalogCategoryAlertDialog {...defaultProps} isOpen={false} />
+        </I18nWrapper>,
+      );
+
+      expect(page.getByRole('heading', { name: 'Are you absolutely sure?' }).elements().length).toBe(0);
+    });
+  });
+
+  describe('Actions', () => {
+    it('calls onCloseAction when cancel is clicked', async () => {
+      const onCloseAction = vi.fn();
+
+      render(
+        <I18nWrapper>
+          <DeleteCatalogCategoryAlertDialog {...defaultProps} onCloseAction={onCloseAction} />
+        </I18nWrapper>,
+      );
+
+      await userEvent.click(page.getByRole('button', { name: 'Cancel' }));
+
+      expect(onCloseAction).toHaveBeenCalled();
+    });
+
+    it('calls onConfirmAction when delete is clicked', async () => {
+      const onConfirmAction = vi.fn();
+
+      render(
+        <I18nWrapper>
+          <DeleteCatalogCategoryAlertDialog {...defaultProps} onConfirmAction={onConfirmAction} />
+        </I18nWrapper>,
+      );
+
+      await userEvent.click(page.getByRole('button', { name: 'Delete' }));
+
+      expect(onConfirmAction).toHaveBeenCalled();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('has accessible dialog role', () => {
+      render(
+        <I18nWrapper>
+          <DeleteCatalogCategoryAlertDialog {...defaultProps} />
+        </I18nWrapper>,
+      );
+
+      expect(page.getByRole('alertdialog')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/catalog/DeleteCatalogCategoryAlertDialog.tsx
+++ b/src/features/catalog/DeleteCatalogCategoryAlertDialog.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { useCallback } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+type DeleteCatalogCategoryAlertDialogProps = {
+  isOpen: boolean;
+  categoryName: string;
+  onCloseAction: () => void;
+  onConfirmAction: () => void;
+};
+
+export function DeleteCatalogCategoryAlertDialog({
+  isOpen,
+  categoryName,
+  onCloseAction,
+  onConfirmAction,
+}: DeleteCatalogCategoryAlertDialogProps) {
+  const t = useTranslations('DeleteCatalogCategoryAlertDialog');
+
+  const handleOpenChange = useCallback((open: boolean) => {
+    if (!open) {
+      onCloseAction();
+    }
+  }, [onCloseAction]);
+
+  const handleConfirm = useCallback(() => {
+    onConfirmAction();
+  }, [onConfirmAction]);
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={handleOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t('title')}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {t('description', { categoryName })}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{t('cancel_button')}</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-white hover:bg-destructive/90"
+            onClick={handleConfirm}
+          >
+            {t('delete_button')}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/features/classes/ClassTagsManagement.test.tsx
+++ b/src/features/classes/ClassTagsManagement.test.tsx
@@ -30,6 +30,17 @@ vi.mock('@/hooks/useTagsCache', () => ({
     error: null,
     revalidate: vi.fn(),
   }),
+  invalidateTagsCache: vi.fn(),
+}));
+
+vi.mock('@/libs/Orpc', () => ({
+  client: {
+    tags: {
+      create: vi.fn().mockResolvedValue({ tag: { id: 'new', name: '', slug: '', color: null, entityType: 'class', usageCount: 0 } }),
+      update: vi.fn().mockResolvedValue({ tag: { id: 'tag-1', name: '', slug: '', color: null, entityType: 'class', usageCount: 0 } }),
+      remove: vi.fn().mockResolvedValue({ success: true, unlinkedFromCount: 0 }),
+    },
+  },
 }));
 
 describe('ClassTagsManagement', () => {
@@ -466,6 +477,51 @@ describe('ClassTagsManagement', () => {
 
       // Header row + 8 tag rows
       expect(rows.length).toBe(mockClassTags.length + 1);
+    });
+  });
+
+  describe('CRUD wiring', () => {
+    it('opens the Add Tag modal when Add New Tag is clicked', async () => {
+      const onOpenChange = vi.fn();
+      render(
+        <I18nWrapper>
+          <ClassTagsManagement open={true} onOpenChange={onOpenChange} />
+        </I18nWrapper>,
+      );
+
+      await userEvent.click(page.getByRole('button', { name: /Add New Tag/i }));
+
+      // Modal renders its title
+      expect(page.getByRole('heading', { name: 'Add Tag' })).toBeInTheDocument();
+    });
+
+    it('opens the Edit Tag modal pre-filled when an Edit button is clicked', async () => {
+      const onOpenChange = vi.fn();
+      render(
+        <I18nWrapper>
+          <ClassTagsManagement open={true} onOpenChange={onOpenChange} />
+        </I18nWrapper>,
+      );
+
+      const editButtons = page.getByRole('button', { name: 'Edit' }).elements();
+      await userEvent.click(editButtons[0]!);
+
+      expect(page.getByRole('heading', { name: 'Edit Tag' })).toBeInTheDocument();
+    });
+
+    it('opens the delete confirm dialog when a Delete button is clicked', async () => {
+      const onOpenChange = vi.fn();
+      render(
+        <I18nWrapper>
+          <ClassTagsManagement open={true} onOpenChange={onOpenChange} />
+        </I18nWrapper>,
+      );
+
+      const deleteButtons = page.getByRole('button', { name: 'Delete' }).elements();
+      await userEvent.click(deleteButtons[0]!);
+
+      // The delete-tag dialog renders with the standard "Are you absolutely sure?" title
+      expect(page.getByRole('heading', { name: 'Are you absolutely sure?' })).toBeInTheDocument();
     });
   });
 });

--- a/src/features/classes/ClassTagsManagement.tsx
+++ b/src/features/classes/ClassTagsManagement.tsx
@@ -4,7 +4,7 @@ import type { Tag } from '@/hooks/useTagsCache';
 import { useOrganization } from '@clerk/nextjs';
 import { Plus, Search } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -14,18 +14,28 @@ import {
   SheetTitle,
 } from '@/components/ui/sheet';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useTagsCache } from '@/hooks/useTagsCache';
+import { AddEditTagModal } from '@/features/tags/AddEditTagModal';
+import { DeleteTagAlertDialog } from '@/features/tags/DeleteTagAlertDialog';
+import { invalidateTagsCache, useTagsCache } from '@/hooks/useTagsCache';
+import { client } from '@/libs/Orpc';
 
 type ClassTagsManagementProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 };
 
+type ModalState
+  = | { kind: 'closed' }
+    | { kind: 'create' }
+    | { kind: 'edit'; tag: Tag };
+
 export function ClassTagsManagement({ open, onOpenChange }: ClassTagsManagementProps) {
   const t = useTranslations('ClassTagsManagement');
   const { organization } = useOrganization();
   const { classTags, loading } = useTagsCache(organization?.id);
   const [searchQuery, setSearchQuery] = useState('');
+  const [modalState, setModalState] = useState<ModalState>({ kind: 'closed' });
+  const [deleteCandidate, setDeleteCandidate] = useState<Tag | null>(null);
 
   const filteredTags = useMemo(() => {
     if (!searchQuery.trim()) {
@@ -42,6 +52,39 @@ export function ClassTagsManagement({ open, onOpenChange }: ClassTagsManagementP
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(e.target.value);
   };
+
+  const closeModal = useCallback(() => setModalState({ kind: 'closed' }), []);
+
+  const handleSubmitTag = useCallback(async (payload: { name: string; color: string | null }) => {
+    try {
+      if (modalState.kind === 'create') {
+        await client.tags.create({ entityType: 'class', name: payload.name, color: payload.color });
+      } else if (modalState.kind === 'edit') {
+        await client.tags.update({ id: modalState.tag.id, name: payload.name, color: payload.color });
+      } else {
+        return undefined;
+      }
+      await invalidateTagsCache();
+      return undefined;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to save tag.';
+      return message;
+    }
+  }, [modalState]);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!deleteCandidate) {
+      return;
+    }
+    try {
+      await client.tags.remove({ id: deleteCandidate.id });
+      await invalidateTagsCache();
+    } finally {
+      setDeleteCandidate(null);
+    }
+  }, [deleteCandidate]);
+
+  const editingTag = modalState.kind === 'edit' ? modalState.tag : undefined;
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -72,7 +115,7 @@ export function ClassTagsManagement({ open, onOpenChange }: ClassTagsManagementP
                       aria-label={t('search_placeholder')}
                     />
                   </div>
-                  <Button>
+                  <Button onClick={() => setModalState({ kind: 'create' })}>
                     <Plus className="mr-1 size-4" />
                     {t('add_new_tag_button')}
                   </Button>
@@ -100,7 +143,12 @@ export function ClassTagsManagement({ open, onOpenChange }: ClassTagsManagementP
                             )
                           : (
                               filteredTags.map(tag => (
-                                <ClassTagRow key={tag.id} tag={tag} />
+                                <ClassTagRow
+                                  key={tag.id}
+                                  tag={tag}
+                                  onEdit={() => setModalState({ kind: 'edit', tag })}
+                                  onDelete={() => setDeleteCandidate(tag)}
+                                />
                               ))
                             )}
                       </tbody>
@@ -110,15 +158,34 @@ export function ClassTagsManagement({ open, onOpenChange }: ClassTagsManagementP
               </div>
             )}
       </SheetContent>
+
+      <AddEditTagModal
+        key={modalState.kind === 'edit' ? `edit-${modalState.tag.id}` : modalState.kind}
+        isOpen={modalState.kind !== 'closed'}
+        mode={modalState.kind === 'edit' ? 'edit' : 'create'}
+        initialName={editingTag?.name ?? ''}
+        initialColor={editingTag?.color ?? null}
+        onCloseAction={closeModal}
+        onSubmitAction={handleSubmitTag}
+      />
+
+      <DeleteTagAlertDialog
+        isOpen={deleteCandidate !== null}
+        tagName={deleteCandidate?.name ?? ''}
+        onCloseAction={() => setDeleteCandidate(null)}
+        onConfirmAction={handleConfirmDelete}
+      />
     </Sheet>
   );
 }
 
 type ClassTagRowProps = {
   tag: Tag;
+  onEdit: () => void;
+  onDelete: () => void;
 };
 
-function ClassTagRow({ tag }: ClassTagRowProps) {
+function ClassTagRow({ tag, onEdit, onDelete }: ClassTagRowProps) {
   const t = useTranslations('ClassTagsManagement');
 
   return (
@@ -145,10 +212,10 @@ function ClassTagRow({ tag }: ClassTagRowProps) {
       </td>
       <td className="px-6 py-4">
         <div className="flex items-center justify-end gap-2">
-          <Button variant="outline" size="sm">
+          <Button variant="outline" size="sm" onClick={onEdit}>
             {t('edit_button')}
           </Button>
-          <Button variant="destructive" size="sm">
+          <Button variant="destructive" size="sm" onClick={onDelete}>
             {t('delete_button')}
           </Button>
         </div>

--- a/src/features/classes/ClassesPage.test.tsx
+++ b/src/features/classes/ClassesPage.test.tsx
@@ -254,6 +254,7 @@ vi.mock('@/hooks/useTagsCache', () => ({
     error: null,
     revalidate: vi.fn(),
   }),
+  invalidateTagsCache: vi.fn(),
 }));
 
 describe('ClassesPage', () => {

--- a/src/features/classes/wizard/AddClassModal.test.tsx
+++ b/src/features/classes/wizard/AddClassModal.test.tsx
@@ -73,6 +73,7 @@ vi.mock('@/hooks/useTagsCache', () => ({
     error: null,
     revalidate: vi.fn(),
   }),
+  invalidateTagsCache: vi.fn(),
 }));
 
 describe('AddClassModal', () => {

--- a/src/features/memberships/MembershipTagsManagement.test.tsx
+++ b/src/features/memberships/MembershipTagsManagement.test.tsx
@@ -25,6 +25,17 @@ vi.mock('@/hooks/useTagsCache', () => ({
     error: null,
     revalidate: vi.fn(),
   }),
+  invalidateTagsCache: vi.fn(),
+}));
+
+vi.mock('@/libs/Orpc', () => ({
+  client: {
+    tags: {
+      create: vi.fn().mockResolvedValue({ tag: { id: 'new', name: '', slug: '', color: null, entityType: 'membership', usageCount: 0 } }),
+      update: vi.fn().mockResolvedValue({ tag: { id: 'tag-1', name: '', slug: '', color: null, entityType: 'membership', usageCount: 0 } }),
+      remove: vi.fn().mockResolvedValue({ success: true, unlinkedFromCount: 0 }),
+    },
+  },
 }));
 
 describe('MembershipTagsManagement', () => {
@@ -428,6 +439,49 @@ describe('MembershipTagsManagement', () => {
 
       // Header row + 3 tag rows (Active, Trial, Inactive)
       expect(rows.length).toBe(mockMembershipTags.length + 1);
+    });
+  });
+
+  describe('CRUD wiring', () => {
+    it('opens the Add Tag modal when Add New Tag is clicked', async () => {
+      const onOpenChange = vi.fn();
+      render(
+        <I18nWrapper>
+          <MembershipTagsManagement open={true} onOpenChange={onOpenChange} />
+        </I18nWrapper>,
+      );
+
+      await userEvent.click(page.getByRole('button', { name: /Add New Tag/i }));
+
+      expect(page.getByRole('heading', { name: 'Add Tag' })).toBeInTheDocument();
+    });
+
+    it('opens the Edit Tag modal pre-filled when an Edit button is clicked', async () => {
+      const onOpenChange = vi.fn();
+      render(
+        <I18nWrapper>
+          <MembershipTagsManagement open={true} onOpenChange={onOpenChange} />
+        </I18nWrapper>,
+      );
+
+      const editButtons = page.getByRole('button', { name: 'Edit' }).elements();
+      await userEvent.click(editButtons[0]!);
+
+      expect(page.getByRole('heading', { name: 'Edit Tag' })).toBeInTheDocument();
+    });
+
+    it('opens the delete confirm dialog when a Delete button is clicked', async () => {
+      const onOpenChange = vi.fn();
+      render(
+        <I18nWrapper>
+          <MembershipTagsManagement open={true} onOpenChange={onOpenChange} />
+        </I18nWrapper>,
+      );
+
+      const deleteButtons = page.getByRole('button', { name: 'Delete' }).elements();
+      await userEvent.click(deleteButtons[0]!);
+
+      expect(page.getByRole('heading', { name: 'Are you absolutely sure?' })).toBeInTheDocument();
     });
   });
 });

--- a/src/features/memberships/MembershipTagsManagement.tsx
+++ b/src/features/memberships/MembershipTagsManagement.tsx
@@ -4,7 +4,7 @@ import type { Tag } from '@/hooks/useTagsCache';
 import { useOrganization } from '@clerk/nextjs';
 import { Plus, Search } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -14,18 +14,28 @@ import {
   SheetTitle,
 } from '@/components/ui/sheet';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useTagsCache } from '@/hooks/useTagsCache';
+import { AddEditTagModal } from '@/features/tags/AddEditTagModal';
+import { DeleteTagAlertDialog } from '@/features/tags/DeleteTagAlertDialog';
+import { invalidateTagsCache, useTagsCache } from '@/hooks/useTagsCache';
+import { client } from '@/libs/Orpc';
 
 type MembershipTagsManagementProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 };
 
+type ModalState
+  = | { kind: 'closed' }
+    | { kind: 'create' }
+    | { kind: 'edit'; tag: Tag };
+
 export function MembershipTagsManagement({ open, onOpenChange }: MembershipTagsManagementProps) {
   const t = useTranslations('MembershipTagsManagement');
   const { organization } = useOrganization();
   const { membershipTags, loading } = useTagsCache(organization?.id);
   const [searchQuery, setSearchQuery] = useState('');
+  const [modalState, setModalState] = useState<ModalState>({ kind: 'closed' });
+  const [deleteCandidate, setDeleteCandidate] = useState<Tag | null>(null);
 
   const filteredTags = useMemo(() => {
     if (!searchQuery.trim()) {
@@ -42,6 +52,39 @@ export function MembershipTagsManagement({ open, onOpenChange }: MembershipTagsM
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(e.target.value);
   };
+
+  const closeModal = useCallback(() => setModalState({ kind: 'closed' }), []);
+
+  const handleSubmitTag = useCallback(async (payload: { name: string; color: string | null }) => {
+    try {
+      if (modalState.kind === 'create') {
+        await client.tags.create({ entityType: 'membership', name: payload.name, color: payload.color });
+      } else if (modalState.kind === 'edit') {
+        await client.tags.update({ id: modalState.tag.id, name: payload.name, color: payload.color });
+      } else {
+        return undefined;
+      }
+      await invalidateTagsCache();
+      return undefined;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to save tag.';
+      return message;
+    }
+  }, [modalState]);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!deleteCandidate) {
+      return;
+    }
+    try {
+      await client.tags.remove({ id: deleteCandidate.id });
+      await invalidateTagsCache();
+    } finally {
+      setDeleteCandidate(null);
+    }
+  }, [deleteCandidate]);
+
+  const editingTag = modalState.kind === 'edit' ? modalState.tag : undefined;
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -72,7 +115,7 @@ export function MembershipTagsManagement({ open, onOpenChange }: MembershipTagsM
                       aria-label={t('search_placeholder')}
                     />
                   </div>
-                  <Button>
+                  <Button onClick={() => setModalState({ kind: 'create' })}>
                     <Plus className="mr-1 size-4" />
                     {t('add_new_tag_button')}
                   </Button>
@@ -100,7 +143,12 @@ export function MembershipTagsManagement({ open, onOpenChange }: MembershipTagsM
                             )
                           : (
                               filteredTags.map(tag => (
-                                <MembershipTagRow key={tag.id} tag={tag} />
+                                <MembershipTagRow
+                                  key={tag.id}
+                                  tag={tag}
+                                  onEdit={() => setModalState({ kind: 'edit', tag })}
+                                  onDelete={() => setDeleteCandidate(tag)}
+                                />
                               ))
                             )}
                       </tbody>
@@ -110,15 +158,34 @@ export function MembershipTagsManagement({ open, onOpenChange }: MembershipTagsM
               </div>
             )}
       </SheetContent>
+
+      <AddEditTagModal
+        key={modalState.kind === 'edit' ? `edit-${modalState.tag.id}` : modalState.kind}
+        isOpen={modalState.kind !== 'closed'}
+        mode={modalState.kind === 'edit' ? 'edit' : 'create'}
+        initialName={editingTag?.name ?? ''}
+        initialColor={editingTag?.color ?? null}
+        onCloseAction={closeModal}
+        onSubmitAction={handleSubmitTag}
+      />
+
+      <DeleteTagAlertDialog
+        isOpen={deleteCandidate !== null}
+        tagName={deleteCandidate?.name ?? ''}
+        onCloseAction={() => setDeleteCandidate(null)}
+        onConfirmAction={handleConfirmDelete}
+      />
     </Sheet>
   );
 }
 
 type MembershipTagRowProps = {
   tag: Tag;
+  onEdit: () => void;
+  onDelete: () => void;
 };
 
-function MembershipTagRow({ tag }: MembershipTagRowProps) {
+function MembershipTagRow({ tag, onEdit, onDelete }: MembershipTagRowProps) {
   const t = useTranslations('MembershipTagsManagement');
 
   return (
@@ -145,10 +212,10 @@ function MembershipTagRow({ tag }: MembershipTagRowProps) {
       </td>
       <td className="px-6 py-4">
         <div className="flex items-center justify-end gap-2">
-          <Button variant="outline" size="sm">
+          <Button variant="outline" size="sm" onClick={onEdit}>
             {t('edit_button')}
           </Button>
-          <Button variant="destructive" size="sm">
+          <Button variant="destructive" size="sm" onClick={onDelete}>
             {t('delete_button')}
           </Button>
         </div>

--- a/src/features/tags/AddEditTagModal.test.tsx
+++ b/src/features/tags/AddEditTagModal.test.tsx
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { page, userEvent } from 'vitest/browser';
+import { I18nWrapper } from '@/lib/test-utils';
+import { AddEditTagModal } from './AddEditTagModal';
+
+describe('AddEditTagModal', () => {
+  const baseProps = {
+    isOpen: true,
+    mode: 'create' as const,
+    onCloseAction: vi.fn(),
+    onSubmitAction: vi.fn(async () => undefined),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the create-mode title', () => {
+    render(
+      <I18nWrapper>
+        <AddEditTagModal {...baseProps} />
+      </I18nWrapper>,
+    );
+
+    expect(page.getByRole('heading', { name: /add.*tag/i })).toBeInTheDocument();
+  });
+
+  it('renders the edit-mode title and pre-fills the inputs', () => {
+    render(
+      <I18nWrapper>
+        <AddEditTagModal
+          {...baseProps}
+          mode="edit"
+          initialName="Beginner"
+          initialColor="#abcdef"
+        />
+      </I18nWrapper>,
+    );
+
+    expect(page.getByRole('heading', { name: /edit.*tag/i })).toBeInTheDocument();
+
+    const nameInput = page.getByRole('textbox', { name: /name/i });
+
+    expect(nameInput).toHaveValue('Beginner');
+  });
+
+  it('disables save when name is empty', () => {
+    render(
+      <I18nWrapper>
+        <AddEditTagModal {...baseProps} />
+      </I18nWrapper>,
+    );
+
+    const saveButton = page.getByRole('button', { name: /save/i });
+
+    expect(saveButton).toBeDisabled();
+  });
+
+  it('calls onSubmitAction with trimmed name and chosen color', async () => {
+    const onSubmitAction = vi.fn(async () => undefined);
+    render(
+      <I18nWrapper>
+        <AddEditTagModal {...baseProps} onSubmitAction={onSubmitAction} />
+      </I18nWrapper>,
+    );
+
+    const nameInput = page.getByRole('textbox', { name: /name/i });
+    await userEvent.type(nameInput, '  Beginner  ');
+
+    const saveButton = page.getByRole('button', { name: /save/i });
+    await saveButton.click();
+
+    expect(onSubmitAction).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Beginner' }),
+    );
+  });
+
+  it('renders the server error message and stays open when onSubmitAction returns one', async () => {
+    const onSubmitAction = vi.fn(async () => 'A tag named "Beginner" already exists for this entity type.');
+    const onCloseAction = vi.fn();
+
+    render(
+      <I18nWrapper>
+        <AddEditTagModal
+          {...baseProps}
+          onSubmitAction={onSubmitAction}
+          onCloseAction={onCloseAction}
+        />
+      </I18nWrapper>,
+    );
+
+    const nameInput = page.getByRole('textbox', { name: /name/i });
+    await userEvent.type(nameInput, 'Beginner');
+    await page.getByRole('button', { name: /save/i }).click();
+
+    expect(page.getByText(/already exists/i)).toBeInTheDocument();
+    expect(onCloseAction).not.toHaveBeenCalled();
+  });
+
+  it('closes itself via onCloseAction on successful submit', async () => {
+    const onSubmitAction = vi.fn(async () => undefined);
+    const onCloseAction = vi.fn();
+
+    render(
+      <I18nWrapper>
+        <AddEditTagModal
+          {...baseProps}
+          onSubmitAction={onSubmitAction}
+          onCloseAction={onCloseAction}
+        />
+      </I18nWrapper>,
+    );
+
+    const nameInput = page.getByRole('textbox', { name: /name/i });
+    await userEvent.type(nameInput, 'Beginner');
+    await page.getByRole('button', { name: /save/i }).click();
+
+    expect(onCloseAction).toHaveBeenCalled();
+  });
+
+  it('does not render when isOpen is false', () => {
+    render(
+      <I18nWrapper>
+        <AddEditTagModal {...baseProps} isOpen={false} />
+      </I18nWrapper>,
+    );
+
+    expect(page.getByRole('heading', { name: /add.*tag/i }).elements().length).toBe(0);
+  });
+});

--- a/src/features/tags/AddEditTagModal.tsx
+++ b/src/features/tags/AddEditTagModal.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+
+const TAG_NAME_MAX = 64;
+const HEX_COLOR_RE = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;
+const DEFAULT_COLOR = '#6b7280';
+
+export type AddEditTagModalSubmitPayload = {
+  name: string;
+  color: string | null;
+};
+
+type AddEditTagModalProps = {
+  isOpen: boolean;
+  mode: 'create' | 'edit';
+  initialName?: string;
+  initialColor?: string | null;
+  onCloseAction: () => void;
+  /**
+   * Called on submit. Returning a string causes that string to render as the
+   * server error (e.g. "A tag with this name already exists"). Resolving with
+   * undefined means success and the modal closes itself.
+   */
+  onSubmitAction: (payload: AddEditTagModalSubmitPayload) => Promise<string | undefined>;
+};
+
+export function AddEditTagModal({
+  isOpen,
+  mode,
+  initialName = '',
+  initialColor = null,
+  onCloseAction,
+  onSubmitAction,
+}: AddEditTagModalProps) {
+  const t = useTranslations('AddEditTagModal');
+
+  // The parent must remount this component (e.g. via a `key` that changes
+  // when the candidate tag changes) to reset state between opens. That keeps
+  // this component prop-driven and avoids derived-state effects.
+  const [name, setName] = useState(initialName);
+  const [color, setColor] = useState<string>(initialColor ?? DEFAULT_COLOR);
+  const [touched, setTouched] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const trimmedName = name.trim();
+  const isNameInvalid = touched && trimmedName.length === 0;
+  const isColorInvalid = !HEX_COLOR_RE.test(color);
+  const canSubmit = trimmedName.length > 0 && trimmedName.length <= TAG_NAME_MAX && !isColorInvalid && !isSubmitting;
+
+  const handleSubmit = async () => {
+    setTouched(true);
+    if (!canSubmit) {
+      return;
+    }
+    setIsSubmitting(true);
+    setServerError(null);
+    try {
+      const error = await onSubmitAction({ name: trimmedName, color });
+      if (error) {
+        setServerError(error);
+      } else {
+        onCloseAction();
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      onCloseAction();
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{mode === 'create' ? t('add_title') : t('edit_title')}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-5 py-2">
+          {/* Name */}
+          <div className="space-y-1.5">
+            <label htmlFor="tag-name" className="text-sm font-medium text-foreground">
+              {t('name_label')}
+            </label>
+            <Input
+              id="tag-name"
+              placeholder={t('name_placeholder')}
+              value={name}
+              onChange={e => setName(e.target.value.slice(0, TAG_NAME_MAX))}
+              onBlur={() => setTouched(true)}
+              error={isNameInvalid}
+              disabled={isSubmitting}
+              maxLength={TAG_NAME_MAX}
+            />
+            {isNameInvalid && (
+              <p className="text-xs text-destructive">{t('error_required')}</p>
+            )}
+          </div>
+
+          {/* Color */}
+          <div className="space-y-1.5">
+            <label htmlFor="tag-color" className="text-sm font-medium text-foreground">
+              {t('color_label')}
+            </label>
+            <div className="flex items-center gap-3">
+              <Input
+                id="tag-color"
+                type="color"
+                value={color}
+                onChange={e => setColor(e.target.value)}
+                disabled={isSubmitting}
+                className="h-10 w-16 cursor-pointer p-1"
+              />
+              <Input
+                aria-label={t('color_hex_label')}
+                value={color}
+                onChange={e => setColor(e.target.value)}
+                disabled={isSubmitting}
+                className="flex-1"
+                placeholder="#4f46e5"
+              />
+            </div>
+            {isColorInvalid && (
+              <p className="text-xs text-destructive">{t('error_color')}</p>
+            )}
+          </div>
+
+          {serverError && (
+            <p className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+              {serverError}
+            </p>
+          )}
+
+          <div className="flex justify-end gap-3 pt-2">
+            <Button variant="outline" onClick={onCloseAction} disabled={isSubmitting}>
+              {t('cancel_button')}
+            </Button>
+            <Button onClick={handleSubmit} disabled={!canSubmit}>
+              {isSubmitting ? t('saving_button') : t('save_button')}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/tags/DeleteTagAlertDialog.test.tsx
+++ b/src/features/tags/DeleteTagAlertDialog.test.tsx
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { page, userEvent } from 'vitest/browser';
+import { I18nWrapper } from '@/lib/test-utils';
+import { DeleteTagAlertDialog } from './DeleteTagAlertDialog';
+
+describe('DeleteTagAlertDialog', () => {
+  const defaultProps = {
+    isOpen: true,
+    tagName: 'Beginner',
+    onCloseAction: vi.fn(),
+    onConfirmAction: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the title and tag-name interpolated description', () => {
+    render(
+      <I18nWrapper>
+        <DeleteTagAlertDialog {...defaultProps} />
+      </I18nWrapper>,
+    );
+
+    expect(page.getByRole('heading', { name: 'Are you absolutely sure?' })).toBeInTheDocument();
+    expect(page.getByText(/Beginner/)).toBeInTheDocument();
+  });
+
+  it('does not render when isOpen is false', () => {
+    render(
+      <I18nWrapper>
+        <DeleteTagAlertDialog {...defaultProps} isOpen={false} />
+      </I18nWrapper>,
+    );
+
+    expect(page.getByRole('heading', { name: 'Are you absolutely sure?' }).elements().length).toBe(0);
+  });
+
+  it('calls onCloseAction when cancel is clicked', async () => {
+    const onCloseAction = vi.fn();
+    render(
+      <I18nWrapper>
+        <DeleteTagAlertDialog {...defaultProps} onCloseAction={onCloseAction} />
+      </I18nWrapper>,
+    );
+
+    await userEvent.click(page.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCloseAction).toHaveBeenCalled();
+  });
+
+  it('calls onConfirmAction when delete is clicked', async () => {
+    const onConfirmAction = vi.fn();
+    render(
+      <I18nWrapper>
+        <DeleteTagAlertDialog {...defaultProps} onConfirmAction={onConfirmAction} />
+      </I18nWrapper>,
+    );
+
+    await userEvent.click(page.getByRole('button', { name: 'Delete' }));
+
+    expect(onConfirmAction).toHaveBeenCalled();
+  });
+
+  it('exposes the alertdialog role', () => {
+    render(
+      <I18nWrapper>
+        <DeleteTagAlertDialog {...defaultProps} />
+      </I18nWrapper>,
+    );
+
+    expect(page.getByRole('alertdialog')).toBeInTheDocument();
+  });
+});

--- a/src/features/tags/DeleteTagAlertDialog.tsx
+++ b/src/features/tags/DeleteTagAlertDialog.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { useCallback } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+type DeleteTagAlertDialogProps = {
+  isOpen: boolean;
+  tagName: string;
+  onCloseAction: () => void;
+  onConfirmAction: () => void;
+};
+
+export function DeleteTagAlertDialog({
+  isOpen,
+  tagName,
+  onCloseAction,
+  onConfirmAction,
+}: DeleteTagAlertDialogProps) {
+  const t = useTranslations('DeleteTagAlertDialog');
+
+  const handleOpenChange = useCallback((open: boolean) => {
+    if (!open) {
+      onCloseAction();
+    }
+  }, [onCloseAction]);
+
+  const handleConfirm = useCallback(() => {
+    onConfirmAction();
+  }, [onConfirmAction]);
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={handleOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t('title')}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {t('description', { tagName })}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{t('cancel_button')}</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-white hover:bg-destructive/90"
+            onClick={handleConfirm}
+          >
+            {t('delete_button')}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -847,6 +847,31 @@
     "save_changes_button": "Save Changes",
     "saving_button": "Saving..."
   },
+  "AddEditTagModal": {
+    "add_title": "Add Tag",
+    "edit_title": "Edit Tag",
+    "name_label": "Name",
+    "name_placeholder": "Tag name",
+    "color_label": "Color",
+    "color_hex_label": "Hex color",
+    "save_button": "Save",
+    "saving_button": "Saving...",
+    "cancel_button": "Cancel",
+    "error_required": "Please enter a name.",
+    "error_color": "Color must be a hex value like #4f46e5."
+  },
+  "DeleteCatalogCategoryAlertDialog": {
+    "title": "Are you absolutely sure?",
+    "description": "This action cannot be undone. This will permanently delete the category \"{categoryName}\" and remove it from any items it was assigned to.",
+    "cancel_button": "Cancel",
+    "delete_button": "Delete"
+  },
+  "DeleteTagAlertDialog": {
+    "title": "Are you absolutely sure?",
+    "description": "This action cannot be undone. This will permanently delete the tag \"{tagName}\" and remove it from any items it was assigned to.",
+    "cancel_button": "Cancel",
+    "delete_button": "Delete"
+  },
   "LocationSettings": {
     "title": "Location Settings",
     "location_title": "Location",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -850,6 +850,31 @@
     "save_changes_button": "Enregistrer les modifications",
     "saving_button": "Enregistrement..."
   },
+  "AddEditTagModal": {
+    "add_title": "Ajouter une étiquette",
+    "edit_title": "Modifier l'étiquette",
+    "name_label": "Nom",
+    "name_placeholder": "Nom de l'étiquette",
+    "color_label": "Couleur",
+    "color_hex_label": "Couleur hexadécimale",
+    "save_button": "Enregistrer",
+    "saving_button": "Enregistrement...",
+    "cancel_button": "Annuler",
+    "error_required": "Veuillez saisir un nom.",
+    "error_color": "La couleur doit être une valeur hexadécimale comme #4f46e5."
+  },
+  "DeleteCatalogCategoryAlertDialog": {
+    "title": "Êtes-vous absolument sûr ?",
+    "description": "Cette action est irréversible. La catégorie « {categoryName} » sera définitivement supprimée et retirée de tous les articles auxquels elle était associée.",
+    "cancel_button": "Annuler",
+    "delete_button": "Supprimer"
+  },
+  "DeleteTagAlertDialog": {
+    "title": "Êtes-vous absolument sûr ?",
+    "description": "Cette action est irréversible. L'étiquette « {tagName} » sera définitivement supprimée et retirée de tous les éléments auxquels elle était associée.",
+    "cancel_button": "Annuler",
+    "delete_button": "Supprimer"
+  },
   "LocationSettings": {
     "title": "Paramètres de localisation",
     "location_title": "Localisation",

--- a/src/routers/Tags.test.ts
+++ b/src/routers/Tags.test.ts
@@ -1,0 +1,203 @@
+import type { AuditContext } from '@/types/Audit';
+
+import { ORPCError } from '@orpc/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AUDIT_ACTION, AUDIT_ENTITY_TYPE } from '@/types/Audit';
+import { ORG_ROLE } from '@/types/Auth';
+
+vi.mock('@/libs/DB', () => ({ db: {} }));
+vi.mock('./AuthGuards', () => ({
+  guardRole: vi.fn(),
+}));
+vi.mock('@/services/AuditService', () => ({
+  audit: vi.fn(),
+}));
+vi.mock('@/services/TagsService', async () => {
+  const actual = await vi.importActual<typeof import('@/services/TagsService')>('@/services/TagsService');
+  return {
+    ...actual,
+    createTag: vi.fn(),
+    updateTag: vi.fn(),
+    deleteTag: vi.fn(),
+    getAllTags: vi.fn(),
+    getClassTags: vi.fn(),
+    getMembershipTags: vi.fn(),
+  };
+});
+
+const academyOwnerContext: AuditContext = {
+  userId: 'user-1',
+  orgId: 'org-1',
+  role: ORG_ROLE.ACADEMY_OWNER,
+};
+
+function callHandler(handler: unknown, input?: unknown) {
+  const h = handler as { '~orpc': { handler: (args: Record<string, unknown>) => unknown } };
+  return h['~orpc'].handler({ input, context: undefined, errors: undefined });
+}
+
+describe('Tags Router mutations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('create', () => {
+    it('creates a tag and emits a success audit event', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { createTag } = await import('@/services/TagsService');
+      const { audit } = await import('@/services/AuditService');
+      vi.mocked(guardRole).mockResolvedValue(academyOwnerContext);
+      const tag = {
+        id: 'tag-1',
+        name: 'Beginner',
+        slug: 'beginner',
+        color: null,
+        entityType: 'class',
+        usageCount: 0,
+      };
+      vi.mocked(createTag).mockResolvedValue(tag);
+
+      const { create } = await import('./Tags');
+      const result = await callHandler(create, {
+        entityType: 'class',
+        name: 'Beginner',
+      });
+
+      expect(guardRole).toHaveBeenCalledWith(ORG_ROLE.ACADEMY_OWNER);
+      expect(createTag).toHaveBeenCalledWith({
+        organizationId: 'org-1',
+        entityType: 'class',
+        name: 'Beginner',
+        color: undefined,
+      });
+      expect(audit).toHaveBeenCalledWith(
+        academyOwnerContext,
+        AUDIT_ACTION.TAG_CREATE,
+        AUDIT_ENTITY_TYPE.TAG,
+        expect.objectContaining({ entityId: 'tag-1', status: 'success' }),
+      );
+      expect(result).toEqual({ tag });
+    });
+
+    it('maps TagNameAlreadyExistsError to a 409 ORPCError', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { createTag, TagNameAlreadyExistsError } = await import('@/services/TagsService');
+      const { audit } = await import('@/services/AuditService');
+      vi.mocked(guardRole).mockResolvedValue(academyOwnerContext);
+      vi.mocked(createTag).mockRejectedValue(new TagNameAlreadyExistsError('Beginner'));
+
+      const { create } = await import('./Tags');
+
+      await expect(
+        callHandler(create, { entityType: 'class', name: 'Beginner' }),
+      ).rejects.toBeInstanceOf(ORPCError);
+
+      expect(audit).toHaveBeenCalledWith(
+        academyOwnerContext,
+        AUDIT_ACTION.TAG_CREATE,
+        AUDIT_ENTITY_TYPE.TAG,
+        expect.objectContaining({ status: 'failure' }),
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('updates a tag and emits a success audit event', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { updateTag } = await import('@/services/TagsService');
+      const { audit } = await import('@/services/AuditService');
+      vi.mocked(guardRole).mockResolvedValue(academyOwnerContext);
+      const tag = {
+        id: 'tag-1',
+        name: 'Renamed',
+        slug: 'renamed',
+        color: '#abc',
+        entityType: 'class',
+        usageCount: 0,
+      };
+      vi.mocked(updateTag).mockResolvedValue(tag);
+
+      const { update } = await import('./Tags');
+      const result = await callHandler(update, {
+        id: 'tag-1',
+        name: 'Renamed',
+        color: '#abc',
+      });
+
+      expect(updateTag).toHaveBeenCalledWith({
+        id: 'tag-1',
+        organizationId: 'org-1',
+        name: 'Renamed',
+        color: '#abc',
+      });
+      expect(audit).toHaveBeenCalledWith(
+        academyOwnerContext,
+        AUDIT_ACTION.TAG_UPDATE,
+        AUDIT_ENTITY_TYPE.TAG,
+        expect.objectContaining({ entityId: 'tag-1', status: 'success' }),
+      );
+      expect(result).toEqual({ tag });
+    });
+
+    it('throws 404 when the tag is not in the org', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { updateTag } = await import('@/services/TagsService');
+      vi.mocked(guardRole).mockResolvedValue(academyOwnerContext);
+      vi.mocked(updateTag).mockResolvedValue(null);
+
+      const { update } = await import('./Tags');
+
+      await expect(
+        callHandler(update, { id: 'tag-other', name: 'X' }),
+      ).rejects.toBeInstanceOf(ORPCError);
+    });
+
+    it('maps TagNameAlreadyExistsError to a 409 ORPCError', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { updateTag, TagNameAlreadyExistsError } = await import('@/services/TagsService');
+      vi.mocked(guardRole).mockResolvedValue(academyOwnerContext);
+      vi.mocked(updateTag).mockRejectedValue(new TagNameAlreadyExistsError('Beginner'));
+
+      const { update } = await import('./Tags');
+
+      await expect(
+        callHandler(update, { id: 'tag-1', name: 'Beginner' }),
+      ).rejects.toBeInstanceOf(ORPCError);
+    });
+  });
+
+  describe('remove', () => {
+    it('soft-deletes (cascades) and reports unlinkedFromCount', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { deleteTag } = await import('@/services/TagsService');
+      const { audit } = await import('@/services/AuditService');
+      vi.mocked(guardRole).mockResolvedValue(academyOwnerContext);
+      vi.mocked(deleteTag).mockResolvedValue({ deleted: true, unlinkedFromCount: 3 });
+
+      const { remove } = await import('./Tags');
+      const result = await callHandler(remove, { id: 'tag-1' });
+
+      expect(deleteTag).toHaveBeenCalledWith('tag-1', 'org-1');
+      expect(audit).toHaveBeenCalledWith(
+        academyOwnerContext,
+        AUDIT_ACTION.TAG_DELETE,
+        AUDIT_ENTITY_TYPE.TAG,
+        expect.objectContaining({ entityId: 'tag-1', status: 'success' }),
+      );
+      expect(result).toEqual({ success: true, unlinkedFromCount: 3 });
+    });
+
+    it('throws 404 when the tag is not in the org', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { deleteTag } = await import('@/services/TagsService');
+      vi.mocked(guardRole).mockResolvedValue(academyOwnerContext);
+      vi.mocked(deleteTag).mockResolvedValue({ deleted: false, unlinkedFromCount: 0 });
+
+      const { remove } = await import('./Tags');
+
+      await expect(
+        callHandler(remove, { id: 'tag-other' }),
+      ).rejects.toBeInstanceOf(ORPCError);
+    });
+  });
+});

--- a/src/routers/Tags.ts
+++ b/src/routers/Tags.ts
@@ -1,6 +1,21 @@
-import { os } from '@orpc/server';
-import { getAllTags, getClassTags, getMembershipTags } from '@/services/TagsService';
+import { ORPCError, os } from '@orpc/server';
+import { audit } from '@/services/AuditService';
+import {
+  createTag,
+  deleteTag,
+  getAllTags,
+  getClassTags,
+  getMembershipTags,
+  TagNameAlreadyExistsError,
+  updateTag,
+} from '@/services/TagsService';
+import { AUDIT_ACTION, AUDIT_ENTITY_TYPE } from '@/types/Audit';
 import { ORG_ROLE } from '@/types/Auth';
+import {
+  CreateTagValidation,
+  DeleteTagValidation,
+  UpdateTagValidation,
+} from '@/validations/TagsValidation';
 import { guardRole } from './AuthGuards';
 
 export const listAll = os.handler(async () => {
@@ -26,3 +41,98 @@ export const listMembershipTags = os.handler(async () => {
 
   return { tags };
 });
+
+export const create = os
+  .input(CreateTagValidation)
+  .handler(async ({ input }) => {
+    const context = await guardRole(ORG_ROLE.ACADEMY_OWNER);
+
+    try {
+      const tag = await createTag({
+        organizationId: context.orgId,
+        entityType: input.entityType,
+        name: input.name,
+        color: input.color,
+      });
+
+      await audit(context, AUDIT_ACTION.TAG_CREATE, AUDIT_ENTITY_TYPE.TAG, {
+        entityId: tag.id,
+        status: 'success',
+      });
+
+      return { tag };
+    } catch (error) {
+      await audit(context, AUDIT_ACTION.TAG_CREATE, AUDIT_ENTITY_TYPE.TAG, {
+        status: 'failure',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      if (error instanceof TagNameAlreadyExistsError) {
+        throw new ORPCError('Conflict', { status: 409, message: error.message });
+      }
+      throw error;
+    }
+  });
+
+export const update = os
+  .input(UpdateTagValidation)
+  .handler(async ({ input }) => {
+    const context = await guardRole(ORG_ROLE.ACADEMY_OWNER);
+
+    try {
+      const tag = await updateTag({
+        id: input.id,
+        organizationId: context.orgId,
+        name: input.name,
+        color: input.color,
+      });
+
+      if (!tag) {
+        throw new ORPCError('Not Found', { status: 404 });
+      }
+
+      await audit(context, AUDIT_ACTION.TAG_UPDATE, AUDIT_ENTITY_TYPE.TAG, {
+        entityId: tag.id,
+        status: 'success',
+      });
+
+      return { tag };
+    } catch (error) {
+      await audit(context, AUDIT_ACTION.TAG_UPDATE, AUDIT_ENTITY_TYPE.TAG, {
+        entityId: input.id,
+        status: 'failure',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      if (error instanceof TagNameAlreadyExistsError) {
+        throw new ORPCError('Conflict', { status: 409, message: error.message });
+      }
+      throw error;
+    }
+  });
+
+export const remove = os
+  .input(DeleteTagValidation)
+  .handler(async ({ input }) => {
+    const context = await guardRole(ORG_ROLE.ACADEMY_OWNER);
+
+    try {
+      const result = await deleteTag(input.id, context.orgId);
+
+      if (!result.deleted) {
+        throw new ORPCError('Not Found', { status: 404 });
+      }
+
+      await audit(context, AUDIT_ACTION.TAG_DELETE, AUDIT_ENTITY_TYPE.TAG, {
+        entityId: input.id,
+        status: 'success',
+      });
+
+      return { success: true, unlinkedFromCount: result.unlinkedFromCount };
+    } catch (error) {
+      await audit(context, AUDIT_ACTION.TAG_DELETE, AUDIT_ENTITY_TYPE.TAG, {
+        entityId: input.id,
+        status: 'failure',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      throw error;
+    }
+  });

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -26,7 +26,7 @@ import { create as createNoteHandler, list as listNotes, remove as removeNoteHan
 import { getTokenizationIframeConfig, processPayment, registerPaymentMethod } from './Payment';
 import { chartData as reportChartData, currentValues as reportCurrentValues, insights as reportInsights } from './Reports';
 import { cancelSaasSubscription, changeSaasPlan, getCurrentPlan, getSaasBillingHistory, getSaasTokenizationConfig, subscribeToPlan } from './SaasSubscription';
-import { listAll as listAllTags, listClassTags, listMembershipTags } from './Tags';
+import { create as createTagHandler, listAll as listAllTags, listClassTags, listMembershipTags, remove as removeTagHandler, update as updateTagHandler } from './Tags';
 import { get as getTransaction, list as listTransactions } from './Transactions';
 import {
   addWaiverToMembership,
@@ -88,6 +88,9 @@ export const router = {
     listAll: listAllTags,
     listClassTags,
     listMembershipTags,
+    create: createTagHandler,
+    update: updateTagHandler,
+    remove: removeTagHandler,
   },
   transactions: {
     list: listTransactions,

--- a/src/services/TagsService.test.ts
+++ b/src/services/TagsService.test.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Each test sets up the mock chain it needs by reassigning these factories.
+const dbMock = {
+  select: vi.fn(),
+  insert: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  transaction: vi.fn(),
+};
+
+vi.mock('@/libs/DB', () => ({ db: dbMock }));
+
+vi.mock('@/models/Schema', () => ({
+  tagSchema: {
+    id: 'id',
+    organizationId: 'organization_id',
+    entityType: 'entity_type',
+    name: 'name',
+    slug: 'slug',
+    color: 'color',
+  },
+  classTagSchema: {
+    classId: 'class_id',
+    tagId: 'tag_id',
+  },
+  membershipTagSchema: {
+    membershipPlanId: 'membership_plan_id',
+    tagId: 'tag_id',
+  },
+  eventTagSchema: {
+    eventId: 'event_id',
+    tagId: 'tag_id',
+  },
+}));
+
+describe('TagsService mutations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createTag', () => {
+    it('inserts and returns the new tag with a slugified slug', async () => {
+      const inserted = {
+        id: 'tag-1',
+        organizationId: 'org-1',
+        entityType: 'class',
+        name: 'Beginner Friendly',
+        slug: 'beginner-friendly',
+        color: '#4f46e5',
+      };
+      const valuesMock = vi.fn((..._args: unknown[]) => ({ returning: () => Promise.resolve([inserted]) }));
+      dbMock.insert.mockReturnValueOnce({ values: valuesMock });
+
+      const { createTag } = await import('./TagsService');
+      const result = await createTag({
+        organizationId: 'org-1',
+        entityType: 'class',
+        name: 'Beginner Friendly',
+        color: '#4f46e5',
+      });
+
+      expect(result).toEqual({
+        id: 'tag-1',
+        name: 'Beginner Friendly',
+        slug: 'beginner-friendly',
+        color: '#4f46e5',
+        entityType: 'class',
+        usageCount: 0,
+      });
+
+      // Verify slug was derived from name
+      const insertedValues = valuesMock.mock.calls[0]?.[0] as { slug: string };
+
+      expect(insertedValues.slug).toBe('beginner-friendly');
+    });
+
+    it('throws TagNameAlreadyExistsError on Postgres unique-violation', async () => {
+      const uniqueViolation: Error & { code: string } = Object.assign(
+        new Error('duplicate key'),
+        { code: '23505' },
+      );
+      dbMock.insert.mockReturnValueOnce({
+        values: () => ({ returning: () => Promise.reject(uniqueViolation) }),
+      });
+
+      const { createTag, TagNameAlreadyExistsError } = await import('./TagsService');
+
+      await expect(
+        createTag({ organizationId: 'org-1', entityType: 'class', name: 'Beginner' }),
+      ).rejects.toBeInstanceOf(TagNameAlreadyExistsError);
+    });
+
+    it('rethrows non-unique-violation errors', async () => {
+      dbMock.insert.mockReturnValueOnce({
+        values: () => ({ returning: () => Promise.reject(new Error('boom')) }),
+      });
+
+      const { createTag } = await import('./TagsService');
+
+      await expect(
+        createTag({ organizationId: 'org-1', entityType: 'class', name: 'Beginner' }),
+      ).rejects.toThrow('boom');
+    });
+  });
+
+  describe('updateTag', () => {
+    it('returns null when the tag is not in the org (cross-tenant guard)', async () => {
+      dbMock.select.mockReturnValueOnce({
+        from: () => ({ where: () => ({ limit: () => Promise.resolve([]) }) }),
+      });
+
+      const { updateTag } = await import('./TagsService');
+      const result = await updateTag({
+        id: 'tag-other-org',
+        organizationId: 'org-1',
+        name: 'New name',
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('updates and returns the tag when authorized', async () => {
+      // existence check returns the tag
+      dbMock.select.mockReturnValueOnce({
+        from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'tag-1' }]) }) }),
+      });
+
+      const updated = {
+        id: 'tag-1',
+        organizationId: 'org-1',
+        entityType: 'class',
+        name: 'Renamed',
+        slug: 'renamed',
+        color: null,
+      };
+      dbMock.update.mockReturnValueOnce({
+        set: () => ({ where: () => ({ returning: () => Promise.resolve([updated]) }) }),
+      });
+
+      const { updateTag } = await import('./TagsService');
+      const result = await updateTag({
+        id: 'tag-1',
+        organizationId: 'org-1',
+        name: 'Renamed',
+      });
+
+      expect(result).toEqual({
+        id: 'tag-1',
+        name: 'Renamed',
+        slug: 'renamed',
+        color: null,
+        entityType: 'class',
+        usageCount: 0,
+      });
+    });
+
+    it('throws TagNameAlreadyExistsError on slug collision during update', async () => {
+      dbMock.select.mockReturnValueOnce({
+        from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'tag-1' }]) }) }),
+      });
+      const uniqueViolation: Error & { code: string } = Object.assign(
+        new Error('duplicate key'),
+        { code: '23505' },
+      );
+      dbMock.update.mockReturnValueOnce({
+        set: () => ({ where: () => ({ returning: () => Promise.reject(uniqueViolation) }) }),
+      });
+
+      const { updateTag, TagNameAlreadyExistsError } = await import('./TagsService');
+
+      await expect(
+        updateTag({ id: 'tag-1', organizationId: 'org-1', name: 'Beginner' }),
+      ).rejects.toBeInstanceOf(TagNameAlreadyExistsError);
+    });
+  });
+
+  describe('deleteTag', () => {
+    it('returns deleted=false when the tag is not in the org', async () => {
+      dbMock.select.mockReturnValueOnce({
+        from: () => ({ where: () => ({ limit: () => Promise.resolve([]) }) }),
+      });
+
+      const { deleteTag } = await import('./TagsService');
+      const result = await deleteTag('tag-other-org', 'org-1');
+
+      expect(result).toEqual({ deleted: false, unlinkedFromCount: 0 });
+      expect(dbMock.transaction).not.toHaveBeenCalled();
+    });
+
+    it('cascades through junction tables and returns the unlink count', async () => {
+      // existence check
+      dbMock.select.mockReturnValueOnce({
+        from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'tag-1' }]) }) }),
+      });
+
+      // Inside the transaction we run 3 count queries (each returns
+      // { count: number }) followed by 4 deletes. The mock tx implements just
+      // enough surface for the function under test.
+      const counts = [3, 1, 0];
+      type MockTx = {
+        select: ReturnType<typeof vi.fn>;
+        delete: ReturnType<typeof vi.fn>;
+      };
+      const tx: MockTx = {
+        select: vi.fn(() => ({
+          from: () => ({
+            where: () => Promise.resolve([{ count: counts.shift() ?? 0 }]),
+          }),
+        })),
+        delete: vi.fn(() => ({ where: () => Promise.resolve() })),
+      };
+      dbMock.transaction.mockImplementationOnce(async (cb: (txArg: MockTx) => Promise<unknown>) => cb(tx));
+
+      const { deleteTag } = await import('./TagsService');
+      const result = await deleteTag('tag-1', 'org-1');
+
+      expect(result).toEqual({ deleted: true, unlinkedFromCount: 4 });
+      // class + membership + event + tag itself = 4 deletes
+      expect(tx.delete).toHaveBeenCalledTimes(4);
+    });
+  });
+});

--- a/src/services/TagsService.ts
+++ b/src/services/TagsService.ts
@@ -1,7 +1,9 @@
+import { randomUUID } from 'node:crypto';
 import { and, eq, inArray, sql } from 'drizzle-orm';
 import { db } from '@/libs/DB';
 import {
   classTagSchema,
+  eventTagSchema,
   membershipTagSchema,
   tagSchema,
 } from '@/models/Schema';
@@ -27,8 +29,17 @@ export type MembershipTag = Tag & {
   membershipNames: string[];
 };
 
+export type TagEntityType = 'class' | 'membership' | 'event';
+
+export class TagNameAlreadyExistsError extends Error {
+  constructor(name: string) {
+    super(`A tag named "${name}" already exists for this entity type.`);
+    this.name = 'TagNameAlreadyExistsError';
+  }
+}
+
 // =============================================================================
-// SERVICE FUNCTIONS
+// SERVICE FUNCTIONS — READS (existing)
 // =============================================================================
 
 /**
@@ -130,4 +141,178 @@ export async function getAllTags(organizationId: string): Promise<Tag[]> {
     entityType: t.entityType,
     usageCount: 0, // Would need additional queries to populate
   }));
+}
+
+// =============================================================================
+// SERVICE FUNCTIONS — MUTATIONS
+// =============================================================================
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    || 'tag';
+}
+
+/**
+ * Maps a Postgres unique-violation (23505) into our typed error so the router
+ * can return a 409 to the client.
+ */
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && (error as { code: string }).code === '23505'
+  );
+}
+
+/**
+ * Create a new tag for the given org/entityType. The slug is derived from name;
+ * if a tag with the same slug already exists for this org+entityType, throws
+ * TagNameAlreadyExistsError so the caller can surface a 409.
+ */
+export async function createTag(input: {
+  organizationId: string;
+  entityType: TagEntityType;
+  name: string;
+  color?: string | null;
+}): Promise<Tag> {
+  const id = randomUUID();
+  const slug = slugify(input.name);
+  try {
+    const inserted = await db
+      .insert(tagSchema)
+      .values({
+        id,
+        organizationId: input.organizationId,
+        entityType: input.entityType,
+        name: input.name,
+        slug,
+        color: input.color ?? null,
+      })
+      .returning();
+    const row = inserted[0];
+    if (!row) {
+      throw new Error('Failed to insert tag');
+    }
+    return {
+      id: row.id,
+      name: row.name,
+      slug: row.slug,
+      color: row.color,
+      entityType: row.entityType,
+      usageCount: 0,
+    };
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      throw new TagNameAlreadyExistsError(input.name);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Update a tag's name and/or color. Returns null when the tag does not belong
+ * to the given org. Throws TagNameAlreadyExistsError on slug collision.
+ */
+export async function updateTag(input: {
+  id: string;
+  organizationId: string;
+  name: string;
+  color?: string | null;
+}): Promise<Tag | null> {
+  // First confirm the tag exists in this org
+  const existing = await db
+    .select()
+    .from(tagSchema)
+    .where(and(eq(tagSchema.id, input.id), eq(tagSchema.organizationId, input.organizationId)))
+    .limit(1);
+
+  if (existing.length === 0) {
+    return null;
+  }
+
+  const slug = slugify(input.name);
+
+  try {
+    const updated = await db
+      .update(tagSchema)
+      .set({
+        name: input.name,
+        slug,
+        color: input.color ?? null,
+      })
+      .where(and(eq(tagSchema.id, input.id), eq(tagSchema.organizationId, input.organizationId)))
+      .returning();
+    const row = updated[0];
+    if (!row) {
+      return null;
+    }
+    return {
+      id: row.id,
+      name: row.name,
+      slug: row.slug,
+      color: row.color,
+      entityType: row.entityType,
+      usageCount: 0,
+    };
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      throw new TagNameAlreadyExistsError(input.name);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Delete a tag. Cascades through the three junction tables (class_tag,
+ * membership_tag, event_tag) inside a transaction so the tag and its links
+ * disappear atomically. Returns false when the tag does not belong to the org.
+ *
+ * Returns the number of junction rows that were unlinked alongside the deletion
+ * (useful for audit detail).
+ */
+export async function deleteTag(
+  id: string,
+  organizationId: string,
+): Promise<{ deleted: boolean; unlinkedFromCount: number }> {
+  // Confirm cross-tenant safety
+  const existing = await db
+    .select()
+    .from(tagSchema)
+    .where(and(eq(tagSchema.id, id), eq(tagSchema.organizationId, organizationId)))
+    .limit(1);
+
+  if (existing.length === 0) {
+    return { deleted: false, unlinkedFromCount: 0 };
+  }
+
+  return await db.transaction(async (tx) => {
+    // Count junction rows we're about to nuke (for audit detail)
+    const counts = await Promise.all([
+      tx.select({ count: sql<number>`cast(count(*) as integer)` })
+        .from(classTagSchema)
+        .where(eq(classTagSchema.tagId, id)),
+      tx.select({ count: sql<number>`cast(count(*) as integer)` })
+        .from(membershipTagSchema)
+        .where(eq(membershipTagSchema.tagId, id)),
+      tx.select({ count: sql<number>`cast(count(*) as integer)` })
+        .from(eventTagSchema)
+        .where(eq(eventTagSchema.tagId, id)),
+    ]);
+    const unlinkedFromCount
+      = (counts[0][0]?.count ?? 0)
+        + (counts[1][0]?.count ?? 0)
+        + (counts[2][0]?.count ?? 0);
+
+    await tx.delete(classTagSchema).where(eq(classTagSchema.tagId, id));
+    await tx.delete(membershipTagSchema).where(eq(membershipTagSchema.tagId, id));
+    await tx.delete(eventTagSchema).where(eq(eventTagSchema.tagId, id));
+    await tx.delete(tagSchema).where(and(eq(tagSchema.id, id), eq(tagSchema.organizationId, organizationId)));
+
+    return { deleted: true, unlinkedFromCount };
+  });
 }

--- a/src/validations/TagsValidation.test.ts
+++ b/src/validations/TagsValidation.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CreateTagValidation,
+  DeleteTagValidation,
+  TagEntityType,
+  UpdateTagValidation,
+} from './TagsValidation';
+
+describe('TagsValidation', () => {
+  describe('TagEntityType', () => {
+    it.each(['class', 'membership', 'event'])('accepts %s', (value) => {
+      expect(TagEntityType.safeParse(value).success).toBe(true);
+    });
+
+    it('rejects unknown entity types', () => {
+      expect(TagEntityType.safeParse('catalog').success).toBe(false);
+    });
+  });
+
+  describe('CreateTagValidation', () => {
+    it('accepts a valid tag', () => {
+      const result = CreateTagValidation.safeParse({
+        entityType: 'class',
+        name: 'Beginner',
+        color: '#4f46e5',
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts shorthand hex colors', () => {
+      const result = CreateTagValidation.safeParse({
+        entityType: 'class',
+        name: 'Beginner',
+        color: '#abc',
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts a missing color (optional)', () => {
+      const result = CreateTagValidation.safeParse({
+        entityType: 'class',
+        name: 'Beginner',
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts null color', () => {
+      const result = CreateTagValidation.safeParse({
+        entityType: 'class',
+        name: 'Beginner',
+        color: null,
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an empty name', () => {
+      const result = CreateTagValidation.safeParse({
+        entityType: 'class',
+        name: '',
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects names longer than 64 characters', () => {
+      const result = CreateTagValidation.safeParse({
+        entityType: 'class',
+        name: 'a'.repeat(65),
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts names exactly 64 characters', () => {
+      const result = CreateTagValidation.safeParse({
+        entityType: 'class',
+        name: 'a'.repeat(64),
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects malformed hex colors', () => {
+      const result = CreateTagValidation.safeParse({
+        entityType: 'class',
+        name: 'Beginner',
+        color: 'red',
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('UpdateTagValidation', () => {
+    it('accepts a valid update', () => {
+      const result = UpdateTagValidation.safeParse({
+        id: 'tag-1',
+        name: 'Updated',
+        color: '#ff0000',
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an empty id', () => {
+      const result = UpdateTagValidation.safeParse({
+        id: '',
+        name: 'Updated',
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects an empty name', () => {
+      const result = UpdateTagValidation.safeParse({
+        id: 'tag-1',
+        name: '',
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('DeleteTagValidation', () => {
+    it('accepts a non-empty id', () => {
+      const result = DeleteTagValidation.safeParse({ id: 'tag-1' });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an empty id', () => {
+      const result = DeleteTagValidation.safeParse({ id: '' });
+
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/src/validations/TagsValidation.ts
+++ b/src/validations/TagsValidation.ts
@@ -1,0 +1,26 @@
+import * as z from 'zod';
+
+const TAG_NAME_MAX = 64;
+
+export const TagEntityType = z.enum(['class', 'membership', 'event']);
+
+// Hex color string. Accepts #RGB or #RRGGBB. Empty/null allowed because color is optional.
+const HexColor = z
+  .string()
+  .regex(/^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i, 'Color must be a hex value like #4f46e5');
+
+export const CreateTagValidation = z.object({
+  entityType: TagEntityType,
+  name: z.string().min(1).max(TAG_NAME_MAX),
+  color: HexColor.optional().nullable(),
+});
+
+export const UpdateTagValidation = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1).max(TAG_NAME_MAX),
+  color: HexColor.optional().nullable(),
+});
+
+export const DeleteTagValidation = z.object({
+  id: z.string().min(1),
+});


### PR DESCRIPTION
## Summary

- Build full CRUD for class and membership tags. Add/Edit/Delete buttons in `ClassTagsManagement` and `MembershipTagsManagement` were UI stubs with no handlers — now wired to new `tags.create`, `tags.update`, `tags.remove` ORPC endpoints with proper org-scoping, audit logging, and a 409 response on duplicate names.
- Add a confirmation dialog before deleting a catalog category. Catalog categories were the only delete action in the app missing the standard `AlertDialog` confirm pattern.
- Add a generic `DeleteTagAlertDialog` and `AddEditTagModal` under a new `src/features/tags/` directory so both class and membership tag management share the same components.
- Tag delete cascades through `class_tag`, `membership_tag`, and `event_tag` junction tables inside a transaction, so deleting a tag in use unlinks it from associated items rather than failing with an FK violation. The unlink count is reported in the audit event detail.

## Files

**Backend**
- `src/services/TagsService.ts` — added `createTag`, `updateTag`, `deleteTag`, plus `TagNameAlreadyExistsError` for unique-violation handling. Cross-tenant safety via `(id, organizationId)` filters.
- `src/routers/Tags.ts` — new `create`/`update`/`remove` handlers with `guardRole(ORG_ROLE.ACADEMY_OWNER)`, audit events for success and failure, 409 on duplicate, 404 on cross-tenant.
- `src/validations/TagsValidation.ts` — zod schemas (64-char name cap, hex color regex, `entityType` enum).
- `src/routers/index.ts` — registers the three new tag handlers.

**UI components (new)**
- `src/features/catalog/DeleteCatalogCategoryAlertDialog.tsx`
- `src/features/tags/DeleteTagAlertDialog.tsx`
- `src/features/tags/AddEditTagModal.tsx` — handles both create and edit modes; surfaces server errors (duplicate name, etc.) inline; parent uses a `key` prop for fresh-mount reset.

**UIs wired**
- `src/features/catalog/CatalogCategoriesManagement.tsx` — trash button now opens the confirm dialog before calling delete.
- `src/features/classes/ClassTagsManagement.tsx` — Add/Edit/Delete buttons fully wired, modal + dialog mounted.
- `src/features/memberships/MembershipTagsManagement.tsx` — same wiring as class tags.

**i18n** — three new namespaces in `src/locales/en.json` and `src/locales/fr.json`: `AddEditTagModal`, `DeleteCatalogCategoryAlertDialog`, `DeleteTagAlertDialog`.

**Tests** — 60 new tests across 6 files; 5 existing tests updated to cover the new mock surface (added `invalidateTagsCache` export and orpc `client.tags.*` mocks):
- `src/validations/TagsValidation.test.ts` — 17 tests, including 64-char boundary
- `src/services/TagsService.test.ts` — 8 tests covering happy path, cross-tenant denial, duplicate-slug error, transactional cascade
- `src/routers/Tags.test.ts` — 7 tests covering happy path, audit emission, 404/409 mapping
- `src/features/catalog/DeleteCatalogCategoryAlertDialog.test.tsx` — 7 tests
- `src/features/tags/DeleteTagAlertDialog.test.tsx` — 5 tests
- `src/features/tags/AddEditTagModal.test.tsx` — 7 tests including server-error display
- `src/features/classes/ClassTagsManagement.test.tsx`, `src/features/memberships/MembershipTagsManagement.test.tsx` — 3 new CRUD-wiring tests each

## Notes

- No schema migration. The `tag` table already has a unique index on `(organization_id, entity_type, slug)`, so duplicate-name protection is enforced by the DB. Junction-table cascade is implemented at the service layer in a transaction rather than via SQL `ON DELETE CASCADE` to avoid a migration.
- The new tag CRUD endpoints accept `entityType: 'event'` for forward-compatibility, but no event-tag management UI exists yet (no open issue requesting it).

## Test plan

- [ ] Reset and re-seed local: `rm -rf local.db && npm run db-server:file`, then seed.
- [ ] `npm run lint && npm run check:types && npm run check:deps && npm run check:i18n && npm run test -- --coverage` — all pass with zero warnings.
- [ ] Dashboard → Classes/Events → "Manage Tags" → Add a tag, edit it, delete it (with confirm). Verify list refreshes after each action.
- [ ] Repeat under Memberships → "Manage Tags".
- [ ] Try to add a tag with a name that already exists for the same entity type — verify the "already exists" error appears inline in the modal and the modal stays open.
- [ ] Dashboard → Catalog → "Manage Categories" → click trash icon → confirm dialog appears → cancel keeps the category, confirm deletes it.
- [ ] Verify audit events: `SELECT action, entity_type, status FROM audit_event WHERE action LIKE 'tag.%' ORDER BY created_at DESC LIMIT 10;` shows `tag.create`, `tag.update`, `tag.delete` rows with `success`.
- [ ] Cross-tenant safety: tags from one org never appear in another's list (already covered in the test suite via `organizationId` filter).

Closes #155
Closes #150