### PR TITLE
feat(photo): fix edit/delete photo

### DIFF
--- a/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx
+++ b/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx
@@ -7,7 +7,7 @@ import type { Member } from '@/hooks/useMembersCache';
 import type { MemberPaymentMethodData } from '@/services/MembersService';
 import type { SignedWaiverWithTemplateName } from '@/services/WaiversService';
 import { useOrganization } from '@clerk/nextjs';
-import { ArrowRightLeft, Download, Plus, Trash2 } from 'lucide-react';
+import { ArrowRightLeft, Download, Pencil, Plus, Trash2 } from 'lucide-react';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
@@ -21,6 +21,7 @@ import { transformCouponsToUi } from '@/features/marketing';
 import { ConvertMemberModal } from '@/features/members/conversion/ConvertMemberModal';
 import { ChangeMembershipModal } from '@/features/members/details/ChangeMembershipModal';
 import { EditContactInfoModal } from '@/features/members/details/EditContactInfoModal';
+import { EditMemberPhotoModal } from '@/features/members/details/EditMemberPhotoModal';
 import { MemberDetailAttendance } from '@/features/members/details/MemberDetailAttendance';
 import { MemberDetailNotes } from '@/features/members/details/MemberDetailNotes';
 import { AddFamilyMembersModal } from '@/features/members/wizard/AddFamilyMembersModal';
