### PR TITLE
feat(member info): fixed dob, attendance for member info and seed script

### DIFF
--- a/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx
+++ b/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx
@@ -8,6 +8,7 @@ import type { MemberPaymentMethodData } from '@/services/MembersService';
 import type { SignedWaiverWithTemplateName } from '@/services/WaiversService';
 import { useOrganization } from '@clerk/nextjs';
 import { ArrowRightLeft, Download, Pencil, Plus, Trash2 } from 'lucide-react';
+import Link from 'next/link';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
@@ -66,9 +67,13 @@ type FamilyMember = {
   name: string;
   relationship: string;
   photoUrl?: string;
-  membershipType: string;
+  /** Currently-active membership plan name, or null if none. */
+  planName: string | null;
+  /** Plan price in cents, or null if no active membership. */
+  planPrice: number | null;
+  /** Plan billing frequency (e.g. 'monthly'), or null. */
+  planFrequency: string | null;
   status: 'active' | 'on-hold' | 'cancelled';
-  amount: number;
 };
 
 type MembershipDetailsData = {
@@ -107,81 +112,6 @@ type MemberData = {
   familyMembers: FamilyMember[];
   membershipDetails: MembershipDetailsData;
 };
-
-// Mock attendance data for demonstration
-// Note: Class names and instructor names are for demonstration purposes only
-const MOCK_ATTENDANCE: AttendanceRecord[] = [
-  {
-    id: 'att-1',
-    className: 'BJJ Fundamentals I',
-    date: 'Jan 10, 2026',
-    time: '6:00 PM - 7:00 PM',
-    instructor: 'Coach Alex',
-  },
-  {
-    id: 'att-2',
-    className: 'BJJ Fundamentals II',
-    date: 'Jan 9, 2026',
-    time: '6:00 PM - 7:30 PM',
-    instructor: 'Professor Ivan',
-  },
-  {
-    id: 'att-3',
-    className: 'BJJ Fundamentals I',
-    date: 'Jan 8, 2026',
-    time: '6:00 PM - 7:00 PM',
-    instructor: 'Professor Jessica',
-  },
-  {
-    id: 'att-4',
-    className: 'Open Mat',
-    date: 'Jan 5, 2026',
-    time: '10:00 AM - 12:00 PM',
-    instructor: 'N/A',
-  },
-  {
-    id: 'att-5',
-    className: 'BJJ Intermediate',
-    date: 'Jan 6, 2026',
-    time: '7:00 PM - 8:00 PM',
-    instructor: 'Professor Joao',
-  },
-  {
-    id: 'att-6',
-    className: 'BJJ Fundamentals I',
-    date: 'Jan 3, 2026',
-    time: '6:00 PM - 7:00 PM',
-    instructor: 'Coach Alex',
-  },
-  {
-    id: 'att-7',
-    className: 'BJJ Fundamentals II',
-    date: 'Jan 2, 2026',
-    time: '6:00 PM - 7:30 PM',
-    instructor: 'Professor Ivan',
-  },
-  {
-    id: 'att-8',
-    className: 'BJJ Fundamentals I',
-    date: 'Dec 30, 2025',
-    time: '6:00 PM - 7:00 PM',
-    instructor: 'Coach Alex',
-  },
-  {
-    id: 'att-9',
-    className: 'Open Mat',
-    date: 'Dec 29, 2025',
-    time: '10:00 AM - 12:00 PM',
-    instructor: 'N/A',
-  },
-  {
-    id: 'att-10',
-    className: 'BJJ Intermediate',
-    date: 'Dec 27, 2025',
-    time: '7:00 PM - 8:00 PM',
-    instructor: 'Professor Joao',
-  },
-];
 
 // Mock punchcard info for demonstration (used when member has punchcard membership)
 const MOCK_PUNCHCARD_INFO: PunchcardInfo = {
@@ -549,6 +479,10 @@ export default function EditMemberPage() {
   const [notes, setNotes] = useState<MemberNote[]>([]);
   const [isLoadingNotes, setIsLoadingNotes] = useState(true);
 
+  // State for attendance
+  const [attendance, setAttendance] = useState<AttendanceRecord[]>([]);
+  const [isLoadingAttendance, setIsLoadingAttendance] = useState(true);
+
   // State for add family members modal
   const [isAddFamilyModalOpen, setIsAddFamilyModalOpen] = useState(false);
 
@@ -740,14 +674,15 @@ export default function EditMemberPage() {
     }
     try {
       const result = await client.member.listFamilyMembers({ memberId });
-      const mapped: FamilyMember[] = result.familyMembers.map((fm: { id: string; firstName: string; lastName: string; photoUrl: string | null; status: string | null; relationship: string }) => ({
+      const mapped: FamilyMember[] = result.familyMembers.map(fm => ({
         id: fm.id,
         name: `${fm.firstName} ${fm.lastName}`,
         relationship: fm.relationship,
         photoUrl: fm.photoUrl || undefined,
-        membershipType: 'Family Member',
+        planName: fm.planName ?? null,
+        planPrice: fm.planPrice ?? null,
+        planFrequency: fm.planFrequency ?? null,
         status: (fm.status === 'on-hold' ? 'on-hold' : fm.status === 'cancelled' ? 'cancelled' : 'active') as 'active' | 'on-hold' | 'cancelled',
-        amount: 0,
       }));
       setFamilyMembersData(mapped);
     } catch (err) {
@@ -792,6 +727,26 @@ export default function EditMemberPage() {
   useEffect(() => {
     fetchNotes();
   }, [fetchNotes]);
+
+  // Fetch attendance for this member
+  const fetchAttendance = useCallback(async () => {
+    if (!memberId) {
+      return;
+    }
+    setIsLoadingAttendance(true);
+    try {
+      const result = await client.attendance.list({ memberId });
+      setAttendance(result.records);
+    } catch (err) {
+      console.warn('[Edit Member] Failed to fetch attendance:', err);
+      setAttendance([]);
+    } finally {
+      setIsLoadingAttendance(false);
+    }
+  }, [memberId]);
+  useEffect(() => {
+    fetchAttendance();
+  }, [fetchAttendance]);
 
   const handleAddNote = useCallback(async (content: string) => {
     if (!memberId) {
@@ -1032,6 +987,17 @@ export default function EditMemberPage() {
               <Badge variant="destructive">{state.currentData.amountOverdue}</Badge>
             )}
           </div>
+          {isFamilyMember && currentHOH && (
+            <p className="text-sm text-muted-foreground">
+              {'Linked to '}
+              <Link
+                href={`/dashboard/members/${currentHOH.id}`}
+                className="font-medium text-foreground underline-offset-4 hover:underline"
+              >
+                {currentHOH.name}
+              </Link>
+            </p>
+          )}
         </div>
       </div>
 
@@ -1126,6 +1092,7 @@ export default function EditMemberPage() {
               memberId={memberId}
               initialEmail={state.currentData.contactInfo.email || ''}
               initialPhone={state.currentData.contactInfo.phone || ''}
+              initialDateOfBirth={currentMember?.dateOfBirth ? new Date(currentMember.dateOfBirth) : undefined}
               initialAddress={
                 state.currentData.contactInfo.street
                   ? {
@@ -1482,14 +1449,18 @@ export default function EditMemberPage() {
                       </div>
                       <div className="space-y-3 border-t border-border pt-4">
                         <div>
-                          <p className="text-xs font-semibold text-muted-foreground">{member.membershipType}</p>
+                          <p className="text-xs font-semibold text-muted-foreground">
+                            {member.planName ?? 'No active membership'}
+                          </p>
                           <Badge variant={getStatusColor(member.status)} className="mt-2">
                             {getStatusLabel(member.status)}
                           </Badge>
                         </div>
                         <p className="text-2xl font-bold text-primary">
-                          $
-                          {member.amount}
+                          {formatCurrency(member.planPrice ?? 0)}
+                          {member.planFrequency
+                            ? <span className="ml-1 text-sm font-normal text-muted-foreground">{`/ ${member.planFrequency}`}</span>
+                            : null}
                         </p>
                       </div>
                     </Card>
@@ -1524,7 +1495,8 @@ export default function EditMemberPage() {
         <MemberDetailAttendance
           memberId={memberId}
           memberName={state.currentData.memberName}
-          attendanceRecords={MOCK_ATTENDANCE}
+          attendanceRecords={attendance}
+          isLoading={isLoadingAttendance}
           punchcardInfo={currentMembership?.membershipPlan?.category === 'punchcard' ? MOCK_PUNCHCARD_INFO : null}
         />
       )}

--- a/src/features/members/details/EditContactInfoModal.test.tsx
+++ b/src/features/members/details/EditContactInfoModal.test.tsx
@@ -138,6 +138,75 @@ describe('EditContactInfoModal', () => {
     });
   });
 
+  describe('Date of Birth', () => {
+    it('renders the DOB input prefilled with the initial value (YYYY-MM-DD)', () => {
+      const props = {
+        ...mockProps,
+        initialDateOfBirth: new Date(1990, 0, 15),
+      };
+      render(<I18nWrapper><EditContactInfoModal {...props} /></I18nWrapper>);
+
+      const dobInput = document.querySelector('#edit-contact-dob') as HTMLInputElement;
+
+      expect(dobInput).not.toBeNull();
+      expect(dobInput.value).toBe('1990-01-15');
+    });
+
+    it('renders the DOB input empty when no initial value is provided', () => {
+      const props = {
+        ...mockProps,
+        initialDateOfBirth: undefined,
+      };
+      render(<I18nWrapper><EditContactInfoModal {...props} /></I18nWrapper>);
+
+      const dobInput = document.querySelector('#edit-contact-dob') as HTMLInputElement;
+
+      expect(dobInput).not.toBeNull();
+      expect(dobInput.value).toBe('');
+    });
+
+    it('sends dateOfBirth in the updateContactInfo payload when set', async () => {
+      const orpc = await import('@/libs/Orpc');
+      const updateContactInfo = vi.mocked(orpc.client.member.updateContactInfo);
+      updateContactInfo.mockClear();
+      updateContactInfo.mockResolvedValue({});
+
+      const props = {
+        ...mockProps,
+        initialDateOfBirth: new Date(1990, 0, 15),
+      };
+      render(<I18nWrapper><EditContactInfoModal {...props} /></I18nWrapper>);
+
+      const submitButton = page.getByRole('button', { name: 'Save Changes' });
+      await userEvent.click(submitButton);
+
+      expect(updateContactInfo).toHaveBeenCalledWith(expect.objectContaining({
+        dateOfBirth: expect.any(Date),
+      }));
+    });
+
+    it('omits dateOfBirth from the payload when the input is left blank', async () => {
+      const orpc = await import('@/libs/Orpc');
+      const updateContactInfo = vi.mocked(orpc.client.member.updateContactInfo);
+      updateContactInfo.mockClear();
+      updateContactInfo.mockResolvedValue({});
+
+      const props = {
+        ...mockProps,
+        initialDateOfBirth: undefined,
+      };
+      render(<I18nWrapper><EditContactInfoModal {...props} /></I18nWrapper>);
+
+      const submitButton = page.getByRole('button', { name: 'Save Changes' });
+      await userEvent.click(submitButton);
+
+      const payload = updateContactInfo.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+
+      expect(payload).toBeDefined();
+      expect(payload).not.toHaveProperty('dateOfBirth');
+    });
+  });
+
   describe('Modal visibility', () => {
     it('should not render when isOpen is false', () => {
       const closedProps = {

--- a/src/features/members/details/EditContactInfoModal.tsx
+++ b/src/features/members/details/EditContactInfoModal.tsx
@@ -37,6 +37,7 @@ type EditContactInfoModalProps = {
   memberId: string;
   initialEmail: string;
   initialPhone: string;
+  initialDateOfBirth?: Date;
   initialAddress?: Address;
 };
 
@@ -46,12 +47,25 @@ const isValidEmail = (email: string): boolean => {
   return EMAIL_REGEX.test(email);
 };
 
+function dateToInputValue(date: Date | undefined): string {
+  if (!date) {
+    return '';
+  }
+  // Anchor on local timezone so a date picked in the UI persists as the same
+  // calendar day rather than shifting based on UTC offset.
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 export function EditContactInfoModal({
   isOpen,
   onClose,
   memberId,
   initialEmail,
   initialPhone,
+  initialDateOfBirth,
   initialAddress,
 }: EditContactInfoModalProps) {
   const t = useTranslations('EditContactInfoModal');
@@ -59,6 +73,7 @@ export function EditContactInfoModal({
 
   const [email, setEmail] = useState(initialEmail);
   const [phone, setPhone] = useState(initialPhone);
+  const [dateOfBirth, setDateOfBirth] = useState<string>(() => dateToInputValue(initialDateOfBirth));
   const [address, setAddress] = useState<Address>({
     street: initialAddress?.street || '',
     apartment: initialAddress?.apartment || '',
@@ -108,6 +123,7 @@ export function EditContactInfoModal({
         id: memberId,
         email,
         phone: phone || null,
+        ...(dateOfBirth.trim() ? { dateOfBirth: new Date(dateOfBirth) } : {}),
         address: addressPayload,
       });
 
@@ -126,6 +142,7 @@ export function EditContactInfoModal({
   const handleCancel = () => {
     setEmail(initialEmail);
     setPhone(initialPhone);
+    setDateOfBirth(dateToInputValue(initialDateOfBirth));
     setAddress({
       street: initialAddress?.street || '',
       apartment: initialAddress?.apartment || '',
@@ -182,6 +199,19 @@ export function EditContactInfoModal({
               {isPhoneInvalid && (
                 <p className="text-xs text-destructive">{t('phone_error')}</p>
               )}
+            </div>
+
+            <div className="space-y-1.5">
+              <label htmlFor="edit-contact-dob" className="text-sm font-medium text-foreground">
+                {t('date_of_birth_label')}
+              </label>
+              <Input
+                id="edit-contact-dob"
+                type="date"
+                placeholder={t('date_of_birth_placeholder')}
+                value={dateOfBirth}
+                onChange={e => setDateOfBirth(e.target.value)}
+              />
             </div>
 
             <div className="border-t border-border pt-4">

--- a/src/features/members/details/MemberDetailAttendance.test.tsx
+++ b/src/features/members/details/MemberDetailAttendance.test.tsx
@@ -417,4 +417,31 @@ describe('MemberDetailAttendance', () => {
       expect(page.getByText('Class C').first()).toBeInTheDocument();
     });
   });
+
+  describe('Loading state', () => {
+    it('shows the loading message instead of the empty state when isLoading is true', () => {
+      render(
+        <MemberDetailAttendance
+          {...mockProps}
+          attendanceRecords={[]}
+          isLoading
+        />,
+      );
+
+      expect(page.getByText('loading')).toBeInTheDocument();
+      expect(page.getByText('no_attendance').elements().length).toBe(0);
+    });
+
+    it('falls back to the empty state when not loading and there are no records', () => {
+      render(
+        <MemberDetailAttendance
+          {...mockProps}
+          attendanceRecords={[]}
+          isLoading={false}
+        />,
+      );
+
+      expect(page.getByText('no_attendance')).toBeInTheDocument();
+    });
+  });
 });

--- a/src/features/members/details/MemberDetailAttendance.tsx
+++ b/src/features/members/details/MemberDetailAttendance.tsx
@@ -25,6 +25,7 @@ type MemberDetailAttendanceProps = {
   memberName: string;
   attendanceRecords: AttendanceRecord[];
   punchcardInfo: PunchcardInfo | null;
+  isLoading?: boolean;
 };
 
 type SortField = 'className' | 'date' | 'time' | 'instructor';
@@ -33,6 +34,7 @@ type SortDirection = 'asc' | 'desc';
 export function MemberDetailAttendance({
   attendanceRecords,
   punchcardInfo,
+  isLoading = false,
 }: MemberDetailAttendanceProps) {
   const t = useTranslations('MemberDetailAttendance');
   const [sortField, setSortField] = useState<SortField>('date');
@@ -169,138 +171,144 @@ export function MemberDetailAttendance({
             </div>
           </div>
         )}
-        {attendanceRecords.length === 0
+        {isLoading
           ? (
               <div className="flex items-center justify-center py-12">
-                <p className="text-muted-foreground">{t('no_attendance')}</p>
+                <p className="text-muted-foreground">{t('loading')}</p>
               </div>
             )
-          : filteredAndSortedRecords.length === 0
+          : attendanceRecords.length === 0
             ? (
                 <div className="flex items-center justify-center py-12">
-                  <p className="text-muted-foreground">{t('no_matching_attendance')}</p>
+                  <p className="text-muted-foreground">{t('no_attendance')}</p>
                 </div>
               )
-            : (
-                <>
-                  {/* Desktop Table View */}
-                  <div className="hidden overflow-x-auto lg:block">
-                    <table className="w-full">
-                      <thead>
-                        <tr className="border-b border-border bg-secondary">
-                          <th className="px-6 py-3 text-left text-sm font-semibold text-foreground">
-                            <button
-                              type="button"
-                              onClick={() => handleSort('className')}
-                              className="flex cursor-pointer items-center gap-2 hover:text-foreground/80"
-                            >
-                              {t('table_class')}
-                              {renderSortIcon('className')}
-                            </button>
-                          </th>
-                          <th className="px-6 py-3 text-left text-sm font-semibold text-foreground">
-                            <button
-                              type="button"
-                              onClick={() => handleSort('date')}
-                              className="flex cursor-pointer items-center gap-2 hover:text-foreground/80"
-                            >
-                              {t('table_date')}
-                              {renderSortIcon('date')}
-                            </button>
-                          </th>
-                          <th className="px-6 py-3 text-left text-sm font-semibold text-foreground">
-                            <button
-                              type="button"
-                              onClick={() => handleSort('time')}
-                              className="flex cursor-pointer items-center gap-2 hover:text-foreground/80"
-                            >
-                              {t('table_time')}
-                              {renderSortIcon('time')}
-                            </button>
-                          </th>
-                          <th className="px-6 py-3 text-left text-sm font-semibold text-foreground">
-                            <button
-                              type="button"
-                              onClick={() => handleSort('instructor')}
-                              className="flex cursor-pointer items-center gap-2 hover:text-foreground/80"
-                            >
-                              {t('table_instructor')}
-                              {renderSortIcon('instructor')}
-                            </button>
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {filteredAndSortedRecords.map(record => (
-                          <tr key={record.id} className="border-b border-border hover:bg-secondary/30">
-                            <td className="px-6 py-4 text-sm font-medium text-foreground">
-                              {record.className}
-                            </td>
-                            <td className="px-6 py-4 text-sm text-muted-foreground">
-                              {record.date}
-                            </td>
-                            <td className="px-6 py-4 text-sm text-muted-foreground">
-                              {record.time}
-                            </td>
-                            <td className="px-6 py-4 text-sm text-foreground">
-                              {record.instructor}
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
+            : filteredAndSortedRecords.length === 0
+              ? (
+                  <div className="flex items-center justify-center py-12">
+                    <p className="text-muted-foreground">{t('no_matching_attendance')}</p>
                   </div>
+                )
+              : (
+                  <>
+                    {/* Desktop Table View */}
+                    <div className="hidden overflow-x-auto lg:block">
+                      <table className="w-full">
+                        <thead>
+                          <tr className="border-b border-border bg-secondary">
+                            <th className="px-6 py-3 text-left text-sm font-semibold text-foreground">
+                              <button
+                                type="button"
+                                onClick={() => handleSort('className')}
+                                className="flex cursor-pointer items-center gap-2 hover:text-foreground/80"
+                              >
+                                {t('table_class')}
+                                {renderSortIcon('className')}
+                              </button>
+                            </th>
+                            <th className="px-6 py-3 text-left text-sm font-semibold text-foreground">
+                              <button
+                                type="button"
+                                onClick={() => handleSort('date')}
+                                className="flex cursor-pointer items-center gap-2 hover:text-foreground/80"
+                              >
+                                {t('table_date')}
+                                {renderSortIcon('date')}
+                              </button>
+                            </th>
+                            <th className="px-6 py-3 text-left text-sm font-semibold text-foreground">
+                              <button
+                                type="button"
+                                onClick={() => handleSort('time')}
+                                className="flex cursor-pointer items-center gap-2 hover:text-foreground/80"
+                              >
+                                {t('table_time')}
+                                {renderSortIcon('time')}
+                              </button>
+                            </th>
+                            <th className="px-6 py-3 text-left text-sm font-semibold text-foreground">
+                              <button
+                                type="button"
+                                onClick={() => handleSort('instructor')}
+                                className="flex cursor-pointer items-center gap-2 hover:text-foreground/80"
+                              >
+                                {t('table_instructor')}
+                                {renderSortIcon('instructor')}
+                              </button>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {filteredAndSortedRecords.map(record => (
+                            <tr key={record.id} className="border-b border-border hover:bg-secondary/30">
+                              <td className="px-6 py-4 text-sm font-medium text-foreground">
+                                {record.className}
+                              </td>
+                              <td className="px-6 py-4 text-sm text-muted-foreground">
+                                {record.date}
+                              </td>
+                              <td className="px-6 py-4 text-sm text-muted-foreground">
+                                {record.time}
+                              </td>
+                              <td className="px-6 py-4 text-sm text-foreground">
+                                {record.instructor}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
 
-                  {/* Mobile Card View */}
-                  <div className="space-y-4 p-4 lg:hidden">
-                    {filteredAndSortedRecords.map(record => (
-                      <Card key={record.id} className="p-4">
-                        <div className="space-y-3">
-                          {/* Class Name Header */}
-                          <div className="border-b border-border pb-3">
-                            <div className="text-xs font-semibold text-muted-foreground">
-                              {t('table_class')}
+                    {/* Mobile Card View */}
+                    <div className="space-y-4 p-4 lg:hidden">
+                      {filteredAndSortedRecords.map(record => (
+                        <Card key={record.id} className="p-4">
+                          <div className="space-y-3">
+                            {/* Class Name Header */}
+                            <div className="border-b border-border pb-3">
+                              <div className="text-xs font-semibold text-muted-foreground">
+                                {t('table_class')}
+                              </div>
+                              <div className="mt-1 text-sm font-medium text-foreground">
+                                {record.className}
+                              </div>
                             </div>
-                            <div className="mt-1 text-sm font-medium text-foreground">
-                              {record.className}
-                            </div>
-                          </div>
 
-                          {/* Date and Time */}
-                          <div className="flex items-start justify-between">
+                            {/* Date and Time */}
+                            <div className="flex items-start justify-between">
+                              <div>
+                                <div className="text-xs font-semibold text-muted-foreground">
+                                  {t('table_date')}
+                                </div>
+                                <div className="mt-1 text-sm text-foreground">
+                                  {record.date}
+                                </div>
+                              </div>
+                              <div className="text-right">
+                                <div className="text-xs font-semibold text-muted-foreground">
+                                  {t('table_time')}
+                                </div>
+                                <div className="mt-1 text-sm text-foreground">
+                                  {record.time}
+                                </div>
+                              </div>
+                            </div>
+
+                            {/* Instructor */}
                             <div>
                               <div className="text-xs font-semibold text-muted-foreground">
-                                {t('table_date')}
+                                {t('table_instructor')}
                               </div>
                               <div className="mt-1 text-sm text-foreground">
-                                {record.date}
-                              </div>
-                            </div>
-                            <div className="text-right">
-                              <div className="text-xs font-semibold text-muted-foreground">
-                                {t('table_time')}
-                              </div>
-                              <div className="mt-1 text-sm text-foreground">
-                                {record.time}
+                                {record.instructor}
                               </div>
                             </div>
                           </div>
-
-                          {/* Instructor */}
-                          <div>
-                            <div className="text-xs font-semibold text-muted-foreground">
-                              {t('table_instructor')}
-                            </div>
-                            <div className="mt-1 text-sm text-foreground">
-                              {record.instructor}
-                            </div>
-                          </div>
-                        </div>
-                      </Card>
-                    ))}
-                  </div>
-                </>
-              )}
+                        </Card>
+                      ))}
+                    </div>
+                  </>
+                )}
       </div>
     </div>
   );

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1581,6 +1581,8 @@
     "phone_label": "Phone Number",
     "phone_placeholder": "(555) 123-4567",
     "phone_error": "Please enter a phone number",
+    "date_of_birth_label": "Date of Birth",
+    "date_of_birth_placeholder": "YYYY-MM-DD",
     "address_label": "Address",
     "street_label": "Street Address",
     "street_placeholder": "123 Main St",
@@ -1997,6 +1999,7 @@
   "MemberDetailAttendance": {
     "title": "Attendance History",
     "search_placeholder": "Search attendance...",
+    "loading": "Loading attendance...",
     "no_attendance": "No attendance records yet",
     "no_matching_attendance": "No attendance records match your search",
     "table_class": "Class",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1585,6 +1585,8 @@
     "phone_label": "Numéro de téléphone",
     "phone_placeholder": "(555) 123-4567",
     "phone_error": "Veuillez entrer un numéro de téléphone",
+    "date_of_birth_label": "Date de naissance",
+    "date_of_birth_placeholder": "AAAA-MM-JJ",
     "address_label": "Adresse",
     "street_label": "Adresse de la rue",
     "street_placeholder": "123 rue Principale",
@@ -2002,6 +2004,7 @@
   "MemberDetailAttendance": {
     "title": "Historique de présence",
     "search_placeholder": "Rechercher présence...",
+    "loading": "Chargement des présences...",
     "no_attendance": "Aucun enregistrement de présence",
     "no_matching_attendance": "Aucun enregistrement de présence ne correspond à votre recherche",
     "table_class": "Cours",

--- a/src/routers/Attendance.test.ts
+++ b/src/routers/Attendance.test.ts
@@ -1,0 +1,58 @@
+import type { AuditContext } from '@/types/Audit';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ORG_ROLE } from '@/types/Auth';
+
+vi.mock('@/libs/DB', () => ({ db: {} }));
+vi.mock('./AuthGuards', () => ({
+  guardRole: vi.fn(),
+}));
+vi.mock('@/services/AttendanceService', () => ({
+  listAttendanceForMember: vi.fn(),
+}));
+
+const frontDeskContext: AuditContext = {
+  userId: 'user-1',
+  orgId: 'org-1',
+  role: ORG_ROLE.FRONT_DESK,
+};
+
+function callHandler(handler: unknown, input?: unknown) {
+  const h = handler as { '~orpc': { handler: (args: Record<string, unknown>) => unknown } };
+  return h['~orpc'].handler({ input, context: undefined, errors: undefined });
+}
+
+describe('Attendance Router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('list', () => {
+    it('requires FRONT_DESK and forwards orgId to the service', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { listAttendanceForMember } = await import('@/services/AttendanceService');
+      vi.mocked(guardRole).mockResolvedValue(frontDeskContext);
+      const stub = [{ id: 'a1', className: 'BJJ', date: '2026-01-15', time: '18:00 – 19:00', instructor: 'N/A' }];
+      vi.mocked(listAttendanceForMember).mockResolvedValue(stub);
+
+      const { list } = await import('./Attendance');
+      const result = await callHandler(list, { memberId: 'm1' });
+
+      expect(guardRole).toHaveBeenCalledWith(ORG_ROLE.FRONT_DESK);
+      expect(listAttendanceForMember).toHaveBeenCalledWith('m1', 'org-1');
+      expect(result).toEqual({ records: stub });
+    });
+
+    it('returns an empty list when the service returns []', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { listAttendanceForMember } = await import('@/services/AttendanceService');
+      vi.mocked(guardRole).mockResolvedValue(frontDeskContext);
+      vi.mocked(listAttendanceForMember).mockResolvedValue([]);
+
+      const { list } = await import('./Attendance');
+      const result = await callHandler(list, { memberId: 'm-new' });
+
+      expect(result).toEqual({ records: [] });
+    });
+  });
+});

--- a/src/routers/Attendance.ts
+++ b/src/routers/Attendance.ts
@@ -1,0 +1,13 @@
+import { os } from '@orpc/server';
+import { listAttendanceForMember } from '@/services/AttendanceService';
+import { ORG_ROLE } from '@/types/Auth';
+import { ListAttendanceForMemberValidation } from '@/validations/AttendanceValidation';
+import { guardRole } from './AuthGuards';
+
+export const list = os
+  .input(ListAttendanceForMemberValidation)
+  .handler(async ({ input }) => {
+    const { orgId } = await guardRole(ORG_ROLE.FRONT_DESK);
+    const records = await listAttendanceForMember(input.memberId, orgId);
+    return { records };
+  });

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -1,3 +1,4 @@
+import { list as listAttendance } from './Attendance';
 import {
   categoryCreate,
   categoryList,
@@ -84,6 +85,9 @@ export const router = {
   },
   events: {
     list: listEvents,
+  },
+  attendance: {
+    list: listAttendance,
   },
   tags: {
     listAll: listAllTags,

--- a/src/scripts/seed.ts
+++ b/src/scripts/seed.ts
@@ -30,11 +30,14 @@ import {
   classSchema,
   classTagSchema,
   couponSchema,
+  couponUsageSchema,
   eventBillingSchema,
+  eventInstructorSchema,
   eventRegistrationSchema,
   eventSchema,
   eventSessionSchema,
   eventTagSchema,
+  familyMemberSchema,
   memberMembershipSchema,
   memberSchema,
   membershipPlanSchema,
@@ -847,16 +850,38 @@ async function clearSeededData(organizationId: string) {
   await db.delete(transactionSchema).where(eq(transactionSchema.organizationId, organizationId));
   await db.delete(paymentMethodSchema).where(sql`${paymentMethodSchema.memberId} IN (SELECT id FROM member WHERE organization_id = ${organizationId})`);
 
-  // Clear class and event dependencies
+  // Clear class and event dependencies, ordered by foreign-key depth so each
+  // delete only happens after everything that references it has been removed.
+
+  // 1) Tables that reference other "child" tables first.
+  // event_registration references event_billing, event_session, and event.
+  await db.delete(eventRegistrationSchema).where(sql`${eventRegistrationSchema.eventId} IN (SELECT id FROM event WHERE organization_id = ${organizationId})`);
+
+  // attendance references class_schedule_instance and event_session, but those
+  // schemas don't cascade — clear it before its FK targets.
   await db.delete(attendanceSchema).where(eq(attendanceSchema.organizationId, organizationId));
+
+  // class_enrollment references member + class.
   await db.delete(classEnrollmentSchema).where(sql`${classEnrollmentSchema.classId} IN (SELECT id FROM class WHERE organization_id = ${organizationId})`);
+
+  // class_schedule_exception references class_schedule_instance.
   await db.delete(classScheduleExceptionSchema).where(sql`${classScheduleExceptionSchema.classScheduleInstanceId} IN (SELECT csi.id FROM class_schedule_instance csi JOIN class c ON csi.class_id = c.id WHERE c.organization_id = ${organizationId})`);
+
+  // 2) Now safe to clear the schedule instances and event sessions/billings.
   await db.delete(classScheduleInstanceSchema).where(sql`${classScheduleInstanceSchema.classId} IN (SELECT id FROM class WHERE organization_id = ${organizationId})`);
   await db.delete(classInstructorSchema).where(sql`${classInstructorSchema.classId} IN (SELECT id FROM class WHERE organization_id = ${organizationId})`);
   await db.delete(classTagSchema).where(sql`${classTagSchema.classId} IN (SELECT id FROM class WHERE organization_id = ${organizationId})`);
   await db.delete(eventSessionSchema).where(sql`${eventSessionSchema.eventId} IN (SELECT id FROM event WHERE organization_id = ${organizationId})`);
   await db.delete(eventBillingSchema).where(sql`${eventBillingSchema.eventId} IN (SELECT id FROM event WHERE organization_id = ${organizationId})`);
+  await db.delete(eventInstructorSchema).where(sql`${eventInstructorSchema.eventId} IN (SELECT id FROM event WHERE organization_id = ${organizationId})`);
   await db.delete(eventTagSchema).where(sql`${eventTagSchema.eventId} IN (SELECT id FROM event WHERE organization_id = ${organizationId})`);
+
+  // 3) Member-side: coupon_usage and family_member reference member; clear
+  // them before clearing members.
+  await db.delete(couponUsageSchema).where(sql`${couponUsageSchema.memberId} IN (SELECT id FROM member WHERE organization_id = ${organizationId})`);
+  await db.delete(familyMemberSchema).where(sql`${familyMemberSchema.memberId} IN (SELECT id FROM member WHERE organization_id = ${organizationId})`);
+
+  // 4) Membership plans, tags, and members.
   await db.delete(membershipTagSchema).where(sql`${membershipTagSchema.membershipPlanId} IN (SELECT id FROM membership_plan WHERE organization_id = ${organizationId})`);
   await db.delete(memberMembershipSchema).where(sql`${memberMembershipSchema.memberId} IN (SELECT id FROM member WHERE organization_id = ${organizationId})`);
   await db.delete(addressSchema).where(sql`${addressSchema.memberId} IN (SELECT id FROM member WHERE organization_id = ${organizationId})`);
@@ -1619,7 +1644,63 @@ async function seedOrganization(organizationId: string) {
     });
   }
 
-  console.info(`  ✅ Seeded ${programsData.length} programs, ${allTags.length} tags, ${classesData.length} classes, ${eventsData.length} events, ${couponsData.length} coupons, ${membershipPlansData.length} membership plans, ${membersData.length} members, ${catalogCategoriesData.length} catalog categories, ${catalogItemsData.length} catalog items, ${waiverTemplatesData.length} waiver templates, ${signedWaiverCount} signed waivers, ${mergeFieldsData.length} merge fields, ${paymentMethodsData.length} payment methods, ${transactionCount} transactions`);
+  // 16. Seed Attendance Records
+  // Spreads recent attendance across active/trial members, drawing from the
+  // class schedule instances created above. Past_due / cancelled members get
+  // no attendance (matches the signed-waiver seeding rule).
+  console.info('  📋 Seeding attendance records...');
+  let attendanceCount = 0;
+
+  // Re-query the class schedule instances for this org since the IDs created
+  // earlier in this function were captured in a per-class local array.
+  const orgScheduleInstances = await db
+    .select({
+      id: classScheduleInstanceSchema.id,
+      classId: classScheduleInstanceSchema.classId,
+      dayOfWeek: classScheduleInstanceSchema.dayOfWeek,
+    })
+    .from(classScheduleInstanceSchema)
+    .innerJoin(classSchema, eq(classScheduleInstanceSchema.classId, classSchema.id))
+    .where(eq(classSchema.organizationId, organizationId));
+
+  if (orgScheduleInstances.length > 0) {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    for (let i = 0; i < memberIds.length; i++) {
+      const member = membersData[i]!;
+      const memberId = memberIds[i]!;
+      if (member.status !== 'active' && member.status !== 'trial') {
+        continue;
+      }
+
+      // 3 to 8 attendance rows per active member, deterministically based on index.
+      const rowCount = 3 + (i % 6);
+      for (let n = 0; n < rowCount; n++) {
+        const instance = orgScheduleInstances[(i * 7 + n) % orgScheduleInstances.length]!;
+        // Pick a date in the recent past (1..60 days ago) on the schedule's day-of-week.
+        const daysBack = ((i + n) % 60) + 1;
+        const attendanceDate = new Date(today);
+        attendanceDate.setDate(attendanceDate.getDate() - daysBack);
+        // Nudge to the schedule instance's day-of-week so the row makes sense.
+        const dayDelta = (attendanceDate.getDay() - instance.dayOfWeek + 7) % 7;
+        attendanceDate.setDate(attendanceDate.getDate() - dayDelta);
+
+        await db.insert(attendanceSchema).values({
+          id: randomUUID(),
+          organizationId,
+          memberId,
+          classScheduleInstanceId: instance.id,
+          attendanceDate,
+          checkInTime: attendanceDate,
+          checkInMethod: n % 4 === 0 ? 'kiosk' : 'manual',
+        }).onConflictDoNothing();
+        attendanceCount++;
+      }
+    }
+  }
+
+  console.info(`  ✅ Seeded ${programsData.length} programs, ${allTags.length} tags, ${classesData.length} classes, ${eventsData.length} events, ${couponsData.length} coupons, ${membershipPlansData.length} membership plans, ${membersData.length} members, ${catalogCategoriesData.length} catalog categories, ${catalogItemsData.length} catalog items, ${waiverTemplatesData.length} waiver templates, ${signedWaiverCount} signed waivers, ${mergeFieldsData.length} merge fields, ${paymentMethodsData.length} payment methods, ${transactionCount} transactions, ${attendanceCount} attendance records`);
 }
 
 async function main() {

--- a/src/services/AttendanceService.test.ts
+++ b/src/services/AttendanceService.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMock = {
+  select: vi.fn(),
+};
+
+vi.mock('@/libs/DB', () => ({ db: dbMock }));
+
+vi.mock('@/models/Schema', () => ({
+  attendanceSchema: {
+    id: 'id',
+    organizationId: 'organization_id',
+    memberId: 'member_id',
+    classScheduleInstanceId: 'class_schedule_instance_id',
+    eventSessionId: 'event_session_id',
+    attendanceDate: 'attendance_date',
+    instructorClerkId: 'instructor_clerk_id',
+  },
+  memberSchema: {
+    id: 'id',
+    organizationId: 'organization_id',
+  },
+  classScheduleInstanceSchema: {
+    id: 'id',
+    classId: 'class_id',
+    startTime: 'start_time',
+    endTime: 'end_time',
+  },
+  classSchema: {
+    id: 'id',
+    name: 'name',
+  },
+  eventSessionSchema: {
+    id: 'id',
+    eventId: 'event_id',
+    startTime: 'start_time',
+    endTime: 'end_time',
+  },
+  eventSchema: {
+    id: 'id',
+    name: 'name',
+  },
+}));
+
+// Mock chains used by listAttendanceForMember:
+//   Member-in-org check:  select.from.where.limit
+//   Attendance query:     select.from.leftJoin × 4 .where.orderBy
+function memberInOrgChain(rows: unknown[]) {
+  const limit = vi.fn(() => Promise.resolve(rows));
+  const where = vi.fn(() => ({ limit }));
+  const from = vi.fn(() => ({ where }));
+  return { from };
+}
+
+function attendanceChain(rows: unknown[]) {
+  const orderBy = vi.fn(() => Promise.resolve(rows));
+  const where = vi.fn(() => ({ orderBy }));
+  const lj4 = vi.fn(() => ({ where }));
+  const lj3 = vi.fn(() => ({ leftJoin: lj4 }));
+  const lj2 = vi.fn(() => ({ leftJoin: lj3 }));
+  const lj1 = vi.fn(() => ({ leftJoin: lj2 }));
+  const from = vi.fn(() => ({ leftJoin: lj1 }));
+  return { from };
+}
+
+describe('AttendanceService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('listAttendanceForMember', () => {
+    it('returns [] when the member does not belong to the org', async () => {
+      dbMock.select.mockReturnValueOnce(memberInOrgChain([]));
+
+      const { listAttendanceForMember } = await import('./AttendanceService');
+      const result = await listAttendanceForMember('member-other-org', 'org-1');
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns formatted records when the member has class-based attendance', async () => {
+      dbMock.select.mockReturnValueOnce(memberInOrgChain([{ id: 'member-1' }]));
+      const date = new Date('2026-01-15T18:00:00Z');
+      dbMock.select.mockReturnValueOnce(attendanceChain([
+        {
+          id: 'att-1',
+          attendanceDate: date,
+          instructorClerkId: 'user_clerk_123',
+          className: 'BJJ Fundamentals I',
+          classStartTime: '18:00',
+          classEndTime: '19:00',
+          eventName: null,
+          eventStartTime: null,
+          eventEndTime: null,
+        },
+      ]));
+
+      const { listAttendanceForMember } = await import('./AttendanceService');
+      const result = await listAttendanceForMember('member-1', 'org-1');
+
+      expect(result).toEqual([
+        {
+          id: 'att-1',
+          className: 'BJJ Fundamentals I',
+          date: '2026-01-15',
+          time: '18:00 – 19:00',
+          instructor: 'user_clerk_123',
+        },
+      ]);
+    });
+
+    it('falls back to event fields when attendance is event-based', async () => {
+      dbMock.select.mockReturnValueOnce(memberInOrgChain([{ id: 'member-1' }]));
+      dbMock.select.mockReturnValueOnce(attendanceChain([
+        {
+          id: 'att-2',
+          attendanceDate: new Date('2026-02-10T00:00:00Z'),
+          instructorClerkId: null,
+          className: null,
+          classStartTime: null,
+          classEndTime: null,
+          eventName: 'Black Belt Seminar',
+          eventStartTime: '10:00',
+          eventEndTime: '14:00',
+        },
+      ]));
+
+      const { listAttendanceForMember } = await import('./AttendanceService');
+      const result = await listAttendanceForMember('member-1', 'org-1');
+
+      expect(result[0]).toEqual({
+        id: 'att-2',
+        className: 'Black Belt Seminar',
+        date: '2026-02-10',
+        time: '10:00 – 14:00',
+        instructor: 'N/A',
+      });
+    });
+
+    it('returns [] when the member has no attendance', async () => {
+      dbMock.select.mockReturnValueOnce(memberInOrgChain([{ id: 'member-1' }]));
+      dbMock.select.mockReturnValueOnce(attendanceChain([]));
+
+      const { listAttendanceForMember } = await import('./AttendanceService');
+      const result = await listAttendanceForMember('member-1', 'org-1');
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/services/AttendanceService.ts
+++ b/src/services/AttendanceService.ts
@@ -1,0 +1,85 @@
+import { and, desc, eq } from 'drizzle-orm';
+import { db } from '@/libs/DB';
+import {
+  attendanceSchema,
+  classScheduleInstanceSchema,
+  classSchema,
+  eventSchema,
+  eventSessionSchema,
+  memberSchema,
+} from '@/models/Schema';
+
+export type AttendanceRecord = {
+  id: string;
+  className: string; // class.name OR event.name
+  date: string; // ISO date string ('YYYY-MM-DD'); the component formats for display
+  time: string; // 'HH:MM – HH:MM' from the schedule instance OR event session
+  instructor: string; // Clerk user id, or 'N/A' when none recorded
+};
+
+/**
+ * List attendance records for a member, scoped to the given organization.
+ * Returns an empty array when the member doesn't belong to the org (cross-tenant
+ * safety), or when the member simply has no attendance recorded yet.
+ *
+ * Joins:
+ *   attendance → class_schedule_instance → class   (when class-based)
+ *             → event_session            → event   (when event-based)
+ *
+ * One left-join chain per source so a row missing one side still appears.
+ */
+export async function listAttendanceForMember(
+  memberId: string,
+  organizationId: string,
+): Promise<AttendanceRecord[]> {
+  // Confirm the member is in the org before reading their attendance. Mirrors
+  // the cross-tenant guard pattern used in NotesService.listNotesForMember.
+  const memberRows = await db
+    .select({ id: memberSchema.id })
+    .from(memberSchema)
+    .where(and(eq(memberSchema.id, memberId), eq(memberSchema.organizationId, organizationId)))
+    .limit(1);
+
+  if (memberRows.length === 0) {
+    return [];
+  }
+
+  const rows = await db
+    .select({
+      id: attendanceSchema.id,
+      attendanceDate: attendanceSchema.attendanceDate,
+      instructorClerkId: attendanceSchema.instructorClerkId,
+      // Class-based fields (null when this attendance was for an event)
+      className: classSchema.name,
+      classStartTime: classScheduleInstanceSchema.startTime,
+      classEndTime: classScheduleInstanceSchema.endTime,
+      // Event-based fields (null when this attendance was for a class)
+      eventName: eventSchema.name,
+      eventStartTime: eventSessionSchema.startTime,
+      eventEndTime: eventSessionSchema.endTime,
+    })
+    .from(attendanceSchema)
+    .leftJoin(classScheduleInstanceSchema, eq(attendanceSchema.classScheduleInstanceId, classScheduleInstanceSchema.id))
+    .leftJoin(classSchema, eq(classScheduleInstanceSchema.classId, classSchema.id))
+    .leftJoin(eventSessionSchema, eq(attendanceSchema.eventSessionId, eventSessionSchema.id))
+    .leftJoin(eventSchema, eq(eventSessionSchema.eventId, eventSchema.id))
+    .where(and(
+      eq(attendanceSchema.memberId, memberId),
+      eq(attendanceSchema.organizationId, organizationId),
+    ))
+    .orderBy(desc(attendanceSchema.attendanceDate));
+
+  return rows.map((r) => {
+    const name = r.className ?? r.eventName ?? 'Unknown class';
+    const start = r.classStartTime ?? r.eventStartTime;
+    const end = r.classEndTime ?? r.eventEndTime;
+    const time = start && end ? `${start} – ${end}` : '';
+    return {
+      id: r.id,
+      className: name,
+      date: r.attendanceDate.toISOString().slice(0, 10),
+      time,
+      instructor: r.instructorClerkId || 'N/A',
+    };
+  });
+}

--- a/src/services/MembersService.test.ts
+++ b/src/services/MembersService.test.ts
@@ -69,6 +69,17 @@ vi.mock('@/models/Schema', () => ({
     relatedMemberId: 'related_member_id',
     relationship: 'relationship',
   },
+  memberMembershipSchema: {
+    memberId: 'member_id',
+    membershipPlanId: 'membership_plan_id',
+    status: 'status',
+  },
+  membershipPlanSchema: {
+    id: 'id',
+    name: 'name',
+    price: 'price',
+    frequency: 'frequency',
+  },
 }));
 
 vi.mock('@/services/TransactionsService', () => ({}));
@@ -144,6 +155,53 @@ describe('MembersService', () => {
       const result = await updateMemberContactInfo(input, 'org-123');
 
       expect(result).toHaveLength(1);
+    });
+
+    it('writes dateOfBirth into the member set payload when provided', async () => {
+      const { db } = await import('@/libs/DB');
+      const setSpy = vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(() => Promise.resolve([{ id: 'member-123', email: 'updated@example.com' }])),
+        })),
+      }));
+      vi.mocked(db.update).mockReturnValueOnce({ set: setSpy } as any);
+
+      const { updateMemberContactInfo } = await import('./MembersService');
+      const dob = new Date('1990-01-15');
+      await updateMemberContactInfo({
+        id: 'member-123',
+        email: 'updated@example.com',
+        phone: '(555) 999-8888',
+        dateOfBirth: dob,
+      }, 'org-123');
+
+      expect(setSpy).toHaveBeenCalledWith(expect.objectContaining({
+        email: 'updated@example.com',
+        phone: '(555) 999-8888',
+        dateOfBirth: dob,
+      }));
+    });
+
+    it('does not include dateOfBirth in the set payload when omitted', async () => {
+      const { db } = await import('@/libs/DB');
+      const setSpy = vi.fn((..._args: unknown[]) => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(() => Promise.resolve([{ id: 'member-123', email: 'updated@example.com' }])),
+        })),
+      }));
+      vi.mocked(db.update).mockReturnValueOnce({ set: setSpy } as any);
+
+      const { updateMemberContactInfo } = await import('./MembersService');
+      await updateMemberContactInfo({
+        id: 'member-123',
+        email: 'updated@example.com',
+        phone: '(555) 999-8888',
+      }, 'org-123');
+
+      const payload = setSpy.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+
+      expect(payload).toBeDefined();
+      expect(payload).not.toHaveProperty('dateOfBirth');
     });
   });
 
@@ -384,31 +442,70 @@ describe('MembersService', () => {
   });
 
   describe('getFamilyMembers', () => {
-    it('should return family members for an HOH', async () => {
+    // Helper that mirrors the new query chain:
+    //   from.innerJoin.leftJoin.leftJoin.where
+    function mockChain(rows: unknown[]) {
+      const mockWhere = vi.fn(() => Promise.resolve(rows));
+      const mockLeftJoin2 = vi.fn(() => ({ where: mockWhere }));
+      const mockLeftJoin1 = vi.fn(() => ({ leftJoin: mockLeftJoin2 }));
+      const mockInnerJoin = vi.fn(() => ({ leftJoin: mockLeftJoin1 }));
+      const mockFrom = vi.fn(() => ({ innerJoin: mockInnerJoin }));
+      return { from: mockFrom };
+    }
+
+    it('should return family members for an HOH with plan info', async () => {
       const { db } = await import('@/libs/DB');
       const mockFamilyMembers = [
-        { id: 'fm-1', firstName: 'Alice', lastName: 'Doe', email: 'alice@test.com', photoUrl: null, status: 'active', relationship: 'family-member' },
+        {
+          id: 'fm-1',
+          firstName: 'Alice',
+          lastName: 'Doe',
+          email: 'alice@test.com',
+          photoUrl: null,
+          status: 'active',
+          relationship: 'family-member',
+          planName: 'Adult BJJ Monthly',
+          planPrice: 12000,
+          planFrequency: 'monthly',
+        },
       ];
-
-      const mockWhere = vi.fn(() => Promise.resolve(mockFamilyMembers));
-      const mockInnerJoin = vi.fn(() => ({ where: mockWhere }));
-      const mockFrom = vi.fn(() => ({ innerJoin: mockInnerJoin }));
-      vi.mocked(db.select).mockReturnValue({ from: mockFrom } as never);
+      vi.mocked(db.select).mockReturnValue(mockChain(mockFamilyMembers) as never);
 
       const { getFamilyMembers } = await import('./MembersService');
       const result = await getFamilyMembers('hoh-123');
 
       expect(result).toEqual(mockFamilyMembers);
-      expect(db.select).toHaveBeenCalled();
+    });
+
+    it('should return null plan fields when a family member has no active membership', async () => {
+      const { db } = await import('@/libs/DB');
+      const mockFamilyMembers = [
+        {
+          id: 'fm-1',
+          firstName: 'Bob',
+          lastName: 'Doe',
+          email: 'bob@test.com',
+          photoUrl: null,
+          status: 'active',
+          relationship: 'family-member',
+          planName: null,
+          planPrice: null,
+          planFrequency: null,
+        },
+      ];
+      vi.mocked(db.select).mockReturnValue(mockChain(mockFamilyMembers) as never);
+
+      const { getFamilyMembers } = await import('./MembersService');
+      const result = await getFamilyMembers('hoh-123');
+
+      expect(result[0]?.planName).toBeNull();
+      expect(result[0]?.planPrice).toBeNull();
+      expect(result[0]?.planFrequency).toBeNull();
     });
 
     it('should return empty array when HOH has no family members', async () => {
       const { db } = await import('@/libs/DB');
-
-      const mockWhere = vi.fn(() => Promise.resolve([]));
-      const mockInnerJoin = vi.fn(() => ({ where: mockWhere }));
-      const mockFrom = vi.fn(() => ({ innerJoin: mockInnerJoin }));
-      vi.mocked(db.select).mockReturnValue({ from: mockFrom } as never);
+      vi.mocked(db.select).mockReturnValue(mockChain([]) as never);
 
       const { getFamilyMembers } = await import('./MembersService');
       const result = await getFamilyMembers('hoh-no-family');

--- a/src/services/MembersService.ts
+++ b/src/services/MembersService.ts
@@ -334,6 +334,7 @@ type UpdateMemberContactInfoInput = {
   id: string;
   email: string;
   phone?: string | null;
+  dateOfBirth?: Date;
   address?: {
     street: string;
     apartment?: string;
@@ -345,21 +346,27 @@ type UpdateMemberContactInfoInput = {
 };
 
 /**
- * Update a member's contact information (email, phone, address)
+ * Update a member's contact information (email, phone, dateOfBirth, address)
  * @param input - Contact info data to update
  * @param organizationId - The organization ID
  * @returns The updated member record
  */
 export async function updateMemberContactInfo(input: UpdateMemberContactInfoInput, organizationId: string) {
-  const { id, email, phone, address } = input;
+  const { id, email, phone, dateOfBirth, address } = input;
 
-  // Update member email and phone
+  // Build the partial set so a missing dateOfBirth doesn't overwrite the
+  // existing column with undefined.
+  const memberUpdates: Record<string, unknown> = {
+    email,
+    phone: phone ?? null,
+  };
+  if (dateOfBirth !== undefined) {
+    memberUpdates.dateOfBirth = dateOfBirth;
+  }
+
   const memberResult = await db
     .update(memberSchema)
-    .set({
-      email,
-      phone: phone ?? null,
-    })
+    .set(memberUpdates)
     .where(and(eq(memberSchema.id, id), eq(memberSchema.organizationId, organizationId)))
     .returning();
 
@@ -650,11 +657,19 @@ export type FamilyMemberData = {
   photoUrl: string | null;
   status: string | null;
   relationship: string;
+  /** Currently-active membership plan name, or null if the family member has none. */
+  planName: string | null;
+  /** Plan price as a number, or null when there's no active membership. */
+  planPrice: number | null;
+  /** Plan billing frequency (e.g. 'monthly', 'annual'), or null. */
+  planFrequency: string | null;
 };
 
 /**
  * Get family members linked to a Head of Household.
- * Joins family_member with member to return full member details.
+ * Joins family_member with member, then left-joins the family member's
+ * currently-active membership and its plan so the row can render plan name +
+ * price without a follow-up query per member.
  */
 export async function getFamilyMembers(hohMemberId: string): Promise<FamilyMemberData[]> {
   return db
@@ -666,9 +681,17 @@ export async function getFamilyMembers(hohMemberId: string): Promise<FamilyMembe
       photoUrl: memberSchema.photoUrl,
       status: memberSchema.status,
       relationship: familyMemberSchema.relationship,
+      planName: membershipPlanSchema.name,
+      planPrice: membershipPlanSchema.price,
+      planFrequency: membershipPlanSchema.frequency,
     })
     .from(familyMemberSchema)
     .innerJoin(memberSchema, eq(familyMemberSchema.relatedMemberId, memberSchema.id))
+    .leftJoin(memberMembershipSchema, and(
+      eq(memberMembershipSchema.memberId, memberSchema.id),
+      eq(memberMembershipSchema.status, 'active'),
+    ))
+    .leftJoin(membershipPlanSchema, eq(memberMembershipSchema.membershipPlanId, membershipPlanSchema.id))
     .where(eq(familyMemberSchema.memberId, hohMemberId));
 }
 

--- a/src/validations/AttendanceValidation.test.ts
+++ b/src/validations/AttendanceValidation.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { ListAttendanceForMemberValidation } from './AttendanceValidation';
+
+describe('AttendanceValidation', () => {
+  describe('ListAttendanceForMemberValidation', () => {
+    it('accepts a valid memberId', () => {
+      const result = ListAttendanceForMemberValidation.safeParse({ memberId: 'member-123' });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an empty memberId', () => {
+      const result = ListAttendanceForMemberValidation.safeParse({ memberId: '' });
+
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a missing memberId', () => {
+      const result = ListAttendanceForMemberValidation.safeParse({});
+
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/src/validations/AttendanceValidation.ts
+++ b/src/validations/AttendanceValidation.ts
@@ -1,0 +1,5 @@
+import * as z from 'zod';
+
+export const ListAttendanceForMemberValidation = z.object({
+  memberId: z.string().min(1),
+});

--- a/src/validations/MemberValidation.test.ts
+++ b/src/validations/MemberValidation.test.ts
@@ -257,6 +257,49 @@ describe('MemberValidation', () => {
 
       expect(result.success).toBe(true);
     });
+
+    it('accepts a Date dateOfBirth', () => {
+      const result = UpdateMemberContactInfoValidation.safeParse({
+        id: 'member-123',
+        email: 'john.doe@example.com',
+        dateOfBirth: new Date('1990-01-15'),
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('coerces a string dateOfBirth into a Date', () => {
+      const result = UpdateMemberContactInfoValidation.safeParse({
+        id: 'member-123',
+        email: 'john.doe@example.com',
+        dateOfBirth: '1990-01-15',
+      });
+
+      expect(result.success).toBe(true);
+
+      if (result.success) {
+        expect(result.data.dateOfBirth).toBeInstanceOf(Date);
+      }
+    });
+
+    it('accepts a missing dateOfBirth (optional)', () => {
+      const result = UpdateMemberContactInfoValidation.safeParse({
+        id: 'member-123',
+        email: 'john.doe@example.com',
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an unparseable dateOfBirth string', () => {
+      const result = UpdateMemberContactInfoValidation.safeParse({
+        id: 'member-123',
+        email: 'john.doe@example.com',
+        dateOfBirth: 'not-a-date',
+      });
+
+      expect(result.success).toBe(false);
+    });
   });
 
   describe('MemberPaymentMethodsValidation schema', () => {

--- a/src/validations/MemberValidation.ts
+++ b/src/validations/MemberValidation.ts
@@ -36,6 +36,7 @@ export const UpdateMemberContactInfoValidation = z.object({
   id: z.string(),
   email: z.string().email(),
   phone: z.string().nullable().optional(),
+  dateOfBirth: z.coerce.date().optional(),
   address: z.object({
     street: z.string(),
     apartment: z.string().optional(),


### PR DESCRIPTION
## Summary

- Make Date of Birth editable on the member detail page (#130). It was captured at member creation but the edit-contact-info modal, validation, and service all omitted it, so the field was effectively immutable.
- Show the actual membership plan name and price on each family-member card under the HOH detail page (#141). Previously the card hardcoded "Family Member" and "$0" for every row regardless of the family member's actual plan.
- Show a "Linked to {HOH name}" backlink on the family-member detail page so the connection is visible from both ends (#140). The HOH was already fetched in component state for the convert flow — surfacing it in the header was the only piece missing.
- Replace the hardcoded `MOCK_ATTENDANCE` constant with a real per-member attendance fetch (#172, **Critical** severity). Brand-new members were appearing to have attended classes from 2025/2026 because the page passed the same fake list for everyone. Adds a new `attendance.list` ORPC endpoint, service, and validation following the same shape as the merged notes-tab work.
- Seed attendance records for active/trial members so the new tab has data to show out of the box.
- Fix a pre-existing FK-ordering bug in the seed `--reset` flow (`event_registration` blocks `event_billing` deletion, `coupon_usage` blocks `coupon`/`member` deletion, `family_member` blocks `member` deletion). `--reset` now works repeatably.

## Files

**#130 — DOB edit**
- `src/validations/MemberValidation.ts` — `UpdateMemberContactInfoValidation` accepts optional `dateOfBirth: z.coerce.date()`.
- `src/services/MembersService.ts` `updateMemberContactInfo` writes DOB only when present (no overwrite-with-undefined).
- `src/features/members/details/EditContactInfoModal.tsx` — new `<input type="date">` field, `initialDateOfBirth` prop, local-timezone formatter so a date picked in the UI persists as the same calendar day.
- `src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx` passes `currentMember.dateOfBirth` through.

**#141 — Family-row plan info**
- `src/services/MembersService.ts` `getFamilyMembers` now `leftJoin`s `member_membership` (active only) → `membership_plan` and returns `planName | planPrice | planFrequency`.
- The `FamilyMember` UI type and row JSX in the detail page consume the new fields. Empty plans render as "No active membership". Price is rendered through `formatCurrency` with a "/ {frequency}" suffix.

**#140 — HOH backlink**
- `src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx` renders `Linked to {HOH name}` (next/link) under the badges row when the member is a family-member.

**#172 — Real attendance**
- `src/validations/AttendanceValidation.ts` (new) — `ListAttendanceForMemberValidation`.
- `src/services/AttendanceService.ts` (new) — `listAttendanceForMember(memberId, organizationId)` with cross-tenant guard and a left-join chain that returns class-based OR event-based attendance in a single call.
- `src/routers/Attendance.ts` (new) — `attendance.list` handler, `guardRole(FRONT_DESK)`.
- `src/routers/index.ts` registers `attendance.list`.
- `src/features/members/details/MemberDetailAttendance.tsx` gained an optional `isLoading` prop with a "Loading attendance…" placeholder.
- `src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx` — `MOCK_ATTENDANCE` (74 lines of fake records) deleted; replaced with a `client.attendance.list` fetch + state mirroring the existing notes pattern.

**Seed**
- `src/scripts/seed.ts` — new step seeds 3–8 attendance records per active/trial member, attached to real `class_schedule_instance` rows and dated within the last 60 days. Attendance count surfaced in the final summary log.
- `src/scripts/seed.ts` `clearSeededData` — fixed FK-ordering bug. Added deletions for `event_registration`, `coupon_usage`, `family_member`, and `event_instructor` in dependency order, organised into 4 commented phases. `--reset` is now repeatable.

**i18n**
- `EditContactInfoModal.date_of_birth_label` and `EditContactInfoModal.date_of_birth_placeholder` (en + fr).
- `MemberDetailAttendance.loading` (en + fr).

**Tests** (4050 / 4050 passing across 205 test files)
- `MemberValidation.test.ts` — 4 new tests for the DOB schema (Date, string coercion, missing-optional, unparseable rejection).
- `MembersService.test.ts` — 2 new tests for `updateMemberContactInfo` DOB behaviour, plus 3 rewritten tests for `getFamilyMembers` covering the new plan-join shape and null-plan fallback.
- `EditContactInfoModal.test.tsx` — 4 new tests (renders pre-filled DOB, renders empty when no initial value, sends DOB in payload, omits DOB when blank).
- `AttendanceValidation.test.ts` (new) — 3 tests.
- `AttendanceService.test.ts` (new) — 4 tests covering cross-org guard, class-based join, event-based fallback, empty result.
- `Attendance.test.ts` (new) — 2 tests for the router.
- `MemberDetailAttendance.test.tsx` — 2 new tests for the loading branch.

## Test plan

- [ ] Reset and re-seed local: `rm -rf local.db && npm run db-server:file`, then `DATABASE_URL=… npx tsx src/scripts/seed.ts --orgId=org_xxx`. Confirm the final log includes `… N attendance records`.
- [ ] Run `--reset` against the populated DB twice in a row to verify the FK fix: `… npx tsx src/scripts/seed.ts --orgId=org_xxx --reset` should complete without `event_registration_…` violations.
- [ ] `npm run lint && npm run check:types && npm run check:deps && npm run check:i18n && npm run test -- --coverage` — all pass with zero warnings.
- [ ] Open any seeded member → click "Edit Details" → DOB input is present and pre-filled → change it → save → page reflects the new DOB.
- [ ] Open the seeded HOH → scroll to family members → each card shows the actual plan name and price (e.g. "Adult BJJ Monthly", "$120 / monthly"). A family member without a membership shows "No active membership" + "$0".
- [ ] Open a family-member detail page → header shows "Linked to {HOH name}" → click → navigates to the HOH page.
- [ ] **Attendance**: open a seeded active member → Attendance tab shows their real records, scoped to that member only. Open a brand-new member (no attendance) → tab shows the empty-state message, NOT 2025/2026 mock classes.
- [ ] Verify cross-tenant isolation: in psql, confirm `SELECT count(*) FROM attendance WHERE organization_id != 'org_xxx';` returns 0 changes after seeding org_xxx.

Closes #130
Closes #141
Closes #140
Closes #172