### PR TITLE
fix(waivers): fix issues with waiver delete and edit

### DIFF
--- a/src/app/[locale]/(auth)/dashboard/waivers/[waiverId]/page.tsx
+++ b/src/app/[locale]/(auth)/dashboard/waivers/[waiverId]/page.tsx
@@ -10,6 +10,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import { DeleteWaiverAlertDialog } from '@/features/waivers/details/DeleteWaiverAlertDialog';
 import { EditWaiverBasicsModal } from '@/features/waivers/details/EditWaiverBasicsModal';
 import { EditWaiverContentModal } from '@/features/waivers/details/EditWaiverContentModal';
 import { EditWaiverMembershipsModal } from '@/features/waivers/details/EditWaiverMembershipsModal';
@@ -39,6 +40,8 @@ export default function WaiverDetailPage() {
   const [isEditContentOpen, setIsEditContentOpen] = useState(false);
   const [isEditMembershipsOpen, setIsEditMembershipsOpen] = useState(false);
   const [viewingVersion, setViewingVersion] = useState<WaiverTemplate | null>(null);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const fetchWaiver = useCallback(async () => {
     try {
@@ -69,8 +72,30 @@ export default function WaiverDetailPage() {
   }, [router]);
 
   const handleDelete = useCallback(() => {
-    // TODO: Open delete confirmation dialog
+    setIsDeleteOpen(true);
   }, []);
+
+  const handleCancelDelete = useCallback(() => {
+    setIsDeleteOpen(false);
+  }, []);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (isDeleting) {
+      return;
+    }
+    setIsDeleting(true);
+    try {
+      await client.waivers.deleteTemplate({ id: waiverId });
+      setIsDeleteOpen(false);
+      router.push('/dashboard/waivers');
+    } catch (err) {
+      console.error('Failed to delete waiver:', err);
+      setError(t('error_deleting'));
+      setIsDeleteOpen(false);
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [isDeleting, waiverId, router, t]);
 
   // Resolve placeholders for preview using dynamic merge fields
   // Returns React nodes with highlighted merge field values
@@ -373,6 +398,12 @@ export default function WaiverDetailPage() {
         onClose={() => setViewingVersion(null)}
         template={viewingVersion}
         mergeFields={mergeFields}
+      />
+      <DeleteWaiverAlertDialog
+        isOpen={isDeleteOpen}
+        waiverName={waiver?.name ?? ''}
+        onCloseAction={handleCancelDelete}
+        onConfirmAction={handleConfirmDelete}
       />
     </div>
   );

--- a/src/features/waivers/details/DeleteWaiverAlertDialog.test.tsx
+++ b/src/features/waivers/details/DeleteWaiverAlertDialog.test.tsx
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { page, userEvent } from 'vitest/browser';
+import { I18nWrapper } from '@/lib/test-utils';
+import { DeleteWaiverAlertDialog } from './DeleteWaiverAlertDialog';
+
+describe('DeleteWaiverAlertDialog', () => {
+  const defaultProps = {
+    isOpen: true,
+    waiverName: 'Standard Adult Waiver',
+    onCloseAction: vi.fn(),
+    onConfirmAction: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the title and waiver-name interpolated description', () => {
+    render(
+      <I18nWrapper>
+        <DeleteWaiverAlertDialog {...defaultProps} />
+      </I18nWrapper>,
+    );
+
+    expect(page.getByRole('heading', { name: 'Are you absolutely sure?' })).toBeInTheDocument();
+    expect(page.getByText(/Standard Adult Waiver/)).toBeInTheDocument();
+  });
+
+  it('does not render when isOpen is false', () => {
+    render(
+      <I18nWrapper>
+        <DeleteWaiverAlertDialog {...defaultProps} isOpen={false} />
+      </I18nWrapper>,
+    );
+
+    expect(page.getByRole('heading', { name: 'Are you absolutely sure?' }).elements().length).toBe(0);
+  });
+
+  it('calls onCloseAction when cancel is clicked', async () => {
+    const onCloseAction = vi.fn();
+    render(
+      <I18nWrapper>
+        <DeleteWaiverAlertDialog {...defaultProps} onCloseAction={onCloseAction} />
+      </I18nWrapper>,
+    );
+
+    await userEvent.click(page.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCloseAction).toHaveBeenCalled();
+  });
+
+  it('calls onConfirmAction when delete is clicked', async () => {
+    const onConfirmAction = vi.fn();
+    render(
+      <I18nWrapper>
+        <DeleteWaiverAlertDialog {...defaultProps} onConfirmAction={onConfirmAction} />
+      </I18nWrapper>,
+    );
+
+    await userEvent.click(page.getByRole('button', { name: 'Delete' }));
+
+    expect(onConfirmAction).toHaveBeenCalled();
+  });
+
+  it('exposes the alertdialog role', () => {
+    render(
+      <I18nWrapper>
+        <DeleteWaiverAlertDialog {...defaultProps} />
+      </I18nWrapper>,
+    );
+
+    expect(page.getByRole('alertdialog')).toBeInTheDocument();
+  });
+});

--- a/src/features/waivers/details/DeleteWaiverAlertDialog.tsx
+++ b/src/features/waivers/details/DeleteWaiverAlertDialog.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { useCallback } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+type DeleteWaiverAlertDialogProps = {
+  isOpen: boolean;
+  waiverName: string;
+  onCloseAction: () => void;
+  onConfirmAction: () => void;
+};
+
+export function DeleteWaiverAlertDialog({
+  isOpen,
+  waiverName,
+  onCloseAction,
+  onConfirmAction,
+}: DeleteWaiverAlertDialogProps) {
+  const t = useTranslations('DeleteWaiverAlertDialog');
+
+  const handleOpenChange = useCallback((open: boolean) => {
+    if (!open) {
+      onCloseAction();
+    }
+  }, [onCloseAction]);
+
+  const handleConfirm = useCallback(() => {
+    onConfirmAction();
+  }, [onConfirmAction]);
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={handleOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t('title')}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {t('description', { waiverName })}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{t('cancel_button')}</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-white hover:bg-destructive/90"
+            onClick={handleConfirm}
+          >
+            {t('delete_button')}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -872,6 +872,12 @@
     "cancel_button": "Cancel",
     "delete_button": "Delete"
   },
+  "DeleteWaiverAlertDialog": {
+    "title": "Are you absolutely sure?",
+    "description": "This action cannot be undone. This will permanently delete the waiver \"{waiverName}\" and remove it from any membership plans it was associated with. Existing signed waivers remain unaffected.",
+    "cancel_button": "Cancel",
+    "delete_button": "Delete"
+  },
   "LocationSettings": {
     "title": "Location Settings",
     "location_title": "Location",
@@ -1142,6 +1148,7 @@
   },
   "WaiverDetailPage": {
     "error_loading": "Failed to load waiver",
+    "error_deleting": "Failed to delete waiver. Please try again.",
     "waiver_not_found": "Waiver not found",
     "back_to_waivers": "Back to Waivers",
     "status_active": "Active",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -875,6 +875,12 @@
     "cancel_button": "Annuler",
     "delete_button": "Supprimer"
   },
+  "DeleteWaiverAlertDialog": {
+    "title": "Êtes-vous absolument sûr ?",
+    "description": "Cette action est irréversible. La décharge « {waiverName} » sera définitivement supprimée et retirée des plans d'adhésion auxquels elle était associée. Les décharges déjà signées ne sont pas affectées.",
+    "cancel_button": "Annuler",
+    "delete_button": "Supprimer"
+  },
   "LocationSettings": {
     "title": "Paramètres de localisation",
     "location_title": "Localisation",
@@ -1146,6 +1152,7 @@
   },
   "WaiverDetailPage": {
     "error_loading": "Échec du chargement de la décharge",
+    "error_deleting": "Échec de la suppression de la décharge. Veuillez réessayer.",
     "waiver_not_found": "Décharge non trouvée",
     "back_to_waivers": "Retour aux décharges",
     "status_active": "Actif",

--- a/src/services/WaiversService.test.ts
+++ b/src/services/WaiversService.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock database and schemas
-vi.mock('@/libs/DB', () => ({
-  db: {
+// Mock database and schemas. `db.transaction(cb)` invokes the callback with
+// the same `db` object as `tx` so existing tests keep asserting against
+// `db.update` / `db.insert` / `db.select` regardless of whether the code
+// under test runs inside a transaction.
+vi.mock('@/libs/DB', () => {
+  const db: Record<string, unknown> = {
     select: vi.fn(() => ({
       from: vi.fn(() => ({
         where: vi.fn(() => Promise.resolve([])),
@@ -23,8 +26,10 @@ vi.mock('@/libs/DB', () => ({
     delete: vi.fn(() => ({
       where: vi.fn(() => Promise.resolve()),
     })),
-  },
-}));
+  };
+  db.transaction = vi.fn(async (cb: (tx: typeof db) => Promise<unknown>) => cb(db));
+  return { db };
+});
 
 vi.mock('@/models/Schema', () => ({
   waiverTemplateSchema: { id: 'id', organizationId: 'organizationId', parentId: 'parentId', isDefault: 'isDefault', content: 'content' },
@@ -467,6 +472,117 @@ describe('WaiversService', () => {
       expect(result.template.isDefault).toBe(true);
       // update called at least twice: once to unset others, once to update template
       expect(db.update).toHaveBeenCalledTimes(2);
+    });
+
+    it('should update the slug when the name changes (regression: previously dead code)', async () => {
+      const { db } = await import('@/libs/DB');
+
+      const updatedTemplate = {
+        ...mockTemplate,
+        name: 'Renamed Waiver',
+        slug: 'renamed-waiver',
+      };
+
+      let selectCallCount = 0;
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([mockTemplate]);
+            }
+            return Promise.resolve([]);
+          }),
+        }),
+      } as any);
+
+      const setSpy = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([updatedTemplate]),
+        }),
+      });
+      vi.mocked(db.update).mockReturnValue({ set: setSpy } as any);
+
+      const { updateWaiverTemplate } = await import('./WaiversService');
+      const result = await updateWaiverTemplate(
+        { id: 'template-1', name: 'Renamed Waiver' },
+        'test-org-123',
+      );
+
+      expect(result.template.slug).toBe('renamed-waiver');
+      // The set() payload must include slug derived from the new name.
+      expect(setSpy).toHaveBeenCalledWith(expect.objectContaining({
+        slug: 'renamed-waiver',
+        name: 'Renamed Waiver',
+      }));
+    });
+
+    it('should NOT update the slug when only non-name fields change', async () => {
+      const { db } = await import('@/libs/DB');
+
+      const updatedTemplate = { ...mockTemplate, isActive: false };
+
+      let selectCallCount = 0;
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([mockTemplate]);
+            }
+            return Promise.resolve([]);
+          }),
+        }),
+      } as any);
+
+      const setSpy = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([updatedTemplate]),
+        }),
+      });
+      vi.mocked(db.update).mockReturnValue({ set: setSpy } as any);
+
+      const { updateWaiverTemplate } = await import('./WaiversService');
+      await updateWaiverTemplate(
+        { id: 'template-1', isActive: false },
+        'test-org-123',
+      );
+
+      const setPayload = setSpy.mock.calls[0]?.[0] as Record<string, unknown>;
+
+      expect(setPayload).not.toHaveProperty('slug');
+    });
+
+    it('should run inside a transaction (regression: prevents archive-vs-root unique-key collision)', async () => {
+      const { db } = await import('@/libs/DB');
+
+      let selectCallCount = 0;
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([mockTemplate]);
+            }
+            return Promise.resolve([]);
+          }),
+        }),
+      } as any);
+
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ ...mockTemplate, name: 'X' }]),
+          }),
+        }),
+      } as any);
+
+      const { updateWaiverTemplate } = await import('./WaiversService');
+      await updateWaiverTemplate({ id: 'template-1', name: 'X' }, 'test-org-123');
+
+      // The mocked `db.transaction` is invoked with a callback that runs the
+      // update — the test passes if the call count is non-zero.
+      expect(db.transaction).toHaveBeenCalled();
     });
   });
 