@@ -522,6 +523,9 @@ export default function EditMemberPage() {
   // State for edit contact info modal
   const [isEditContactModalOpen, setIsEditContactModalOpen] = useState(false);
 
+  // State for edit photo modal
+  const [isEditPhotoModalOpen, setIsEditPhotoModalOpen] = useState(false);
+
   // State for change membership modal
   const [isChangeMembershipModalOpen, setIsChangeMembershipModalOpen] = useState(false);
   const [membershipModalMode, setMembershipModalMode] = useState<'add' | 'change'>('add');
@@ -948,10 +952,20 @@ export default function EditMemberPage() {
 
       {/* Member Header */}
       <div className="flex items-center gap-4">
-        <Avatar className="h-16 w-16">
-          {state.currentData.photoUrl && <AvatarImage src={state.currentData.photoUrl} alt={state.currentData.memberName} />}
-          <AvatarFallback>{getInitials(state.currentData.memberName)}</AvatarFallback>
-        </Avatar>
+        <div className="relative h-16 w-16 shrink-0">
+          <Avatar className="h-16 w-16">
+            {state.currentData.photoUrl && <AvatarImage src={state.currentData.photoUrl} alt={state.currentData.memberName} />}
+            <AvatarFallback>{getInitials(state.currentData.memberName)}</AvatarFallback>
+          </Avatar>
+          <button
+            type="button"
+            onClick={() => setIsEditPhotoModalOpen(true)}
+            aria-label="Edit photo"
+            className="absolute -right-1 -bottom-1 cursor-pointer rounded-full border border-border bg-background p-1 shadow-sm hover:bg-accent"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </button>
+        </div>
         <div className="flex flex-col gap-2">
           <div className="flex items-center gap-3">
             <h1 className="text-2xl font-bold text-foreground">{state.currentData.memberName}</h1>
@@ -1124,6 +1138,20 @@ export default function EditMemberPage() {
                     }
                   : undefined
               }
+            />
+
+            {/* Edit Photo Modal — keyed on open state so internal state resets per-open */}
+            <EditMemberPhotoModal
+              key={isEditPhotoModalOpen ? 'open' : 'closed'}
+              isOpen={isEditPhotoModalOpen}
+              memberId={memberId}
+              memberName={state.currentData.memberName}
+              currentPhotoUrl={state.currentData.photoUrl ?? null}
+              onCloseAction={() => setIsEditPhotoModalOpen(false)}
+              onSavedAction={() => {
+                // The modal already calls invalidateMembersCache(); useMembersCache
+                // re-runs and the avatar refreshes without a full page reload.
+              }}
             />
 
             {/* Membership Details - Comprehensive */}

--- a/src/features/members/details/EditMemberPhotoModal.test.tsx
+++ b/src/features/members/details/EditMemberPhotoModal.test.tsx
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { page, userEvent } from 'vitest/browser';
+import { I18nWrapper } from '@/lib/test-utils';
+import { EditMemberPhotoModal } from './EditMemberPhotoModal';
+
+const updatePhotoMock = vi.fn();
+const invalidateMembersCacheMock = vi.fn();
+const compressImageForStorageMock = vi.fn();
+
+vi.mock('@/libs/Orpc', () => ({
+  client: {
+    member: {
+      updatePhoto: (...args: unknown[]) => updatePhotoMock(...args),
+    },
+  },
+}));
+
+vi.mock('@/hooks/useMembersCache', () => ({
+  invalidateMembersCache: (...args: unknown[]) => invalidateMembersCacheMock(...args),
+}));
+
+vi.mock('@/utils/imageCompression', () => ({
+  compressImageForStorage: (file: File) => compressImageForStorageMock(file),
+  formatFileSize: (n: number) => `${n} B`,
+}));
+
+const SAMPLE_DATA_URL = 'data:image/jpeg;base64,/9j/SAMPLE';
+
+const baseProps = {
+  isOpen: true,
+  memberId: 'member-1',
+  memberName: 'Jane Doe',
+  currentPhotoUrl: null as string | null,
+  onCloseAction: vi.fn(),
+  onSavedAction: vi.fn(),
+};
+
+describe('EditMemberPhotoModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updatePhotoMock.mockResolvedValue({});
+    invalidateMembersCacheMock.mockResolvedValue(undefined);
+    // Default: a working compression that yields a fixed data URL.
+    compressImageForStorageMock.mockImplementation(async (file: File) => ({
+      compressedFile: file,
+      originalSize: 1000,
+      compressedSize: 200,
+      compressionRatio: 80,
+    }));
+    // Mock FileReader so the data URL is deterministic.
+    class MockFileReader {
+      onload: ((e: { target: { result: string } }) => void) | null = null;
+      readAsDataURL() {
+        setTimeout(() => {
+          this.onload?.({ target: { result: SAMPLE_DATA_URL } });
+        }, 0);
+      }
+    }
+    vi.stubGlobal('FileReader', MockFileReader as unknown as typeof FileReader);
+  });
+
+  it('renders the title and the no-photo placeholder when no current photo is set', () => {
+    render(
+      <I18nWrapper>
+        <EditMemberPhotoModal {...baseProps} />
+      </I18nWrapper>,
+    );
+
+    expect(page.getByRole('heading', { name: 'Edit Photo' })).toBeInTheDocument();
+    expect(page.getByText('No photo uploaded')).toBeInTheDocument();
+  });
+
+  it('shows Save disabled until the user picks a file or removes', () => {
+    render(
+      <I18nWrapper>
+        <EditMemberPhotoModal {...baseProps} />
+      </I18nWrapper>,
+    );
+
+    expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('does not render the Remove button when there is no current photo', () => {
+    render(
+      <I18nWrapper>
+        <EditMemberPhotoModal {...baseProps} />
+      </I18nWrapper>,
+    );
+
+    expect(page.getByRole('button', { name: 'Remove' }).elements().length).toBe(0);
+  });
+
+  it('renders the Remove button when there is a current photo', () => {
+    render(
+      <I18nWrapper>
+        <EditMemberPhotoModal {...baseProps} currentPhotoUrl={SAMPLE_DATA_URL} />
+      </I18nWrapper>,
+    );
+
+    expect(page.getByRole('button', { name: 'Remove' })).toBeInTheDocument();
+  });
+
+  it('opens the confirm dialog and only clears the photo on confirm', async () => {
+    render(
+      <I18nWrapper>
+        <EditMemberPhotoModal {...baseProps} currentPhotoUrl={SAMPLE_DATA_URL} />
+      </I18nWrapper>,
+    );
+
+    await userEvent.click(page.getByRole('button', { name: 'Remove' }));
+
+    expect(page.getByRole('heading', { name: 'Remove photo?' })).toBeInTheDocument();
+    expect(updatePhotoMock).not.toHaveBeenCalled();
+
+    await userEvent.click(page.getByRole('button', { name: 'Remove photo' }));
+
+    // The Save button is enabled only after a pending change, so we click it.
+    await userEvent.click(page.getByRole('button', { name: 'Save' }));
+
+    expect(updatePhotoMock).toHaveBeenCalledWith({ id: 'member-1', photoUrl: null });
+  });
+
+  it('cancels the remove when the AlertDialog is cancelled', async () => {
+    render(
+      <I18nWrapper>
+        <EditMemberPhotoModal {...baseProps} currentPhotoUrl={SAMPLE_DATA_URL} />
+      </I18nWrapper>,
+    );
+
+    await userEvent.click(page.getByRole('button', { name: 'Remove' }));
+    // Cancel button inside the AlertDialog
+    await userEvent.click(page.getByRole('button', { name: 'Cancel' }).first());
+
+    // Save remains disabled because no pending change
+    expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
+    expect(updatePhotoMock).not.toHaveBeenCalled();
+  });
+
+  it('shows an error banner and does not call updatePhoto when an unsupported file type is chosen', async () => {
+    render(
+      <I18nWrapper>
+        <EditMemberPhotoModal {...baseProps} />
+      </I18nWrapper>,
+    );
+
+    const input = document.querySelector('#edit-member-photo-input') as HTMLInputElement;
+    const pdf = new File(['x'], 'doc.pdf', { type: 'application/pdf' });
+    Object.defineProperty(input, 'files', { value: [pdf], configurable: true });
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(page.getByText(/Invalid file type/)).toBeInTheDocument();
+    expect(updatePhotoMock).not.toHaveBeenCalled();
+    expect(compressImageForStorageMock).not.toHaveBeenCalled();
+  });
+
+  it('renders an error banner when the server rejects', async () => {
+    updatePhotoMock.mockRejectedValueOnce(new Error('server boom'));
+
+    render(
+      <I18nWrapper>
+        <EditMemberPhotoModal {...baseProps} currentPhotoUrl={SAMPLE_DATA_URL} />
+      </I18nWrapper>,
+    );
+
+    await userEvent.click(page.getByRole('button', { name: 'Remove' }));
+    await userEvent.click(page.getByRole('button', { name: 'Remove photo' }));
+    await userEvent.click(page.getByRole('button', { name: 'Save' }));
+
+    expect(page.getByText('server boom')).toBeInTheDocument();
+  });
+
+  it('calls onSavedAction and onCloseAction after a successful save', async () => {
+    const onSaved = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <I18nWrapper>
+        <EditMemberPhotoModal
+          {...baseProps}
+          currentPhotoUrl={SAMPLE_DATA_URL}
+          onSavedAction={onSaved}
+          onCloseAction={onClose}
+        />
+      </I18nWrapper>,
+    );
+
+    await userEvent.click(page.getByRole('button', { name: 'Remove' }));
+    await userEvent.click(page.getByRole('button', { name: 'Remove photo' }));
+    await userEvent.click(page.getByRole('button', { name: 'Save' }));
+
+    expect(invalidateMembersCacheMock).toHaveBeenCalled();
+    expect(onSaved).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/features/members/details/EditMemberPhotoModal.tsx
+++ b/src/features/members/details/EditMemberPhotoModal.tsx
@@ -1,0 +1,266 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { useState } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Spinner } from '@/components/ui/spinner';
+import { invalidateMembersCache } from '@/hooks/useMembersCache';
+import { client } from '@/libs/Orpc';
+import { compressImageForStorage, formatFileSize } from '@/utils/imageCompression';
+
+const ACCEPTED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif'];
+
+type EditMemberPhotoModalProps = {
+  isOpen: boolean;
+  memberId: string;
+  memberName: string;
+  /** Current photo (data URL or null). */
+  currentPhotoUrl: string | null;
+  onCloseAction: () => void;
+  /** Called after a successful save so the parent can refetch member data. */
+  onSavedAction: () => void | Promise<void>;
+};
+
+export function EditMemberPhotoModal({
+  isOpen,
+  memberId,
+  memberName,
+  currentPhotoUrl,
+  onCloseAction,
+  onSavedAction,
+}: EditMemberPhotoModalProps) {
+  const t = useTranslations('EditMemberPhotoModal');
+
+  // The parent must remount via a `key` that changes between opens so state
+  // resets. This avoids derived-state effects flagged by react-hooks-extra.
+  const [preview, setPreview] = useState<string | null>(null);
+  const [isCompressing, setIsCompressing] = useState(false);
+  const [compressionInfo, setCompressionInfo] = useState<{
+    originalSize: number;
+    compressedSize: number;
+    compressionRatio: number;
+  } | null>(null);
+  const [pendingRemoval, setPendingRemoval] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false);
+
+  const displayedPhoto = pendingRemoval ? null : (preview ?? currentPhotoUrl);
+  const hasPhoto = !!displayedPhoto;
+  const hasPendingChange = preview !== null || pendingRemoval;
+
+  const handleFileSelect = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    if (!ACCEPTED_IMAGE_TYPES.includes(file.type)) {
+      setError(t('invalid_file_type'));
+      return;
+    }
+
+    setError(null);
+    setIsCompressing(true);
+    try {
+      const result = await compressImageForStorage(file);
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        const dataUrl = e.target?.result as string;
+        setPreview(dataUrl);
+        setPendingRemoval(false);
+        setCompressionInfo({
+          originalSize: result.originalSize,
+          compressedSize: result.compressedSize,
+          compressionRatio: result.compressionRatio,
+        });
+      };
+      reader.readAsDataURL(result.compressedFile);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      setError(`${t('invalid_file_type')}: ${message}`);
+    } finally {
+      setIsCompressing(false);
+    }
+  };
+
+  const handleRequestRemove = () => {
+    setConfirmRemoveOpen(true);
+  };
+
+  const handleConfirmRemove = () => {
+    setPendingRemoval(true);
+    setPreview(null);
+    setCompressionInfo(null);
+    setConfirmRemoveOpen(false);
+  };
+
+  const handleCancelRemove = () => {
+    setConfirmRemoveOpen(false);
+  };
+
+  const handleSave = async () => {
+    if (!hasPendingChange || isSaving) {
+      return;
+    }
+    setError(null);
+    setIsSaving(true);
+    try {
+      const photoUrl = pendingRemoval ? null : preview!;
+      await client.member.updatePhoto({ id: memberId, photoUrl });
+      await invalidateMembersCache();
+      await onSavedAction();
+      onCloseAction();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : t('save_error');
+      setError(message);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open && !isSaving) {
+      onCloseAction();
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t('title')}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-5 py-2">
+          <p className="text-sm text-muted-foreground">{t('subtitle', { memberName })}</p>
+
+          <div className="flex flex-col items-center gap-4">
+            {isCompressing
+              ? (
+                  <div className="flex h-48 w-48 items-center justify-center rounded-lg border-2 border-dashed border-border bg-accent/50">
+                    <Spinner size="lg" />
+                  </div>
+                )
+              : hasPhoto
+                ? (
+                    // Plain <img> rather than next/image because the source is a
+                    // base64 data URL — Next.js image optimization doesn't apply.
+                    // eslint-disable-next-line next/no-img-element
+                    <img
+                      src={displayedPhoto}
+                      alt={memberName}
+                      width={192}
+                      height={192}
+                      className="rounded-lg object-cover"
+                    />
+                  )
+                : (
+                    <div className="flex h-48 w-48 items-center justify-center rounded-lg border-2 border-dashed border-border bg-accent/50">
+                      <p className="text-sm text-muted-foreground">{t('no_photo')}</p>
+                    </div>
+                  )}
+
+            {compressionInfo && (
+              <div className="w-full rounded-lg bg-secondary/50 p-3 text-xs text-muted-foreground">
+                <div className="flex justify-between">
+                  <span>{t('original_size')}</span>
+                  <span className="font-medium">{formatFileSize(compressionInfo.originalSize)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>{t('compressed_size')}</span>
+                  <span className="font-medium text-foreground">{formatFileSize(compressionInfo.compressedSize)}</span>
+                </div>
+              </div>
+            )}
+
+            <input
+              id="edit-member-photo-input"
+              type="file"
+              accept=".jpg,.jpeg,.png,.gif"
+              onChange={handleFileSelect}
+              disabled={isCompressing || isSaving}
+              className="hidden"
+              aria-label={t('choose_file_button')}
+            />
+
+            <div className="flex flex-wrap justify-center gap-2">
+              <Button asChild variant="outline" disabled={isCompressing || isSaving}>
+                <label htmlFor="edit-member-photo-input" className="cursor-pointer">
+                  {hasPhoto ? t('change_button') : t('choose_file_button')}
+                </label>
+              </Button>
+              {hasPhoto && (
+                <Button
+                  variant="outline"
+                  onClick={handleRequestRemove}
+                  disabled={isCompressing || isSaving}
+                >
+                  {t('remove_button')}
+                </Button>
+              )}
+            </div>
+          </div>
+
+          {error && (
+            <p className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+              {error}
+            </p>
+          )}
+
+          <div className="flex justify-end gap-3 pt-2">
+            <Button variant="outline" onClick={onCloseAction} disabled={isSaving}>
+              {t('cancel_button')}
+            </Button>
+            <Button onClick={handleSave} disabled={!hasPendingChange || isSaving}>
+              {isSaving ? t('saving_button') : t('save_button')}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+
+      <AlertDialog
+        open={confirmRemoveOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            handleCancelRemove();
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('confirm_remove_title')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('confirm_remove_description', { memberName })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t('cancel_button')}</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-white hover:bg-destructive/90"
+              onClick={handleConfirmRemove}
+            >
+              {t('confirm_remove_action')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Dialog>
+  );
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1599,6 +1599,24 @@
     "saving_button": "Saving...",
     "submit_error": "Failed to update contact information. Please try again."
   },
+  "EditMemberPhotoModal": {
+    "title": "Edit Photo",
+    "subtitle": "Upload a new photo for {memberName} or remove the existing one.",
+    "no_photo": "No photo uploaded",
+    "choose_file_button": "Choose photo",
+    "change_button": "Change photo",
+    "remove_button": "Remove",
+    "cancel_button": "Cancel",
+    "save_button": "Save",
+    "saving_button": "Saving...",
+    "save_error": "Failed to update photo. Please try again.",
+    "invalid_file_type": "Invalid file type. Please upload a JPG, PNG, or GIF image.",
+    "original_size": "Original size:",
+    "compressed_size": "Compressed size:",
+    "confirm_remove_title": "Remove photo?",
+    "confirm_remove_description": "This will remove the photo for {memberName}. You can upload a new one later.",
+    "confirm_remove_action": "Remove photo"
+  },
   "ChangeMembershipModal": {
     "add_title": "Add Membership",
     "change_title": "Change Membership",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1603,6 +1603,24 @@
     "saving_button": "Enregistrement...",
     "submit_error": "Échec de la mise à jour des informations de contact. Veuillez réessayer."
   },
+  "EditMemberPhotoModal": {
+    "title": "Modifier la photo",
+    "subtitle": "Téléversez une nouvelle photo pour {memberName} ou supprimez l'existante.",
+    "no_photo": "Aucune photo téléversée",
+    "choose_file_button": "Choisir une photo",
+    "change_button": "Changer la photo",
+    "remove_button": "Supprimer",
+    "cancel_button": "Annuler",
+    "save_button": "Enregistrer",
+    "saving_button": "Enregistrement...",
+    "save_error": "Échec de la mise à jour de la photo. Veuillez réessayer.",
+    "invalid_file_type": "Type de fichier invalide. Veuillez téléverser une image JPG, PNG ou GIF.",
+    "original_size": "Taille d'origine :",
+    "compressed_size": "Taille compressée :",
+    "confirm_remove_title": "Supprimer la photo ?",
+    "confirm_remove_description": "Cela supprimera la photo de {memberName}. Vous pourrez en téléverser une nouvelle plus tard.",
+    "confirm_remove_action": "Supprimer la photo"
+  },
   "ChangeMembershipModal": {
     "add_title": "Ajouter une adhésion",
     "change_title": "Changer d'adhésion",

--- a/src/routers/Member.test.ts
+++ b/src/routers/Member.test.ts
@@ -30,6 +30,7 @@ vi.mock('@/services/MembersService', () => ({
   updateMember: vi.fn(),
   updateMemberStatus: vi.fn(),
   updateMemberContactInfo: vi.fn(),
+  updateMemberPhoto: vi.fn(),
   addMemberMembership: vi.fn(),
   changeMemberMembership: vi.fn(),
   getMembershipPlans: vi.fn(),
@@ -640,6 +641,100 @@ describe('Member Router', () => {
         AUDIT_ACTION.MEMBER_UPDATE,
         AUDIT_ENTITY_TYPE.MEMBER,
         { entityId: 'member-1', status: 'failure', error: 'DB error' },
+      );
+    });
+  });
+
+  describe('updatePhoto', () => {
+    const validPhoto = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD';
+
+    it('updates the photo, requires ACADEMY_OWNER, and emits a success audit with after-set sentinel', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { updateMemberPhoto } = await import('@/services/MembersService');
+      const { audit } = await import('@/services/AuditService');
+
+      vi.mocked(guardRole).mockResolvedValue(mockAcademyOwnerContext);
+      vi.mocked(updateMemberPhoto).mockResolvedValue([{ id: 'member-1' }]);
+
+      const { updatePhoto } = await import('./Member');
+      const result = await callHandler(updatePhoto, { id: 'member-1', photoUrl: validPhoto });
+
+      expect(guardRole).toHaveBeenCalledWith(ORG_ROLE.ACADEMY_OWNER);
+      expect(updateMemberPhoto).toHaveBeenCalledWith({ id: 'member-1', photoUrl: validPhoto }, 'test-org-456');
+      expect(audit).toHaveBeenCalledWith(
+        mockAcademyOwnerContext,
+        AUDIT_ACTION.MEMBER_UPDATE_CONTACT,
+        AUDIT_ENTITY_TYPE.MEMBER,
+        expect.objectContaining({
+          entityId: 'member-1',
+          status: 'success',
+          changes: { photoUrl: { before: '<photo>', after: '<photo>' } },
+        }),
+      );
+      expect(result).toEqual({});
+    });
+
+    it('clears the photo and emits a success audit with after=null', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { updateMemberPhoto } = await import('@/services/MembersService');
+      const { audit } = await import('@/services/AuditService');
+
+      vi.mocked(guardRole).mockResolvedValue(mockAcademyOwnerContext);
+      vi.mocked(updateMemberPhoto).mockResolvedValue([{ id: 'member-1' }]);
+
+      const { updatePhoto } = await import('./Member');
+      await callHandler(updatePhoto, { id: 'member-1', photoUrl: null });
+
+      expect(updateMemberPhoto).toHaveBeenCalledWith({ id: 'member-1', photoUrl: null }, 'test-org-456');
+      expect(audit).toHaveBeenCalledWith(
+        mockAcademyOwnerContext,
+        AUDIT_ACTION.MEMBER_UPDATE_CONTACT,
+        AUDIT_ENTITY_TYPE.MEMBER,
+        expect.objectContaining({
+          entityId: 'member-1',
+          status: 'success',
+          changes: { photoUrl: { before: '<photo>', after: null } },
+        }),
+      );
+    });
+
+    it('throws 404 when the member is not in the org', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { updateMemberPhoto } = await import('@/services/MembersService');
+
+      vi.mocked(guardRole).mockResolvedValue(mockAcademyOwnerContext);
+      vi.mocked(updateMemberPhoto).mockResolvedValue([]);
+
+      const { updatePhoto } = await import('./Member');
+
+      await expect(
+        callHandler(updatePhoto, { id: 'member-other-org', photoUrl: validPhoto }),
+      ).rejects.toThrow(ORPCError);
+    });
+
+    it('emits a failure audit when the service throws', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { updateMemberPhoto } = await import('@/services/MembersService');
+      const { audit } = await import('@/services/AuditService');
+
+      vi.mocked(guardRole).mockResolvedValue(mockAcademyOwnerContext);
+      vi.mocked(updateMemberPhoto).mockRejectedValue(new Error('DB error'));
+
+      const { updatePhoto } = await import('./Member');
+
+      await expect(
+        callHandler(updatePhoto, { id: 'member-1', photoUrl: validPhoto }),
+      ).rejects.toThrow('DB error');
+
+      expect(audit).toHaveBeenCalledWith(
+        mockAcademyOwnerContext,
+        AUDIT_ACTION.MEMBER_UPDATE_CONTACT,
+        AUDIT_ENTITY_TYPE.MEMBER,
+        expect.objectContaining({
+          entityId: 'member-1',
+          status: 'failure',
+          error: 'DB error',
+        }),
       );
     });
   });

--- a/src/routers/Member.ts
+++ b/src/routers/Member.ts
@@ -5,12 +5,12 @@ import { z } from 'zod';
 import { logger } from '@/libs/Logger';
 import { audit } from '@/services/AuditService';
 import { sendMemberConfirmationEmail } from '@/services/EmailService';
-import { addMemberMembership, changeMemberMembership, createMember, getAllMembershipPlans, getFamilyMembers, getHeadOfHouseholdMembers, getHOHForFamilyMember, getMemberPaymentMethods, getMembershipPlans, getMemberTransactions, linkFamilyMember, unlinkFamilyMember, updateMember, updateMemberContactInfo, updateMemberStatus } from '@/services/MembersService';
+import { addMemberMembership, changeMemberMembership, createMember, getAllMembershipPlans, getFamilyMembers, getHeadOfHouseholdMembers, getHOHForFamilyMember, getMemberPaymentMethods, getMembershipPlans, getMemberTransactions, linkFamilyMember, unlinkFamilyMember, updateMember, updateMemberContactInfo, updateMemberPhoto, updateMemberStatus } from '@/services/MembersService';
 import { generatePdfFilename } from '@/services/WaiverPdfService';
 import { generateWaiverPdfBuffer } from '@/services/WaiverPdfService.server';
 import { AUDIT_ACTION, AUDIT_ENTITY_TYPE } from '@/types/Audit';
 import { ORG_ROLE } from '@/types/Auth';