--- a/src/services/WaiversService.ts
+++ b/src/services/WaiversService.ts
@@ -344,75 +344,82 @@ export async function updateWaiverTemplate(
   const currentTemplate = existing[0]!;
   const contentChanged = updateData.content !== undefined && updateData.content !== currentTemplate.content;
 
-  // If this is set as default, unset other default templates
-  if (updateData.isDefault) {
-    await db
-      .update(waiverTemplateSchema)
-      .set({ isDefault: false })
-      .where(and(
-        eq(waiverTemplateSchema.organizationId, organizationId),
-        eq(waiverTemplateSchema.isDefault, true),
-      ));
-  }
-
-  // If content changed, archive the current version before updating
-  if (contentChanged) {
-    await db.insert(waiverTemplateSchema).values({
-      id: randomUUID(),
-      organizationId: currentTemplate.organizationId,
-      name: currentTemplate.name,
-      slug: currentTemplate.slug,
-      version: currentTemplate.version,
-      content: currentTemplate.content,
-      description: currentTemplate.description,
-      isActive: currentTemplate.isActive,
-      isDefault: currentTemplate.isDefault,
-      requiresGuardian: currentTemplate.requiresGuardian,
-      guardianAgeThreshold: currentTemplate.guardianAgeThreshold,
-      sortOrder: currentTemplate.sortOrder,
-      parentId: currentTemplate.id,
-    });
-  }
-
-  // Prepare update data
+  // Build the partial set passed to the root update.
   const dataToUpdate: Record<string, unknown> = { ...updateData };
   if (contentChanged) {
     dataToUpdate.version = currentTemplate.version + 1;
   }
-
-  // Update slug if name changes
-  if (updateData.name && !input.name) {
+  // Re-derive the slug when the name changes so the URL slug stays in sync.
+  if (updateData.name !== undefined && updateData.name !== currentTemplate.name) {
     dataToUpdate.slug = generateSlug(updateData.name);
   }
 
-  const result = await db
-    .update(waiverTemplateSchema)
-    .set(dataToUpdate)
-    .where(and(eq(waiverTemplateSchema.id, id), eq(waiverTemplateSchema.organizationId, organizationId)))
-    .returning();
+  // Run the entire update inside a transaction so:
+  //   1) the unset-other-defaults, archive-insert, and root-update are atomic, and
+  //   2) the root version bump happens BEFORE the archive insert. The archive
+  //      copies the row at its OLD version; if we inserted it before bumping the
+  //      root, both rows would briefly share (organization_id, slug, version) and
+  //      hit the unique index violation.
+  const updatedRow = await db.transaction(async (tx) => {
+    if (updateData.isDefault) {
+      await tx
+        .update(waiverTemplateSchema)
+        .set({ isDefault: false })
+        .where(and(
+          eq(waiverTemplateSchema.organizationId, organizationId),
+          eq(waiverTemplateSchema.isDefault, true),
+        ));
+    }
 
-  const template = result[0];
-  if (!template) {
-    throw new Error('Failed to update waiver template');
-  }
+    const updateResult = await tx
+      .update(waiverTemplateSchema)
+      .set(dataToUpdate)
+      .where(and(eq(waiverTemplateSchema.id, id), eq(waiverTemplateSchema.organizationId, organizationId)))
+      .returning();
+
+    const updated = updateResult[0];
+    if (!updated) {
+      throw new Error('Failed to update waiver template');
+    }
+
+    if (contentChanged) {
+      await tx.insert(waiverTemplateSchema).values({
+        id: randomUUID(),
+        organizationId: currentTemplate.organizationId,
+        name: currentTemplate.name,
+        slug: currentTemplate.slug,
+        version: currentTemplate.version,
+        content: currentTemplate.content,
+        description: currentTemplate.description,
+        isActive: currentTemplate.isActive,
+        isDefault: currentTemplate.isDefault,
+        requiresGuardian: currentTemplate.requiresGuardian,
+        guardianAgeThreshold: currentTemplate.guardianAgeThreshold,
+        sortOrder: currentTemplate.sortOrder,
+        parentId: currentTemplate.id,
+      });
+    }
+
+    return updated;
+  });
 
   return {
     template: {
-      id: template.id,
-      organizationId: template.organizationId,
-      name: template.name,
-      slug: template.slug,
-      version: template.version,
-      content: template.content,
-      description: template.description,
-      isActive: template.isActive ?? true,
-      isDefault: template.isDefault ?? false,
-      requiresGuardian: template.requiresGuardian ?? true,
-      guardianAgeThreshold: template.guardianAgeThreshold ?? 16,
-      sortOrder: template.sortOrder ?? 0,
-      parentId: template.parentId,
-      createdAt: template.createdAt,
-      updatedAt: template.updatedAt,
+      id: updatedRow.id,
+      organizationId: updatedRow.organizationId,
+      name: updatedRow.name,
+      slug: updatedRow.slug,
+      version: updatedRow.version,
+      content: updatedRow.content,
+      description: updatedRow.description,
+      isActive: updatedRow.isActive ?? true,
+      isDefault: updatedRow.isDefault ?? false,
+      requiresGuardian: updatedRow.requiresGuardian ?? true,
+      guardianAgeThreshold: updatedRow.guardianAgeThreshold ?? 16,
+      sortOrder: updatedRow.sortOrder ?? 0,
+      parentId: updatedRow.parentId,
+      createdAt: updatedRow.createdAt,
+      updatedAt: updatedRow.updatedAt,
     },
     versionCreated: contentChanged,
   };


### PR DESCRIPTION
## Summary

- Wire up the waiver delete button so it actually deletes a waiver template, with the standard `AlertDialog` confirmation pattern used by every other delete action in the app. The existing `client.waivers.deleteTemplate` endpoint and its `guardRole(ACADEMY_OWNER)` were already in place — only the UI was a TODO stub.
- Fix the underlying bug that was causing waiver content edits to silently fail. When a user changed content (which triggers an archive-and-version-bump on the server), the archive insert collided with the still-unbumped root row on the unique index `(organization_id, slug, version)` → Postgres `23505` → save aborted, user reported it as "name and description don't save".

## Changes

### #158 — UI wire-up

- `src/features/waivers/details/DeleteWaiverAlertDialog.tsx` — new component, mirrors `DeleteCatalogCategoryAlertDialog` / `DeleteTagAlertDialog`.
- `src/app/[locale]/(auth)/dashboard/waivers/[waiverId]/page.tsx` — replaced the `handleDelete` TODO stub with a full flow: open dialog → confirm → call `client.waivers.deleteTemplate({ id })` → redirect to `/dashboard/waivers`. Dialog mounted at the bottom of the page tree.
- `src/locales/en.json`, `src/locales/fr.json` — new `DeleteWaiverAlertDialog` namespace plus a `WaiverDetailPage.error_deleting` key for the failure path.

### #157 — Server-side fix

`src/services/WaiversService.ts` `updateWaiverTemplate`:
- Wrapped the entire update in `db.transaction` so unset-other-defaults, root update, and archive insert are atomic — no half-applied state on failure.
- **Reordered the archive flow**: update the root row FIRST (bumping version `N` → `N+1`, applying new content/name/etc.), THEN insert the archive row at the original `version=N`. This is the actual bug fix — under the previous order, the archive insert and the still-unbumped root briefly shared `(organization_id, slug, version)`, tripping the unique index and aborting the whole transaction.
- Fixed a dead-code condition (`if (updateData.name && !input.name)`) that was preventing the slug from ever updating when the name changed. The slug now re-derives from the new name on every rename.

### Tests

- `src/features/waivers/details/DeleteWaiverAlertDialog.test.tsx` — 5 tests (render, visibility, cancel, confirm, accessibility).
- `src/services/WaiversService.test.ts` — 3 new regression tests:
  - Slug updates when the name changes.
  - Slug does NOT update when only non-name fields change.
  - The update runs inside `db.transaction` (locks in the atomicity guarantee).
- The existing `db` mock was extended with a `transaction` implementation that invokes its callback with the same `db`, so all 88 prior tests continue to assert against `db.update` / `db.insert` unchanged.

## Verification

- Reproduced both bugs against local seed data, then confirmed the fixes end-to-end:
  - Settings-only edit (name + description, no content): persists correctly, no version bump.
  - Content edit: archive row created at version=N, root bumped to version=N+1, no constraint violation.
  - Consecutive content edits: each bumps the root version cleanly.
- `npm run lint && npm run check:types && npm run check:deps && npm run check:i18n && npm run test -- --coverage` — 4003 / 4003 tests pass across 201 files, zero warnings.

## Test plan

- [ ] On a seeded preview/local environment, navigate to Dashboard → Waivers → open any waiver detail page.
- [ ] Click the trash icon → confirm dialog appears → cancel → waiver still there.
- [ ] Click the trash icon → confirm → redirected to `/dashboard/waivers` and the waiver is gone.
- [ ] Open another waiver → click the edit icon next to "Basics" → change name + description → save → page refreshes with the new values; reopen the modal → values match what was saved.
- [ ] Open the edit icon next to the "Content" area → change name + content → save → version increments by 1, new name persists. Repeat to confirm consecutive content edits work.
- [ ] Verify audit events fire: `SELECT action, status FROM audit_event WHERE action LIKE 'waiverTemplate.%' ORDER BY created_at DESC LIMIT 5;` shows `waiverTemplate.delete` and `waiverTemplate.update` rows with `success`.

Closes #158
Closes #157