-import { DeleteMemberValidation, EditMemberValidation, GetHOHForMemberValidation, GetHOHPaymentMethodsValidation, LinkFamilyMemberValidation, ListFamilyMembersValidation, MemberPaymentMethodsValidation, MemberTransactionsValidation, MemberValidation, SearchHOHValidation, SendConfirmationEmailValidation, UnlinkFamilyMemberValidation, UpdateMemberContactInfoValidation, UpdateMemberTypeValidation } from '@/validations/MemberValidation';
+import { DeleteMemberValidation, EditMemberValidation, GetHOHForMemberValidation, GetHOHPaymentMethodsValidation, LinkFamilyMemberValidation, ListFamilyMembersValidation, MemberPaymentMethodsValidation, MemberTransactionsValidation, MemberValidation, SearchHOHValidation, SendConfirmationEmailValidation, UnlinkFamilyMemberValidation, UpdateMemberContactInfoValidation, UpdateMemberPhotoValidation, UpdateMemberTypeValidation } from '@/validations/MemberValidation';
 import { guardAuth, guardRole } from './AuthGuards';
 
 export const create = os
@@ -282,6 +282,52 @@ export const updateContactInfo = os
       await audit(context, AUDIT_ACTION.MEMBER_UPDATE_CONTACT, AUDIT_ENTITY_TYPE.MEMBER, {
         entityId: input.id,
         status: 'failure',
+        error: errorMessage,
+      });
+
+      throw error;
+    }
+  });
+
+export const updatePhoto = os
+  .input(UpdateMemberPhotoValidation)
+  .handler(async ({ input }) => {
+    const context = await guardRole(ORG_ROLE.ACADEMY_OWNER);
+    const photoCleared = input.photoUrl === null;
+    // Don't store the actual base64 in audit logs — they're large and we only
+    // need to know set vs clear for compliance. Use a sentinel.
+    const photoChange = {
+      photoUrl: {
+        before: '<photo>',
+        after: photoCleared ? null : '<photo>',
+      },
+    };
+
+    try {
+      const result = await updateMemberPhoto(input, context.orgId);
+
+      if (result.length === 0) {
+        throw new ORPCError('Member not found', { status: 404 });
+      }
+
+      logger.info(`Member photo updated: ${input.id}`, { photoCleared });
+
+      // Reuse MEMBER_UPDATE_CONTACT — photos are contact info; the changes
+      // field captures whether the photo was set or cleared.
+      await audit(context, AUDIT_ACTION.MEMBER_UPDATE_CONTACT, AUDIT_ENTITY_TYPE.MEMBER, {
+        entityId: input.id,
+        status: 'success',
+        changes: photoChange,
+      });
+
+      return {};
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+      await audit(context, AUDIT_ACTION.MEMBER_UPDATE_CONTACT, AUDIT_ENTITY_TYPE.MEMBER, {
+        entityId: input.id,
+        status: 'failure',
+        changes: photoChange,
         error: errorMessage,
       });
 

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -20,7 +20,7 @@ import { tags as classTags, list as listClasses } from './Classes';
 import { listActive as listActiveCoupons, list as listCoupons } from './Coupons';
 import { earningsChart, financialStats, memberAverageChart, membershipStats } from './Dashboard';
 import { list as listEvents } from './Events';
-import { addMembership, changeMembership, create as createMember, getHOHForMember, getHOHPaymentMethods, linkFamily, listAllMembershipPlans, listFamily, listMembershipPlans, listMemberTransactions, listPaymentMethods, remove as removeMember, restore as restoreMember, searchHOH, sendConfirmationEmail, unlinkFamily, updateLastAccessed, update as updateMember, updateContactInfo as updateMemberContactInfo, updateMemberType } from './Member';
+import { addMembership, changeMembership, create as createMember, getHOHForMember, getHOHPaymentMethods, linkFamily, listAllMembershipPlans, listFamily, listMembershipPlans, listMemberTransactions, listPaymentMethods, remove as removeMember, restore as restoreMember, searchHOH, sendConfirmationEmail, unlinkFamily, updateLastAccessed, update as updateMember, updateContactInfo as updateMemberContactInfo, updatePhoto as updateMemberPhoto, updateMemberType } from './Member';
 import { list as listMembers } from './Members';
 import { create as createNoteHandler, list as listNotes, remove as removeNoteHandler, update as updateNoteHandler } from './Notes';
 import { getTokenizationIframeConfig, processPayment, registerPaymentMethod } from './Payment';
@@ -59,6 +59,7 @@ export const router = {
     create: createMember,
     update: updateMember,
     updateContactInfo: updateMemberContactInfo,
+    updatePhoto: updateMemberPhoto,
     addMembership,
     changeMembership,
     listMembershipPlans,

--- a/src/services/MembersService.test.ts
+++ b/src/services/MembersService.test.ts
@@ -174,6 +174,58 @@ describe('MembersService', () => {
     });
   });
 
+  describe('updateMemberPhoto', () => {
+    it('writes the photoUrl and returns the updated id when the member is in the org', async () => {
+      const { db } = await import('@/libs/DB');
+      const setSpy = vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(() => Promise.resolve([{ id: 'member-123' }])),
+        })),
+      }));
+      vi.mocked(db.update).mockReturnValueOnce({ set: setSpy } as any);
+
+      const { updateMemberPhoto } = await import('./MembersService');
+      const result = await updateMemberPhoto({
+        id: 'member-123',
+        photoUrl: 'data:image/jpeg;base64,/9j/AA',
+      }, 'org-123');
+
+      expect(setSpy).toHaveBeenCalledWith({ photoUrl: 'data:image/jpeg;base64,/9j/AA' });
+      expect(result).toEqual([{ id: 'member-123' }]);
+    });
+
+    it('clears the photoUrl when null is passed', async () => {
+      const { db } = await import('@/libs/DB');
+      const setSpy = vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(() => Promise.resolve([{ id: 'member-123' }])),
+        })),
+      }));
+      vi.mocked(db.update).mockReturnValueOnce({ set: setSpy } as any);
+
+      const { updateMemberPhoto } = await import('./MembersService');
+      await updateMemberPhoto({ id: 'member-123', photoUrl: null }, 'org-123');
+
+      expect(setSpy).toHaveBeenCalledWith({ photoUrl: null });
+    });
+
+    it('returns an empty array when the member is not in the org (cross-tenant guard)', async () => {
+      const { db } = await import('@/libs/DB');
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn(() => ({
+          where: vi.fn(() => ({
+            returning: vi.fn(() => Promise.resolve([])),
+          })),
+        })),
+      } as any);
+
+      const { updateMemberPhoto } = await import('./MembersService');
+      const result = await updateMemberPhoto({ id: 'member-other-org', photoUrl: null }, 'org-123');
+
+      expect(result).toEqual([]);
+    });
+  });
+
   describe('getMemberPaymentMethods', () => {
     it('should return payment methods for a member', async () => {
       const { db } = await import('@/libs/DB');

--- a/src/services/MembersService.ts
+++ b/src/services/MembersService.ts
@@ -295,6 +295,24 @@ export function updateMember(member: UpdateMemberInput, organizationId: string) 
 }
 
 /**
+ * Update a member's photo (or clear it). photoUrl=null clears the column;
+ * a base64 data URL string overwrites it.
+ *
+ * Returns an array containing `{ id }` of the updated member, or an empty
+ * array when the member is not in the org (used by the router to map to 404).
+ */
+export function updateMemberPhoto(
+  input: { id: string; photoUrl: string | null },
+  organizationId: string,
+): Promise<{ id: string }[]> {
+  return db
+    .update(memberSchema)
+    .set({ photoUrl: input.photoUrl })
+    .where(and(eq(memberSchema.id, input.id), eq(memberSchema.organizationId, organizationId)))
+    .returning({ id: memberSchema.id });
+}
+
+/**
  * Update a member's status
  * @param memberId - The member ID to update
  * @param organizationId - The organization ID

--- a/src/validations/MemberValidation.test.ts
+++ b/src/validations/MemberValidation.test.ts
@@ -13,6 +13,7 @@ import {
   SendConfirmationEmailValidation,
   UnlinkFamilyMemberValidation,
   UpdateMemberContactInfoValidation,
+  UpdateMemberPhotoValidation,
   UpdateMemberTypeValidation,
 } from './MemberValidation';
 
@@ -638,6 +639,95 @@ describe('MemberValidation', () => {
       });
 
       expect(result.success).toBe(false);
+    });
+  });
+
+  describe('UpdateMemberPhotoValidation schema', () => {
+    const tinyJpegDataUrl = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD';
+
+    it('accepts a valid jpeg data URL', () => {
+      const result = UpdateMemberPhotoValidation.safeParse({
+        id: 'member-123',
+        photoUrl: tinyJpegDataUrl,
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts a valid png data URL', () => {
+      const result = UpdateMemberPhotoValidation.safeParse({
+        id: 'member-123',
+        photoUrl: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA',
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts null (clears the photo)', () => {
+      const result = UpdateMemberPhotoValidation.safeParse({
+        id: 'member-123',
+        photoUrl: null,
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an empty id', () => {
+      const result = UpdateMemberPhotoValidation.safeParse({
+        id: '',
+        photoUrl: tinyJpegDataUrl,
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a non-image data URL prefix (pdf)', () => {
+      const result = UpdateMemberPhotoValidation.safeParse({
+        id: 'member-123',
+        photoUrl: 'data:application/pdf;base64,JVBERi0xLjcK',
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a webp image (only jpeg/png/gif allowed)', () => {
+      const result = UpdateMemberPhotoValidation.safeParse({
+        id: 'member-123',
+        photoUrl: 'data:image/webp;base64,UklGRiYAAABXRUJQVlA4',
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a non-data-URL string', () => {
+      const result = UpdateMemberPhotoValidation.safeParse({
+        id: 'member-123',
+        photoUrl: 'https://example.com/photo.jpg',
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a photoUrl exceeding 300KB', () => {
+      const oversized = `data:image/jpeg;base64,${'A'.repeat(300_000)}`;
+      const result = UpdateMemberPhotoValidation.safeParse({
+        id: 'member-123',
+        photoUrl: oversized,
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts a photoUrl exactly at the 300KB cap', () => {
+      const prefix = 'data:image/jpeg;base64,';
+      const padding = 'A'.repeat(300_000 - prefix.length);
+      const atCap = `${prefix}${padding}`;
+      const result = UpdateMemberPhotoValidation.safeParse({
+        id: 'member-123',
+        photoUrl: atCap,
+      });
+
+      expect(result.success).toBe(true);
     });
   });
 });

--- a/src/validations/MemberValidation.ts
+++ b/src/validations/MemberValidation.ts
@@ -46,6 +46,17 @@ export const UpdateMemberContactInfoValidation = z.object({
   }).optional(),
 });
 
+export const UpdateMemberPhotoValidation = z.object({
+  id: z.string().min(1),
+  // null clears the photo. When set, must be a base64 data URL of a supported
+  // image type, capped at ~300KB so the request payload stays manageable.
+  photoUrl: z
+    .string()
+    .max(300_000, 'Photo data URL must be 300KB or less')
+    .regex(/^data:image\/(jpeg|png|gif);base64,/, 'photoUrl must be a data URL for an image (jpeg, png, gif)')
+    .nullable(),
+});
+
 export const MemberPaymentMethodsValidation = z.object({
   memberId: z.string().min(1),
 });


### PR DESCRIPTION
## Summary

- Add the missing edit/remove photo flow on the member detail page. Members could upload a photo during the Add Member wizard, but afterwards the avatar in the header was display-only — no edit affordance, no modal handled it, and the existing `updateContactInfo` validation explicitly excluded `photoUrl`.
- Adds a pencil overlay button on the avatar that opens a new `EditMemberPhotoModal`. The modal reuses the wizard's compression util and supports both replace-photo and remove-with-confirmation.
- Adds a dedicated `member.updatePhoto` ORPC endpoint (separate from `updateContactInfo` because the data-URL payload is large and needs its own validation) with `guardRole(ACADEMY_OWNER)`, audit logging via the existing `MEMBER_UPDATE_CONTACT` action, and cross-tenant 404 protection.

## Files

**Backend**
- `src/validations/MemberValidation.ts` — new `UpdateMemberPhotoValidation`. Regex-validates a JPEG/PNG/GIF data URL, capped at 300KB, accepts null for clear.
- `src/services/MembersService.ts` — new `updateMemberPhoto(input, organizationId)`. Org-scoped via the existing `(id, organizationId)` filter pattern; returns `[]` on cross-tenant access so the router can map to 404.
- `src/routers/Member.ts` — new `updatePhoto` handler. `guardRole(ACADEMY_OWNER)` (matches `updateContactInfo`), audits via `MEMBER_UPDATE_CONTACT` with `changes: { photoUrl: { before: '<photo>', after: '<photo>' | null } }` — sentinel strings keep the actual base64 (~150KB) out of audit logs while still letting dashboards distinguish set vs clear events.
- `src/routers/index.ts` — exposes `member.updatePhoto`.

**UI**
- `src/features/members/details/EditMemberPhotoModal.tsx` (new) — upload + preview + remove flow mirroring the wizard's `MemberPhotoStep`. Reuses `compressImageForStorage` from `src/utils/imageCompression.ts`. Plain `<img>` for the preview (next/image doesn't optimize data URLs anyway). Inline `AlertDialog` confirms photo removal. Server errors render in a destructive banner. Parent-driven `key` resets state per-open instead of an effect.
- `src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx` — pencil overlay button on the avatar in the member header. Modal mounted next to `EditContactInfoModal`. `invalidateMembersCache()` (called inside the modal on save) drives the avatar refresh through `useMembersCache` — no manual page reload needed.

**i18n** — new `EditMemberPhotoModal` namespace (17 keys) in `en.json` + `fr.json`.

**Tests** — 16 new tests, 4 existing audit/sub-suites updated for the new mock surface:
- `src/validations/MemberValidation.test.ts` — 9 tests covering boundary cases (prefix mismatch rejected, webp rejected, null accepted, oversize rejected, exact-cap accepted).
- `src/services/MembersService.test.ts` — 3 tests (set, clear, cross-org isolation).
- `src/routers/Member.test.ts` — 4 tests (success audit on set, success audit on clear, 404 on cross-tenant, failure audit on thrown error).
- `src/features/members/details/EditMemberPhotoModal.test.tsx` (new) — 9 tests (no-photo placeholder, save-disabled-until-pending-change, remove button visibility, confirm/cancel remove dialog flow, invalid file type banner, server error banner, onSaved/onClose callbacks).

## Notes

- Photos continue to be stored as base64 data URLs in `member.photo_url`. Migrating to image storage (Vercel Blob, etc.) is its own PR and isn't blocking #174 — the schema comment already notes `photoUrl` is "Legacy field - use imageId for new uploads".
- No schema migration. The `photo_url` column already accepts text/null; the only change is allowing it to be set/cleared via the new endpoint.

## Test plan

- [ ] Reset and reseed local: `rm -rf local.db && npm run db-server:file`, then run the seed script.
- [ ] `npm run lint && npm run check:types && npm run check:deps && npm run check:i18n && npm run test -- --coverage` — all pass with zero warnings.
- [ ] Member with no photo: header shows initials avatar + pencil overlay; click opens modal; upload PNG → preview appears → save → header shows the photo immediately (no manual refresh).
- [ ] Member with existing photo: open modal; "Change photo" replaces the preview; save persists; refresh page confirms persistence.
- [ ] Remove flow: click "Remove" → AlertDialog → Cancel keeps the photo; reopen → Confirm clears it; header reverts to initials.
- [ ] File type validation: try a `.pdf` → "Invalid file type" error appears, no upload.
- [ ] Oversized image: a 5MB JPEG still saves (compression brings it under cap). Verify in psql: `SELECT length(photo_url) FROM member WHERE id = '<id>';` ≤ 300_000.
- [ ] Audit trail: `SELECT action, status, details FROM audit_event WHERE entity_id = '<id>' ORDER BY created_at DESC LIMIT 5;` — `member.updateContact` rows show `changes.photoUrl.after = null` for clears, `'<photo>'` for sets.
- [ ] Layout regression: at narrow viewports the name/badge/Convert dropdown still align horizontally; pencil overlay stays anchored to the avatar's bottom-right.

Closes #174