### PR TITLE
fix(waivers/members): fixed waivers filter and hoh to individual conversion flow

### DIFF
--- a/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx
+++ b/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx
@@ -1480,7 +1480,7 @@ export default function EditMemberPage() {
                   </div>
                   <h3 className="font-semibold text-foreground">Add Family Member</h3>
                   <p className="text-sm text-muted-foreground">Create a new family membership</p>
-                  <Button variant="outline" className="mt-2" onClick={() => setIsAddFamilyModalOpen(true)}>
+                  <Button variant="outline" className="mt-2" disabled={isLoadingPayment} onClick={() => setIsAddFamilyModalOpen(true)}>
                     Add Family Member
                   </Button>
                 </div>
@@ -1513,7 +1513,7 @@ export default function EditMemberPage() {
         />
       )}
 
-      {hohMemberData && (
+      {isAddFamilyModalOpen && hohMemberData && (
         <AddFamilyMembersModal
           isOpen={isAddFamilyModalOpen}
           onCloseAction={handleAddFamilyModalClose}

--- a/src/app/[locale]/(auth)/dashboard/waivers/page.test.tsx
+++ b/src/app/[locale]/(auth)/dashboard/waivers/page.test.tsx
@@ -1,0 +1,202 @@
+import type { WaiverTemplateWithStats } from '@/services/WaiversService';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { page, userEvent } from 'vitest/browser';
+import { I18nWrapper } from '@/lib/test-utils';
+import WaiversPage from './page';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    refresh: vi.fn(),
+    push: vi.fn(),
+    replace: vi.fn(),
+  }),
+}));
+
+const listTemplatesMock = vi.fn();
+
+vi.mock('@/libs/Orpc', () => ({
+  client: {
+    waivers: {
+      listTemplates: () => listTemplatesMock(),
+      // The page also calls listMergeFields when opening the merge fields sheet —
+      // not exercised in these tests but the import must exist.
+      listMergeFields: () => Promise.resolve({ mergeFields: [] }),
+      createTemplate: vi.fn(),
+    },
+  },
+}));
+
+const baseTimestamp = new Date('2026-01-15T12:00:00Z');
+
+function makeWaiver(overrides: Partial<WaiverTemplateWithStats> = {}): WaiverTemplateWithStats {
+  return {
+    id: 'w-1',
+    organizationId: 'org-1',
+    name: 'Standard Adult Waiver',
+    slug: 'standard-adult-waiver',
+    version: 1,
+    content: 'This is the waiver content for testing purposes.',
+    description: 'A waiver for adult members.',
+    isActive: true,
+    isDefault: false,
+    requiresGuardian: false,
+    guardianAgeThreshold: 16,
+    sortOrder: 0,
+    parentId: null,
+    createdAt: baseTimestamp,
+    updatedAt: baseTimestamp,
+    signedCount: 0,
+    membershipCount: 0,
+    ...overrides,
+  };
+}
+
+describe('WaiversPage status filter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listTemplatesMock.mockResolvedValue({
+      templates: [
+        makeWaiver({ id: 'w-active-1', name: 'Standard Adult Waiver', isActive: true }),
+        makeWaiver({ id: 'w-active-2', name: 'Kids Program Waiver', isActive: true }),
+        makeWaiver({ id: 'w-inactive-1', name: 'Legacy Liability Waiver', isActive: false }),
+      ],
+    });
+  });
+
+  it('renders all waivers by default', async () => {
+    render(<I18nWrapper><WaiversPage /></I18nWrapper>);
+
+    await expect.poll(() => page.getByText('Standard Adult Waiver').elements().length).toBeGreaterThan(0);
+    expect(page.getByText('Kids Program Waiver').first()).toBeInTheDocument();
+    expect(page.getByText('Legacy Liability Waiver').first()).toBeInTheDocument();
+  });
+
+  it('renders the status filter Select with all three options', async () => {
+    render(<I18nWrapper><WaiversPage /></I18nWrapper>);
+
+    await expect.poll(() => page.getByText('Standard Adult Waiver').elements().length).toBeGreaterThan(0);
+
+    const statusFilter = page.getByLabelText('Status');
+
+    expect(statusFilter).toBeInTheDocument();
+  });
+
+  it('filters to only active waivers when status=active', async () => {
+    render(<I18nWrapper><WaiversPage /></I18nWrapper>);
+
+    await expect.poll(() => page.getByText('Standard Adult Waiver').elements().length).toBeGreaterThan(0);
+
+    await userEvent.click(page.getByLabelText('Status'));
+    await userEvent.click(page.getByRole('option', { name: 'Active', exact: true }));
+
+    expect(page.getByText('Standard Adult Waiver').first()).toBeInTheDocument();
+    expect(page.getByText('Kids Program Waiver').first()).toBeInTheDocument();
+    expect(page.getByText('Legacy Liability Waiver').elements().length).toBe(0);
+  });
+
+  it('filters to only inactive waivers when status=inactive', async () => {
+    render(<I18nWrapper><WaiversPage /></I18nWrapper>);
+
+    await expect.poll(() => page.getByText('Standard Adult Waiver').elements().length).toBeGreaterThan(0);
+
+    await userEvent.click(page.getByLabelText('Status'));
+    await userEvent.click(page.getByRole('option', { name: 'Inactive' }));
+
+    expect(page.getByText('Legacy Liability Waiver').first()).toBeInTheDocument();
+    expect(page.getByText('Standard Adult Waiver').elements().length).toBe(0);
+    expect(page.getByText('Kids Program Waiver').elements().length).toBe(0);
+  });
+
+  it('combines search and status filters with AND logic', async () => {
+    render(<I18nWrapper><WaiversPage /></I18nWrapper>);
+
+    await expect.poll(() => page.getByText('Standard Adult Waiver').elements().length).toBeGreaterThan(0);
+
+    // Filter by active
+    await userEvent.click(page.getByLabelText('Status'));
+    await userEvent.click(page.getByRole('option', { name: 'Active', exact: true }));
+
+    // Type a search query that only matches one of the active waivers
+    const search = page.getByPlaceholder('Search waivers...');
+    await userEvent.type(search, 'Kids');
+
+    expect(page.getByText('Kids Program Waiver').first()).toBeInTheDocument();
+    expect(page.getByText('Standard Adult Waiver').elements().length).toBe(0);
+    expect(page.getByText('Legacy Liability Waiver').elements().length).toBe(0);
+  });
+
+  it('shows the no-results message when filters exclude everything', async () => {
+    render(<I18nWrapper><WaiversPage /></I18nWrapper>);
+
+    await expect.poll(() => page.getByText('Standard Adult Waiver').elements().length).toBeGreaterThan(0);
+
+    await userEvent.click(page.getByLabelText('Status'));
+    await userEvent.click(page.getByRole('option', { name: 'Inactive' }));
+
+    const search = page.getByPlaceholder('Search waivers...');
+    await userEvent.type(search, 'nonexistent xyz');
+
+    expect(page.getByText('No waivers match your filters')).toBeInTheDocument();
+  });
+});
+
+describe('WaiversPage status filter visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hides the status filter when only active waivers exist', async () => {
+    listTemplatesMock.mockResolvedValue({
+      templates: [
+        makeWaiver({ id: 'w-1', name: 'Standard Adult Waiver', isActive: true }),
+        makeWaiver({ id: 'w-2', name: 'Kids Program Waiver', isActive: true }),
+      ],
+    });
+
+    render(<I18nWrapper><WaiversPage /></I18nWrapper>);
+
+    await expect.poll(() => page.getByText('Standard Adult Waiver').elements().length).toBeGreaterThan(0);
+
+    expect(page.getByLabelText('Status').elements().length).toBe(0);
+  });
+
+  it('hides the status filter when only inactive waivers exist', async () => {
+    listTemplatesMock.mockResolvedValue({
+      templates: [
+        makeWaiver({ id: 'w-1', name: 'Legacy Waiver', isActive: false }),
+      ],
+    });
+
+    render(<I18nWrapper><WaiversPage /></I18nWrapper>);
+
+    await expect.poll(() => page.getByText('Legacy Waiver').elements().length).toBeGreaterThan(0);
+
+    expect(page.getByLabelText('Status').elements().length).toBe(0);
+  });
+
+  it('hides the status filter when there are no waivers at all', async () => {
+    listTemplatesMock.mockResolvedValue({ templates: [] });
+
+    render(<I18nWrapper><WaiversPage /></I18nWrapper>);
+
+    await expect.poll(() => page.getByText('No waivers found').elements().length).toBeGreaterThan(0);
+
+    expect(page.getByLabelText('Status').elements().length).toBe(0);
+  });
+
+  it('shows the status filter only when both active and inactive waivers exist', async () => {
+    listTemplatesMock.mockResolvedValue({
+      templates: [
+        makeWaiver({ id: 'w-1', name: 'Active Waiver', isActive: true }),
+        makeWaiver({ id: 'w-2', name: 'Inactive Waiver', isActive: false }),
+      ],
+    });
+
+    render(<I18nWrapper><WaiversPage /></I18nWrapper>);
+
+    await expect.poll(() => page.getByText('Active Waiver').elements().length).toBeGreaterThan(0);
+
+    expect(page.getByLabelText('Status')).toBeInTheDocument();
+  });
+});

--- a/src/app/[locale]/(auth)/dashboard/waivers/page.tsx
+++ b/src/app/[locale]/(auth)/dashboard/waivers/page.tsx
@@ -9,6 +9,13 @@ import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select/select';
 import { Skeleton } from '@/components/ui/skeleton';
 import { AddWaiverModal } from '@/features/waivers/AddWaiverModal';
 import { MergeFieldsManagement } from '@/features/waivers/MergeFieldsManagement';
@@ -22,6 +29,7 @@ export default function WaiversPage() {
   const [waivers, setWaivers] = useState<WaiverTemplateWithStats[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState<'all' | 'active' | 'inactive'>('all');
   const [isMergeFieldsSheetOpen, setIsMergeFieldsSheetOpen] = useState(false);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
 
@@ -79,17 +87,43 @@ export default function WaiversPage() {
     membershipsUsing: 0, // TODO: Count from membership_waiver table
   }), [waivers]);
 
-  // Filter waivers by search
+  const hasActiveWaivers = stats.active > 0;
+  const hasInactiveWaivers = stats.totalWaivers - stats.active > 0;
+  // Only render the filter when both statuses are present — otherwise the
+  // dropdown would be a no-op (one status + 'all' both show the same list).
+  const showStatusFilter = hasActiveWaivers && hasInactiveWaivers;
+
+  // If the selected filter is no longer applicable to the current waiver set
+  // (e.g. user picked 'inactive' then deleted the only inactive waiver), treat
+  // the filter as 'all' for filtering purposes without resetting state.
+  const effectiveStatusFilter: 'all' | 'active' | 'inactive'
+    = (statusFilter === 'active' && !hasActiveWaivers)
+      || (statusFilter === 'inactive' && !hasInactiveWaivers)
+      ? 'all'
+      : statusFilter;
+
+  // Filter waivers by search query and active/inactive status. Both filters
+  // AND together; an empty search and 'all' status returns the whole list.
   const filteredWaivers = useMemo(() => {
-    if (!search.trim()) {
-      return waivers;
-    }
-    const searchLower = search.toLowerCase();
-    return waivers.filter(waiver =>
-      waiver.name.toLowerCase().includes(searchLower)
-      || (waiver.description?.toLowerCase().includes(searchLower) ?? false),
-    );
-  }, [waivers, search]);
+    const searchLower = search.trim().toLowerCase();
+    return waivers.filter((waiver) => {
+      if (effectiveStatusFilter === 'active' && !waiver.isActive) {
+        return false;
+      }
+      if (effectiveStatusFilter === 'inactive' && waiver.isActive) {
+        return false;
+      }
+      if (!searchLower) {
+        return true;
+      }
+      return (
+        waiver.name.toLowerCase().includes(searchLower)
+        || (waiver.description?.toLowerCase().includes(searchLower) ?? false)
+      );
+    });
+  }, [waivers, search, effectiveStatusFilter]);
+
+  const hasActiveFilters = search.trim().length > 0 || effectiveStatusFilter !== 'all';
 
   const statsData = useMemo(() => [
     { id: 'total', label: t('total_waivers_label'), value: stats.totalWaivers },
@@ -133,17 +167,34 @@ export default function WaiversPage() {
         </Button>
       </div>
 
-      {/* Search Bar and Add Button */}
+      {/* Search Bar, Status Filter, and Add Button */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
-        <div className="relative min-w-50 flex-1 sm:max-w-xs">
-          <Search className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            type="text"
-            placeholder={t('search_placeholder')}
-            value={search}
-            onChange={e => setSearch(e.target.value)}
-            className="pl-9"
-          />
+        <div className="flex flex-1 flex-col gap-3 sm:flex-row sm:items-center sm:gap-3">
+          <div className="relative min-w-50 flex-1 sm:max-w-xs">
+            <Search className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              type="text"
+              placeholder={t('search_placeholder')}
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+          {showStatusFilter && (
+            <Select
+              value={statusFilter}
+              onValueChange={value => setStatusFilter(value as 'all' | 'active' | 'inactive')}
+            >
+              <SelectTrigger className="w-full sm:w-44" aria-label={t('filter_status_label')}>
+                <SelectValue placeholder={t('filter_status_label')} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">{t('filter_status_all')}</SelectItem>
+                <SelectItem value="active">{t('filter_status_active')}</SelectItem>
+                <SelectItem value="inactive">{t('filter_status_inactive')}</SelectItem>
+              </SelectContent>
+            </Select>
+          )}
         </div>
 
         {/* Add New Waiver Button */}
@@ -158,7 +209,7 @@ export default function WaiversPage() {
         {filteredWaivers.length === 0
           ? (
               <div className="col-span-full p-8 text-center text-muted-foreground">
-                {search
+                {hasActiveFilters
                   ? t('no_results_found')
                   : t('no_waivers_found')}
               </div>

--- a/src/features/members/conversion/ConvertConfirmStep.test.tsx
+++ b/src/features/members/conversion/ConvertConfirmStep.test.tsx
@@ -14,6 +14,10 @@ const baseData: ConvertMemberWizardData = {
   targetMemberType: 'individual',
   hasMembership: true,
   hasPaymentMethod: true,
+  // WizardStepData fields:
+  firstName: 'John',
+  lastName: 'Doe',
+  email: 'john@test.com',
   membershipPlanId: null,
   waiverTemplateId: null,
 };

--- a/src/features/members/conversion/ConvertMemberModal.tsx
+++ b/src/features/members/conversion/ConvertMemberModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { Coupon } from '@/features/marketing';
-import type { AddMemberWizardData, AppliedCoupon, MemberType, PaymentDeclineReason } from '@/hooks/useAddMemberWizard';
+import type { AppliedCoupon, MemberType, PaymentDeclineReason } from '@/hooks/useAddMemberWizard';
 import type { ConversionType, ConvertMemberWizardData } from '@/hooks/useConvertMemberWizard';
 import type { TokenizationIframeConfig } from '@/libs/IQPro';
 import { useTranslations } from 'next-intl';
@@ -10,9 +10,9 @@ import { useEffect, useRef, useState } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { useConvertMemberWizard } from '@/hooks/useConvertMemberWizard';
 import { client } from '@/libs/Orpc';
-import { MemberMembershipStep } from '../wizard/MemberMembershipStep';
-import { MemberPaymentStep } from '../wizard/MemberPaymentStep';
-import { MemberWaiverStep } from '../wizard/MemberWaiverStep';
+import { MembershipStep } from '../wizard/MembershipStep';
+import { PaymentStep } from '../wizard/PaymentStep';
+import { WaiverStep } from '../wizard/WaiverStep';
 import { ConvertConfirmStep } from './ConvertConfirmStep';
 import { ConvertSuccessStep } from './ConvertSuccessStep';
 
@@ -34,53 +34,6 @@ function computeDiscountedPrice(price: number | undefined, coupon: AppliedCoupon
     case 'Free Trial':
       return 0;
   }
-}
-
-/**
- * Adapt ConvertMemberWizardData to AddMemberWizardData shape
- * so existing step components (MemberMembershipStep, MemberWaiverStep, MemberPaymentStep) can be reused.
- */
-function toAddMemberData(data: ConvertMemberWizardData): AddMemberWizardData {
-  return {
-    memberType: data.targetMemberType,
-    firstName: data.memberName.split(' ')[0] ?? '',
-    lastName: data.memberName.split(' ').slice(1).join(' ') ?? '',
-    email: data.memberEmail,
-    phone: '',
-    dateOfBirth: data.memberDateOfBirth,
-    membershipPlanId: data.membershipPlanId,
-    membershipPlanPrice: data.membershipPlanPrice,
-    membershipPlanFrequency: data.membershipPlanFrequency,
-    membershipPlanName: data.membershipPlanName,
-    membershipPlanIsTrial: data.membershipPlanIsTrial,
-    membershipPlanContractLength: data.membershipPlanContractLength,
-    membershipPlanSignupFee: data.membershipPlanSignupFee,
-    waiverTemplateId: data.waiverTemplateId,
-    waiverSignatureDataUrl: data.waiverSignatureDataUrl,
-    waiverSignedByName: data.waiverSignedByName,
-    waiverSignedByRelationship: data.waiverSignedByRelationship,
-    waiverGuardianEmail: data.waiverGuardianEmail,
-    waiverSignedAt: data.waiverSignedAt,
-    waiverSkipped: data.waiverSkipped,
-    waiverRenderedContent: data.waiverRenderedContent,
-    paymentMethod: data.paymentMethod,
-    billingType: data.billingType,
-    cardholderName: data.cardholderName,
-    cardNumber: data.cardNumber,
-    cardToken: data.cardToken,
-    cardFirstSix: data.cardFirstSix,
-    cardLastFour: data.cardLastFour,
-    cardExpiry: data.cardExpiry,
-    cardCvc: data.cardCvc,
-    achAccountHolder: data.achAccountHolder,
-    achRoutingNumber: data.achRoutingNumber,
-    achAccountNumber: data.achAccountNumber,
-    achAccountType: data.achAccountType,
-    appliedCoupon: data.appliedCoupon,
-    paymentStatus: data.paymentStatus,
-    paymentDeclineReason: data.paymentDeclineReason,
-    paymentProcessed: data.paymentProcessed,
-  };
 }
 
 type ConvertMemberModalProps = {
@@ -383,55 +336,6 @@ export const ConvertMemberModal = ({
     }
   };
 
-  // Adapter for step components that expect AddMemberWizardData
-  const adaptedData = toAddMemberData(wizard.data);
-
-  // Fields shared between AddMemberWizardData and ConvertMemberWizardData
-  const SHARED_FIELDS = [
-    'membershipPlanId',
-    'membershipPlanPrice',
-    'membershipPlanFrequency',
-    'membershipPlanName',
-    'membershipPlanIsTrial',
-    'membershipPlanContractLength',
-    'membershipPlanSignupFee',
-    'waiverTemplateId',
-    'waiverSignatureDataUrl',
-    'waiverSignedByName',
-    'waiverSignedByRelationship',
-    'waiverGuardianEmail',
-    'waiverSignedAt',
-    'waiverSkipped',
-    'waiverRenderedContent',
-    'paymentMethod',
-    'billingType',
-    'cardholderName',
-    'cardNumber',
-    'cardToken',
-    'cardFirstSix',
-    'cardLastFour',
-    'cardExpiry',
-    'cardCvc',
-    'achAccountHolder',
-    'achRoutingNumber',
-    'achAccountNumber',
-    'achAccountType',
-    'appliedCoupon',
-    'paymentStatus',
-    'paymentDeclineReason',
-    'paymentProcessed',
-  ] as const;
-
-  const adaptedUpdate = (updates: Partial<AddMemberWizardData>) => {
-    const mapped: Partial<ConvertMemberWizardData> = {};
-    for (const key of SHARED_FIELDS) {
-      if (updates[key] !== undefined) {
-        (mapped as Record<string, unknown>)[key] = updates[key];
-      }
-    }
-    updateDataWithRef(mapped);
-  };
-
   return (
     <Dialog open={isOpen} onOpenChange={open => !open && handleCancel()}>
       <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-3xl">
@@ -449,9 +353,9 @@ export const ConvertMemberModal = ({
           )}
 
           {wizard.step === 'subscription' && (
-            <MemberMembershipStep
-              data={adaptedData}
-              onUpdate={adaptedUpdate}
+            <MembershipStep
+              data={wizard.data}
+              onUpdate={updateDataWithRef}
               onNext={wizard.nextStep}
               onBack={wizard.previousStep}
               onCancel={handleCancel}
@@ -460,9 +364,9 @@ export const ConvertMemberModal = ({
           )}
 
           {wizard.step === 'waiver' && (
-            <MemberWaiverStep
-              data={adaptedData}
-              onUpdate={adaptedUpdate}
+            <WaiverStep
+              data={wizard.data}
+              onUpdate={updateDataWithRef}
               onNext={wizard.nextStep}
               onBack={wizard.previousStep}
               onCancel={handleCancel}
@@ -472,9 +376,9 @@ export const ConvertMemberModal = ({
           )}
 
           {wizard.step === 'payment' && (
-            <MemberPaymentStep
-              data={adaptedData}
-              onUpdateAction={adaptedUpdate}
+            <PaymentStep
+              data={wizard.data}
+              onUpdateAction={updateDataWithRef}
               onNextAction={handleConvert}
               onBackAction={wizard.previousStep}
               onCancelAction={handleCancel}

--- a/src/features/members/conversion/ConvertSuccessStep.test.tsx
+++ b/src/features/members/conversion/ConvertSuccessStep.test.tsx
@@ -14,6 +14,10 @@ const baseData: ConvertMemberWizardData = {
   targetMemberType: 'individual',
   hasMembership: true,
   hasPaymentMethod: true,
+  // WizardStepData fields:
+  firstName: 'John',
+  lastName: 'Doe',
+  email: 'john@test.com',
   membershipPlanId: null,
   waiverTemplateId: null,
 };

--- a/src/features/members/wizard/AddFamilyMembersModal.tsx
+++ b/src/features/members/wizard/AddFamilyMembersModal.tsx
@@ -14,9 +14,9 @@ import { client } from '@/libs/Orpc';
 import { FamilyMemberSuccessStep } from './FamilyMemberSuccessStep';
 import { FamilyPaymentStep } from './FamilyPaymentStep';
 import { MemberDetailsStep } from './MemberDetailsStep';
-import { MemberMembershipStep } from './MemberMembershipStep';
 import { MemberPhotoStep } from './MemberPhotoStep';
-import { MemberWaiverStep } from './MemberWaiverStep';
+import { MembershipStep } from './MembershipStep';
+import { WaiverStep } from './WaiverStep';
 
 function computeDiscountedPrice(price: number | undefined, coupon: AppliedCoupon): number | undefined {
   if (price === undefined || price <= 0) {
@@ -467,7 +467,7 @@ export const AddFamilyMembersModal = ({
         )}
 
         {wizard.step === 'subscription' && (
-          <MemberMembershipStep
+          <MembershipStep
             data={wizard.data}
             onUpdate={wizard.updateData}
             onNext={wizard.nextStep}
@@ -478,7 +478,7 @@ export const AddFamilyMembersModal = ({
         )}
 
         {wizard.step === 'waiver' && (
-          <MemberWaiverStep
+          <WaiverStep
             data={wizard.data}
             onUpdate={wizard.updateData}
             onNext={wizard.nextStep}

--- a/src/features/members/wizard/AddMemberModal.tsx
+++ b/src/features/members/wizard/AddMemberModal.tsx
@@ -12,12 +12,12 @@ import { client } from '@/libs/Orpc';
 import { FamilyPaymentStep } from './FamilyPaymentStep';
 import { HOHSelectionStep } from './HOHSelectionStep';
 import { MemberDetailsStep } from './MemberDetailsStep';
-import { MemberMembershipStep } from './MemberMembershipStep';
-import { MemberPaymentStep } from './MemberPaymentStep';
 import { MemberPhotoStep } from './MemberPhotoStep';
+import { MembershipStep } from './MembershipStep';
 import { MemberSuccessStep } from './MemberSuccessStep';
 import { MemberTypeStep } from './MemberTypeStep';
-import { MemberWaiverStep } from './MemberWaiverStep';
+import { PaymentStep } from './PaymentStep';
+import { WaiverStep } from './WaiverStep';
 
 function computeDiscountedPrice(price: number | undefined, coupon: AppliedCoupon): number | undefined {
   if (price === undefined || price <= 0) {
@@ -397,7 +397,7 @@ export const AddMemberModal = ({ isOpen, onCloseAction, availableCoupons = [] }:
               ? `Membership: ${wizard.data.membershipPlanName}`
               : 'Membership payment',
             // Card fields (cardToken = PCI-compliant tokenized card; cardNumber = fallback)
-            // Read cardToken from ref because React setState in MemberPaymentStep is async
+            // Read cardToken from ref because React setState in PaymentStep is async
             // and wizard.data.cardToken may not yet reflect the tokenized value.
             ...(wizard.data.cardholderName && { cardholderName: wizard.data.cardholderName }),
             ...((cardTokenRef.current || wizard.data.cardToken) && { cardToken: cardTokenRef.current || wizard.data.cardToken }),
@@ -772,7 +772,7 @@ export const AddMemberModal = ({ isOpen, onCloseAction, availableCoupons = [] }:
           )}
 
           {wizard.step === 'subscription' && (
-            <MemberMembershipStep
+            <MembershipStep
               data={wizard.data}
               onUpdate={wizard.updateData}
               onNext={handleSubscriptionNext}
@@ -783,7 +783,7 @@ export const AddMemberModal = ({ isOpen, onCloseAction, availableCoupons = [] }:
           )}
 
           {wizard.step === 'waiver' && (
-            <MemberWaiverStep
+            <WaiverStep
               data={wizard.data}
               onUpdate={wizard.updateData}
               onNext={wizard.nextStep}
@@ -795,7 +795,7 @@ export const AddMemberModal = ({ isOpen, onCloseAction, availableCoupons = [] }:
           )}
 
           {wizard.step === 'payment' && (
-            <MemberPaymentStep
+            <PaymentStep
               data={wizard.data}
               onUpdateAction={updateDataWithRef}
               onNextAction={handleFinalNext}

--- a/src/features/members/wizard/FamilyPaymentStep.tsx
+++ b/src/features/members/wizard/FamilyPaymentStep.tsx
@@ -59,7 +59,7 @@ export const FamilyPaymentStep = ({
   tokenizationConfig,
 }: FamilyPaymentStepProps) => {
   const t = useTranslations('AddMemberWizard.FamilyPaymentStep');
-  const tPayment = useTranslations('AddMemberWizard.MemberPaymentStep');
+  const tPayment = useTranslations('AddMemberWizard.PaymentStep');
   const { resolvedTheme } = useTheme();
   const [touched, setTouched] = useState<Record<string, boolean>>({});
   const [tokenizing, setTokenizing] = useState(false);

--- a/src/features/members/wizard/MembershipStep.test.tsx
+++ b/src/features/members/wizard/MembershipStep.test.tsx
@@ -2,7 +2,7 @@ import type { AddMemberWizardData } from '@/hooks/useAddMemberWizard';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { page } from 'vitest/browser';
-import { MemberMembershipStep } from './MemberMembershipStep';
+import { MembershipStep } from './MembershipStep';
 
 // Mock translation keys
 const translationKeys: Record<string, string> = {
@@ -135,7 +135,7 @@ const mockMembershipPlans = [
   },
 ];
 
-describe('MemberMembershipStep', () => {
+describe('MembershipStep', () => {
   const mockData: AddMemberWizardData = {
     memberType: 'individual',
     firstName: 'John',
@@ -161,7 +161,7 @@ describe('MemberMembershipStep', () => {
   describe('Rendering', () => {
     it('should render the membership step title and subtitle', async () => {
       render(
-        <MemberMembershipStep
+        <MembershipStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -180,7 +180,7 @@ describe('MemberMembershipStep', () => {
       );
 
       render(
-        <MemberMembershipStep
+        <MembershipStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -194,7 +194,7 @@ describe('MemberMembershipStep', () => {
 
     it('should display 6 membership plans after loading', async () => {
       render(
-        <MemberMembershipStep
+        <MembershipStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -213,7 +213,7 @@ describe('MemberMembershipStep', () => {
 
     it('should display prices correctly', async () => {
       render(
-        <MemberMembershipStep
+        <MembershipStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -230,7 +230,7 @@ describe('MemberMembershipStep', () => {
 
     it('should show Free for trial plans', async () => {
       render(
-        <MemberMembershipStep
+        <MembershipStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -247,7 +247,7 @@ describe('MemberMembershipStep', () => {
 
     it('should show Trial badge for trial plans', async () => {
       render(
-        <MemberMembershipStep
+        <MembershipStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -264,7 +264,7 @@ describe('MemberMembershipStep', () => {
 
     it('should render Back, Cancel, and Next buttons', async () => {
       render(
-        <MemberMembershipStep
+        <MembershipStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -284,7 +284,7 @@ describe('MemberMembershipStep', () => {
   describe('Plan Selection', () => {
     it('should disable Next button when no plan is selected', async () => {
       render(
-        <MemberMembershipStep
+        <MembershipStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -307,7 +307,7 @@ describe('MemberMembershipStep', () => {
       };
 
       render(
-        <MemberMembershipStep
+        <MembershipStep
           data={dataWithSelection}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -325,7 +325,7 @@ describe('MemberMembershipStep', () => {
 
     it('should call onUpdate when a plan is clicked', async () => {
       render(
-        <MemberMembershipStep
+        <MembershipStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -357,7 +357,7 @@ describe('MemberMembershipStep', () => {
       };
 
       render(
-        <MemberMembershipStep
+        <MembershipStep
           data={dataWithSelection}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -378,7 +378,7 @@ describe('MemberMembershipStep', () => {
   describe('Navigation', () => {
     it('should call onBack when Back button is clicked', async () => {
       render(
-        <MemberMembershipStep
+        <MembershipStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -397,7 +397,7 @@ describe('MemberMembershipStep', () => {
 
     it('should call onCancel when Cancel button is clicked', async () => {
       render(
-        <MemberMembershipStep
+        <MembershipStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -421,7 +421,7 @@ describe('MemberMembershipStep', () => {
       };
 
       render(
-        <MemberMembershipStep
+        <MembershipStep
           data={dataWithSelection}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -444,7 +444,7 @@ describe('MemberMembershipStep', () => {
       mockListMembershipPlans.mockResolvedValue({ plans: [] });
 
       render(
-        <MemberMembershipStep
+        <MembershipStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -462,7 +462,7 @@ describe('MemberMembershipStep', () => {
       mockListMembershipPlans.mockRejectedValue(new Error('Network error'));
 
       render(
-        <MemberMembershipStep
+        <MembershipStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -484,7 +484,7 @@ describe('MemberMembershipStep', () => {
       };
 
       render(
-        <MemberMembershipStep
+        <MembershipStep
           data={dataWithSelection}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -507,7 +507,7 @@ describe('MemberMembershipStep', () => {
       };
 
       render(
-        <MemberMembershipStep
+        <MembershipStep
           data={dataWithSelection}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -528,7 +528,7 @@ describe('MemberMembershipStep', () => {
   describe('Plan Details Display', () => {
     it('should display plan categories', async () => {
       render(
-        <MemberMembershipStep
+        <MembershipStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -544,7 +544,7 @@ describe('MemberMembershipStep', () => {
 
     it('should display contract lengths', async () => {
       render(
-        <MemberMembershipStep
+        <MembershipStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -561,7 +561,7 @@ describe('MemberMembershipStep', () => {
 
     it('should display signup fees for paid plans', async () => {
       render(
-        <MemberMembershipStep
+        <MembershipStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -577,7 +577,7 @@ describe('MemberMembershipStep', () => {
 
     it('should display plan descriptions', async () => {
       render(
-        <MemberMembershipStep
+        <MembershipStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}

--- a/src/features/members/wizard/MembershipStep.tsx
+++ b/src/features/members/wizard/MembershipStep.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { AddMemberWizardData } from '@/hooks/useAddMemberWizard';
+import type { MemberType, WizardStepData } from '@/hooks/useAddMemberWizard';
 import type { MembershipPlanData } from '@/services/MembersService';
 import { Check } from 'lucide-react';
 import { useTranslations } from 'next-intl';
@@ -8,9 +8,22 @@ import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { client } from '@/libs/Orpc';
 
-type MemberMembershipStepProps = {
-  data: AddMemberWizardData;
-  onUpdate: (updates: Partial<AddMemberWizardData>) => void;
+/**
+ * The AddMember flow has a HOH-only "Skip for now" button that the convert
+ * flow doesn't need. We model this by accepting an optional `memberType` +
+ * `membershipSkipped` superset of `WizardStepData` — the convert flow simply
+ * omits them and the Skip button is hidden. Both AddMemberWizardData and
+ * ConvertMemberWizardData are assignable here because the extra fields are
+ * optional.
+ */
+type MembershipStepData = WizardStepData & {
+  memberType?: MemberType | null;
+  membershipSkipped?: boolean;
+};
+
+type MembershipStepProps = {
+  data: MembershipStepData;
+  onUpdate: (updates: Partial<MembershipStepData>) => void;
   onNext: () => void | Promise<void>;
   onBack: () => void;
   onCancel: () => void;
@@ -112,15 +125,15 @@ const mockMembershipPlans: MembershipPlanData[] = [
   },
 ];
 
-export const MemberMembershipStep = ({
+export const MembershipStep = ({
   data,
   onUpdate,
   onNext,
   onBack,
   onCancel,
   isLoading = false,
-}: MemberMembershipStepProps) => {
-  const t = useTranslations('AddMemberWizard.MemberMembershipStep');
+}: MembershipStepProps) => {
+  const t = useTranslations('AddMemberWizard.MembershipStep');
 
   const [membershipPlans, setMembershipPlans] = useState<MembershipPlanData[]>([]);
   const [isFetchingPlans, setIsFetchingPlans] = useState(true);

--- a/src/features/members/wizard/PaymentStep.test.tsx
+++ b/src/features/members/wizard/PaymentStep.test.tsx
@@ -3,7 +3,7 @@ import type { AddMemberWizardData } from '@/hooks/useAddMemberWizard';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { page, userEvent } from 'vitest/browser';
-import { MemberPaymentStep } from './MemberPaymentStep';
+import { PaymentStep } from './PaymentStep';
 
 // Mock next-intl
 const translationKeys: Record<string, string> = {
@@ -185,10 +185,10 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe('MemberPaymentStep', () => {
+describe('PaymentStep', () => {
   it('renders payment amount for monthly plan', () => {
     render(
-      <MemberPaymentStep {...defaultProps} />,
+      <PaymentStep {...defaultProps} />,
     );
 
     expect(page.getByText(/Pay \$160/)).toBeTruthy();
@@ -196,7 +196,7 @@ describe('MemberPaymentStep', () => {
 
   it('renders payment description with correct plan type', () => {
     render(
-      <MemberPaymentStep {...defaultProps} />,
+      <PaymentStep {...defaultProps} />,
     );
 
     const description = page.getByText(/monthly recurring membership/);
@@ -214,7 +214,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...annualProps} />,
+      <PaymentStep {...annualProps} />,
     );
 
     expect(page.getByText(/Pay \$1600/)).toBeTruthy();
@@ -222,7 +222,7 @@ describe('MemberPaymentStep', () => {
 
   it('shows credit card tab as selected by default', () => {
     render(
-      <MemberPaymentStep {...defaultProps} />,
+      <PaymentStep {...defaultProps} />,
     );
 
     const cardButton = Array.from(document.querySelectorAll('button')).find(btn => btn.textContent?.includes('Debit / Credit Card')) as HTMLButtonElement;
@@ -233,7 +233,7 @@ describe('MemberPaymentStep', () => {
   it('switches to ACH tab when clicked', async () => {
     const onUpdateAction = vi.fn();
     render(
-      <MemberPaymentStep
+      <PaymentStep
         {...defaultProps}
         onUpdateAction={onUpdateAction}
       />,
@@ -253,7 +253,7 @@ describe('MemberPaymentStep', () => {
 
   it('renders card form fields when card tab is selected', () => {
     render(
-      <MemberPaymentStep {...defaultProps} />,
+      <PaymentStep {...defaultProps} />,
     );
 
     expect(page.getByLabelText(/Name on card/)).toBeTruthy();
@@ -272,7 +272,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...achProps} />,
+      <PaymentStep {...achProps} />,
     );
 
     expect(page.getByLabelText(/Account holder name/)).toBeTruthy();
@@ -283,7 +283,7 @@ describe('MemberPaymentStep', () => {
 
   it('disables Next button when card form is incomplete', () => {
     render(
-      <MemberPaymentStep {...defaultProps} />,
+      <PaymentStep {...defaultProps} />,
     );
 
     const nextButton = Array.from(document.querySelectorAll('button')).find(btn => btn.textContent === 'Next') as HTMLButtonElement;
@@ -302,7 +302,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...achProps} />,
+      <PaymentStep {...achProps} />,
     );
 
     const nextButton = Array.from(document.querySelectorAll('button')).find(btn => btn.textContent === 'Next') as HTMLButtonElement;
@@ -323,7 +323,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...completedProps} />,
+      <PaymentStep {...completedProps} />,
     );
 
     const nextButton = Array.from(document.querySelectorAll('button')).find(btn => btn.textContent === 'Next') as HTMLButtonElement;
@@ -344,7 +344,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...completedProps} />,
+      <PaymentStep {...completedProps} />,
     );
 
     const nextButton = Array.from(document.querySelectorAll('button')).find(btn => btn.textContent === 'Next') as HTMLButtonElement;
@@ -355,7 +355,7 @@ describe('MemberPaymentStep', () => {
   it('calls onUpdateAction when card field changes', async () => {
     const onUpdateAction = vi.fn();
     render(
-      <MemberPaymentStep
+      <PaymentStep
         {...defaultProps}
         onUpdateAction={onUpdateAction}
       />,
@@ -381,7 +381,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...achProps} />,
+      <PaymentStep {...achProps} />,
     );
 
     const accountHolderInput = document.querySelector('input#achAccountHolder') as HTMLInputElement;
@@ -407,7 +407,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...completedProps} />,
+      <PaymentStep {...completedProps} />,
     );
 
     const nextButton = Array.from(document.querySelectorAll('button')).find(btn => btn.textContent === 'Next');
@@ -434,7 +434,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...declinedProps} />,
+      <PaymentStep {...declinedProps} />,
     );
 
     expect(page.getByText('Payment Declined')).toBeTruthy();
@@ -458,7 +458,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...declinedProps} />,
+      <PaymentStep {...declinedProps} />,
     );
 
     const button = page.getByText('Add Member Anyway');
@@ -474,7 +474,7 @@ describe('MemberPaymentStep', () => {
 
   it('shows "Next" button when payment status is not declined', () => {
     render(
-      <MemberPaymentStep {...defaultProps} />,
+      <PaymentStep {...defaultProps} />,
     );
 
     const button = page.getByText('Next');
@@ -497,7 +497,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...approvedProps} />,
+      <PaymentStep {...approvedProps} />,
     );
 
     expect(page.getByText('Payment Approved')).toBeTruthy();
@@ -507,7 +507,7 @@ describe('MemberPaymentStep', () => {
   it('calls onBackAction when back button is clicked', async () => {
     const onBackAction = vi.fn();
     render(
-      <MemberPaymentStep
+      <PaymentStep
         {...defaultProps}
         onBackAction={onBackAction}
       />,
@@ -524,7 +524,7 @@ describe('MemberPaymentStep', () => {
   it('calls onCancelAction when cancel button is clicked', async () => {
     const onCancelAction = vi.fn();
     render(
-      <MemberPaymentStep
+      <PaymentStep
         {...defaultProps}
         onCancelAction={onCancelAction}
       />,
@@ -552,7 +552,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...loadingProps} />,
+      <PaymentStep {...loadingProps} />,
     );
 
     const nextButton = Array.from(document.querySelectorAll('button')).find(btn => btn.textContent?.includes('Processing...')) as HTMLButtonElement;
@@ -574,7 +574,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...populatedProps} />,
+      <PaymentStep {...populatedProps} />,
     );
 
     const nameInput = document.querySelector('input#cardholderName') as HTMLInputElement;
@@ -601,7 +601,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...populatedProps} />,
+      <PaymentStep {...populatedProps} />,
     );
 
     const accountHolderInput = document.querySelector('input#achAccountHolder') as HTMLInputElement;
@@ -625,7 +625,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...invalidCvcProps} />,
+      <PaymentStep {...invalidCvcProps} />,
     );
 
     expect(page.getByText(/CVC\/CVV code is incorrect/)).toBeTruthy();
@@ -643,7 +643,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...expiredProps} />,
+      <PaymentStep {...expiredProps} />,
     );
 
     expect(page.getByText(/card has expired/)).toBeTruthy();
@@ -661,7 +661,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...declinedProps} />,
+      <PaymentStep {...declinedProps} />,
     );
 
     expect(page.getByText(/card was declined/)).toBeTruthy();
@@ -680,7 +680,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...achFailedProps} />,
+      <PaymentStep {...achFailedProps} />,
     );
 
     expect(page.getByText(/ACH transaction failed/)).toBeTruthy();
@@ -698,7 +698,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...genericDeclineProps} />,
+      <PaymentStep {...genericDeclineProps} />,
     );
 
     expect(page.getByText(/payment could not be processed/)).toBeTruthy();
@@ -714,7 +714,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...freeTrialProps} />,
+      <PaymentStep {...freeTrialProps} />,
     );
 
     expect(page.getByText(/Pay \$0/)).toBeTruthy();
@@ -730,7 +730,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...noSubProps} />,
+      <PaymentStep {...noSubProps} />,
     );
 
     expect(page.getByText(/Pay \$0/)).toBeTruthy();
@@ -746,7 +746,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...processingProps} />,
+      <PaymentStep {...processingProps} />,
     );
 
     expect(page.getByText(/Processing payment, please wait/)).toBeTruthy();
@@ -754,7 +754,7 @@ describe('MemberPaymentStep', () => {
 
   it('shows validation error for cardholder name after blur', async () => {
     render(
-      <MemberPaymentStep {...defaultProps} />,
+      <PaymentStep {...defaultProps} />,
     );
 
     const nameInput = document.querySelector('input#cardholderName') as HTMLInputElement;
@@ -783,7 +783,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...achProps} />,
+      <PaymentStep {...achProps} />,
     );
 
     const cardButton = Array.from(document.querySelectorAll('button')).find(btn => btn.textContent?.includes('Debit / Credit Card')) as HTMLButtonElement;
@@ -800,7 +800,7 @@ describe('MemberPaymentStep', () => {
   it('updates card number field', async () => {
     const onUpdateAction = vi.fn();
     render(
-      <MemberPaymentStep
+      <PaymentStep
         {...defaultProps}
         onUpdateAction={onUpdateAction}
       />,
@@ -817,7 +817,7 @@ describe('MemberPaymentStep', () => {
   it('updates card expiry field', async () => {
     const onUpdateAction = vi.fn();
     render(
-      <MemberPaymentStep
+      <PaymentStep
         {...defaultProps}
         onUpdateAction={onUpdateAction}
       />,
@@ -834,7 +834,7 @@ describe('MemberPaymentStep', () => {
   it('updates card CVC field', async () => {
     const onUpdateAction = vi.fn();
     render(
-      <MemberPaymentStep
+      <PaymentStep
         {...defaultProps}
         onUpdateAction={onUpdateAction}
       />,
@@ -860,7 +860,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...achProps} />,
+      <PaymentStep {...achProps} />,
     );
 
     const routingInput = document.querySelector('input#achRoutingNumber') as HTMLInputElement;
@@ -883,7 +883,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...achProps} />,
+      <PaymentStep {...achProps} />,
     );
 
     const accountInput = document.querySelector('input#achAccountNumber') as HTMLInputElement;
@@ -904,7 +904,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...annualProps} />,
+      <PaymentStep {...annualProps} />,
     );
 
     expect(page.getByText(/annual recurring membership/)).toBeTruthy();
@@ -924,7 +924,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...loadingProps} />,
+      <PaymentStep {...loadingProps} />,
     );
 
     const nameInput = document.querySelector('input#cardholderName') as HTMLInputElement;
@@ -939,7 +939,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...loadingProps} />,
+      <PaymentStep {...loadingProps} />,
     );
 
     const achButton = Array.from(document.querySelectorAll('button')).find(btn => btn.textContent?.includes('ACH Bank Account')) as HTMLButtonElement;
@@ -957,7 +957,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...achProps} />,
+      <PaymentStep {...achProps} />,
     );
 
     const accountHolderInput = document.querySelector('input#achAccountHolder') as HTMLInputElement;
@@ -979,7 +979,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...achProps} />,
+      <PaymentStep {...achProps} />,
     );
 
     const routingInput = document.querySelector('input#achRoutingNumber') as HTMLInputElement;
@@ -1001,7 +1001,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...achProps} />,
+      <PaymentStep {...achProps} />,
     );
 
     const accountInput = document.querySelector('input#achAccountNumber') as HTMLInputElement;
@@ -1025,7 +1025,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...priceProps} />,
+      <PaymentStep {...priceProps} />,
     );
 
     expect(page.getByText(/Pay \$149\.99/)).toBeTruthy();
@@ -1043,7 +1043,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...annualPriceProps} />,
+      <PaymentStep {...annualPriceProps} />,
     );
 
     expect(page.getByText(/year/)).toBeTruthy();
@@ -1061,7 +1061,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...yearlyPriceProps} />,
+      <PaymentStep {...yearlyPriceProps} />,
     );
 
     expect(page.getByText(/year/)).toBeTruthy();
@@ -1079,7 +1079,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...noneFrequencyProps} />,
+      <PaymentStep {...noneFrequencyProps} />,
     );
 
     // The plan description should show without a period text
@@ -1104,7 +1104,7 @@ describe('MemberPaymentStep', () => {
     };
 
     render(
-      <MemberPaymentStep {...declinedProps} />,
+      <PaymentStep {...declinedProps} />,
     );
 
     // Change card number to trigger reset
@@ -1136,7 +1136,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithCoupons} />,
+        <PaymentStep {...propsWithCoupons} />,
       );
 
       expect(page.getByText(/Apply Coupon/)).toBeTruthy();
@@ -1154,7 +1154,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithoutCoupons} />,
+        <PaymentStep {...propsWithoutCoupons} />,
       );
 
       // Should not find the coupon label
@@ -1175,7 +1175,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithZeroPrice} />,
+        <PaymentStep {...propsWithZeroPrice} />,
       );
 
       // Should not find the coupon label since price is 0
@@ -1196,7 +1196,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithCoupons} />,
+        <PaymentStep {...propsWithCoupons} />,
       );
 
       const select = document.querySelector('#couponSelect');
@@ -1223,7 +1223,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithAppliedCoupon} />,
+        <PaymentStep {...propsWithAppliedCoupon} />,
       );
 
       // Should show coupon applied alert
@@ -1250,7 +1250,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithAppliedCoupon} />,
+        <PaymentStep {...propsWithAppliedCoupon} />,
       );
 
       // Should show the original price crossed out ($160)
@@ -1279,7 +1279,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithPercentageCoupon} />,
+        <PaymentStep {...propsWithPercentageCoupon} />,
       );
 
       // 15% of $200 = $30 off, so final price = $170
@@ -1307,7 +1307,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithFixedCoupon} />,
+        <PaymentStep {...propsWithFixedCoupon} />,
       );
 
       // $50 off from $200 = $150
@@ -1335,7 +1335,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithFreeTrialCoupon} />,
+        <PaymentStep {...propsWithFreeTrialCoupon} />,
       );
 
       // Free trial makes payment $0
@@ -1358,7 +1358,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithCoupons} />,
+        <PaymentStep {...propsWithCoupons} />,
       );
 
       // Click on the select trigger to open dropdown
@@ -1383,7 +1383,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithoutCoupon} />,
+        <PaymentStep {...propsWithoutCoupon} />,
       );
 
       const couponAppliedText = Array.from(document.querySelectorAll('*')).find(el => el.textContent?.includes('Coupon Applied:'));
@@ -1404,7 +1404,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithCoupons} />,
+        <PaymentStep {...propsWithCoupons} />,
       );
 
       const selectTrigger = document.querySelector('#couponSelect');
@@ -1432,7 +1432,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithAppliedCoupon} />,
+        <PaymentStep {...propsWithAppliedCoupon} />,
       );
 
       // Coupon should still be applied
@@ -1461,7 +1461,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithLargeCoupon} />,
+        <PaymentStep {...propsWithLargeCoupon} />,
       );
 
       // Discount should be capped at the price, so final = $0
@@ -1486,7 +1486,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithMonthlyMembership} />,
+        <PaymentStep {...propsWithMonthlyMembership} />,
       );
 
       expect(page.getByText('Payment Schedule')).toBeTruthy();
@@ -1507,7 +1507,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithAnnualMembership} />,
+        <PaymentStep {...propsWithAnnualMembership} />,
       );
 
       expect(page.getByText('Payment Schedule')).toBeTruthy();
@@ -1528,7 +1528,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithTrialMembership} />,
+        <PaymentStep {...propsWithTrialMembership} />,
       );
 
       // Should not find the billing type label
@@ -1550,7 +1550,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithOneTimeMembership} />,
+        <PaymentStep {...propsWithOneTimeMembership} />,
       );
 
       // Should not find the billing type label
@@ -1572,7 +1572,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithZeroPrice} />,
+        <PaymentStep {...propsWithZeroPrice} />,
       );
 
       // Should not find the billing type label
@@ -1595,7 +1595,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithMonthlyMembership} />,
+        <PaymentStep {...propsWithMonthlyMembership} />,
       );
 
       // Find the autopay button and check it has the selected class
@@ -1619,7 +1619,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithMonthlyMembership} />,
+        <PaymentStep {...propsWithMonthlyMembership} />,
       );
 
       const oneTimeButton = Array.from(document.querySelectorAll('button')).find(btn => btn.textContent?.includes('One-Time'));
@@ -1651,7 +1651,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithOneTimeBilling} />,
+        <PaymentStep {...propsWithOneTimeBilling} />,
       );
 
       const autopayButton = Array.from(document.querySelectorAll('button')).find(btn => btn.textContent?.includes('Autopay'));
@@ -1681,7 +1681,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithAutopay} />,
+        <PaymentStep {...propsWithAutopay} />,
       );
 
       expect(page.getByText(/automatically every month/i)).toBeTruthy();
@@ -1701,7 +1701,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithOneTime} />,
+        <PaymentStep {...propsWithOneTime} />,
       );
 
       // Should not find the autopay note
@@ -1728,7 +1728,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithOneTime} />,
+        <PaymentStep {...propsWithOneTime} />,
       );
 
       // Find one-time button and verify it's selected
@@ -1751,7 +1751,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...loadingProps} />,
+        <PaymentStep {...loadingProps} />,
       );
 
       const oneTimeButton = Array.from(document.querySelectorAll('button')).find(btn => btn.textContent?.includes('One-Time')) as HTMLButtonElement;
@@ -1772,7 +1772,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithMonthlyMembership} />,
+        <PaymentStep {...propsWithMonthlyMembership} />,
       );
 
       expect(page.getByText(/every month/)).toBeTruthy();
@@ -1791,7 +1791,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...propsWithAnnualMembership} />,
+        <PaymentStep {...propsWithAnnualMembership} />,
       );
 
       expect(page.getByText(/every year/)).toBeTruthy();
@@ -1815,7 +1815,7 @@ describe('MemberPaymentStep', () => {
       mockIframeReturn.isCvvValid = false;
 
       render(
-        <MemberPaymentStep
+        <PaymentStep
           {...defaultProps}
           tokenizationConfig={tokenizationConfig}
         />,
@@ -1834,7 +1834,7 @@ describe('MemberPaymentStep', () => {
       mockIframeReturn.isCvvValid = false;
 
       render(
-        <MemberPaymentStep
+        <PaymentStep
           {...defaultProps}
           tokenizationConfig={tokenizationConfig}
         />,
@@ -1851,7 +1851,7 @@ describe('MemberPaymentStep', () => {
       mockIframeReturn.isLoaded = true;
 
       render(
-        <MemberPaymentStep
+        <PaymentStep
           {...defaultProps}
           tokenizationConfig={tokenizationConfig}
         />,
@@ -1868,7 +1868,7 @@ describe('MemberPaymentStep', () => {
       mockIframeReturn.isLoaded = true;
 
       render(
-        <MemberPaymentStep
+        <PaymentStep
           {...defaultProps}
           tokenizationConfig={tokenizationConfig}
         />,
@@ -1886,7 +1886,7 @@ describe('MemberPaymentStep', () => {
       mockIframeReturn.error = null;
 
       render(
-        <MemberPaymentStep
+        <PaymentStep
           {...defaultProps}
           tokenizationConfig={tokenizationConfig}
         />,
@@ -1906,7 +1906,7 @@ describe('MemberPaymentStep', () => {
       mockIframeReturn.error = null;
 
       render(
-        <MemberPaymentStep
+        <PaymentStep
           {...defaultProps}
           tokenizationConfig={tokenizationConfig}
         />,
@@ -1939,7 +1939,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...completedProps} />,
+        <PaymentStep {...completedProps} />,
       );
 
       const nextButton = Array.from(document.querySelectorAll('button')).find(btn => btn.textContent === 'Next') as HTMLButtonElement;
@@ -1967,7 +1967,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...completedProps} />,
+        <PaymentStep {...completedProps} />,
       );
 
       const nextButton = Array.from(document.querySelectorAll('button')).find(btn => btn.textContent === 'Next') as HTMLButtonElement;
@@ -1994,7 +1994,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...completedProps} />,
+        <PaymentStep {...completedProps} />,
       );
 
       const nextButton = Array.from(document.querySelectorAll('button')).find(btn => btn.textContent === 'Next') as HTMLButtonElement;
@@ -2009,7 +2009,7 @@ describe('MemberPaymentStep', () => {
       mockIframeReturn.isLoaded = true;
 
       render(
-        <MemberPaymentStep
+        <PaymentStep
           {...defaultProps}
           tokenizationConfig={tokenizationConfig}
         />,
@@ -2035,7 +2035,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...achProps} />,
+        <PaymentStep {...achProps} />,
       );
 
       // ACH fields should still be regular inputs
@@ -2053,7 +2053,7 @@ describe('MemberPaymentStep', () => {
       mockIframeReturn.error = null;
 
       render(
-        <MemberPaymentStep
+        <PaymentStep
           {...defaultProps}
           tokenizationConfig={tokenizationConfig}
         />,
@@ -2067,7 +2067,7 @@ describe('MemberPaymentStep', () => {
       mockIframeReturn.error = 'Script failed to load';
 
       render(
-        <MemberPaymentStep
+        <PaymentStep
           {...defaultProps}
           tokenizationConfig={tokenizationConfig}
         />,
@@ -2099,7 +2099,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...completedProps} />,
+        <PaymentStep {...completedProps} />,
       );
 
       const nextButton = Array.from(document.querySelectorAll('button')).find(btn => btn.textContent === 'Next');
@@ -2141,7 +2141,7 @@ describe('MemberPaymentStep', () => {
       };
 
       render(
-        <MemberPaymentStep {...completedProps} />,
+        <PaymentStep {...completedProps} />,
       );
 
       const nextButton = Array.from(document.querySelectorAll('button')).find(btn => btn.textContent === 'Next');

--- a/src/features/members/wizard/PaymentStep.tsx
+++ b/src/features/members/wizard/PaymentStep.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { Coupon } from '@/features/marketing';
-import type { AddMemberWizardData, AppliedCoupon, BillingType, MemberType, PaymentDeclineReason, PaymentMethod } from '@/hooks/useAddMemberWizard';
+import type { AppliedCoupon, BillingType, MemberType, PaymentDeclineReason, PaymentMethod, WizardStepData } from '@/hooks/useAddMemberWizard';
 import type { TokenizationIframeConfig } from '@/libs/IQPro';
 import { AlertCircle, CheckCircle2, CreditCard, Info, Landmark, Loader2, RefreshCw, Tag } from 'lucide-react';
 import { useTranslations } from 'next-intl';
@@ -13,9 +13,9 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { calculateCouponDiscount, getValidMembershipCoupons } from '@/features/marketing';
 import { useTokenExIframe } from '@/hooks/useTokenExIframe';
 
-type MemberPaymentStepProps = {
-  data: AddMemberWizardData;
-  onUpdateAction: (updates: Partial<AddMemberWizardData>) => void;
+type PaymentStepProps = {
+  data: WizardStepData;
+  onUpdateAction: (updates: Partial<WizardStepData>) => void;
   onNextAction: () => void;
   onBackAction: () => void;
   onCancelAction: () => void;
@@ -50,7 +50,7 @@ const getFrequencyLabel = (frequency?: string): string => {
   return lower;
 };
 
-export const MemberPaymentStep = ({
+export const PaymentStep = ({
   data,
   onUpdateAction,
   onNextAction,
@@ -61,9 +61,9 @@ export const MemberPaymentStep = ({
   tokenizationConfig,
   memberType,
   captureOnly = false,
-}: MemberPaymentStepProps) => {
-  const t = useTranslations('AddMemberWizard.MemberPaymentStep');
-  const tHOH = useTranslations('AddMemberWizard.MemberPaymentStep_HOHNotice');
+}: PaymentStepProps) => {
+  const t = useTranslations('AddMemberWizard.PaymentStep');
+  const tHOH = useTranslations('AddMemberWizard.PaymentStep_HOHNotice');
   const { resolvedTheme } = useTheme();
   const [touched, setTouched] = useState<Record<string, boolean>>({});
   const [tokenizing, setTokenizing] = useState(false);

--- a/src/features/members/wizard/WaiverStep.test.tsx
+++ b/src/features/members/wizard/WaiverStep.test.tsx
@@ -1,10 +1,11 @@
 import type { AddMemberWizardData } from '@/hooks/useAddMemberWizard';
+import { useState } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { page, userEvent } from 'vitest/browser';
-import { MemberWaiverStep } from './MemberWaiverStep';
+import { WaiverStep } from './WaiverStep';
 
-// Translation keys for MemberWaiverStep
+// Translation keys for WaiverStep
 const translationKeys: Record<string, string> = {
   title: 'Sign Waiver',
   subtitle: 'Please review and sign the liability waiver',
@@ -28,6 +29,7 @@ const translationKeys: Record<string, string> = {
   signature_required_error: 'Please provide your signature',
   name_required_error: 'Please enter your full name',
   agreement_required_error: 'You must agree to the waiver terms',
+  no_waiver_required_message: 'No waiver is required for the selected membership plan. Click Continue to proceed.',
 };
 
 // Translation keys for SignatureCanvas
@@ -112,7 +114,7 @@ const mockWaiver = {
 
 const resolvedContent = 'I, the undersigned, acknowledge the risks associated with martial arts training at Iron Fist Dojo.';
 
-describe('MemberWaiverStep', () => {
+describe('WaiverStep', () => {
   const mockData: AddMemberWizardData = {
     memberType: 'individual',
     firstName: 'John',
@@ -147,7 +149,7 @@ describe('MemberWaiverStep', () => {
       );
 
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -160,12 +162,12 @@ describe('MemberWaiverStep', () => {
     });
   });
 
-  describe('Auto-Advance When No Waiver', () => {
-    it('should call onNext and onUpdate to skip when no active waivers exist', async () => {
+  describe('No Waiver Required Panel', () => {
+    it('should render the no-waiver panel with Back and Continue buttons when no active waivers exist', async () => {
       mockGetWaiversForMembership.mockResolvedValue({ waivers: [] });
 
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -174,29 +176,24 @@ describe('MemberWaiverStep', () => {
         />,
       );
 
-      // Wait for the auto-advance to happen
-      await vi.waitFor(() => {
-        expect(mockHandlers.onUpdate).toHaveBeenCalledWith(
-          expect.objectContaining({
-            waiverTemplateId: null,
-            waiverSkipped: true,
-          }),
-        );
-      });
+      await expect.element(
+        page.getByText('No waiver is required for the selected membership plan. Click Continue to proceed.'),
+      ).toBeInTheDocument();
+      expect(page.getByRole('button', { name: 'Back' })).toBeTruthy();
+      expect(page.getByRole('button', { name: 'Continue' })).toBeTruthy();
 
-      await vi.waitFor(() => {
-        expect(mockHandlers.onNext).toHaveBeenCalled();
-      });
+      // It should NOT auto-advance
+      expect(mockHandlers.onNext).not.toHaveBeenCalled();
     });
 
-    it('should auto-advance when no membership plan is selected', async () => {
+    it('should render the no-waiver panel when no membership plan is selected', async () => {
       const dataWithoutPlan: AddMemberWizardData = {
         ...mockData,
         membershipPlanId: null,
       };
 
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={dataWithoutPlan}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -205,18 +202,19 @@ describe('MemberWaiverStep', () => {
         />,
       );
 
-      await vi.waitFor(() => {
-        expect(mockHandlers.onNext).toHaveBeenCalled();
-      });
+      await expect.element(
+        page.getByText('No waiver is required for the selected membership plan. Click Continue to proceed.'),
+      ).toBeInTheDocument();
+      expect(mockHandlers.onNext).not.toHaveBeenCalled();
     });
 
-    it('should auto-advance when waiver fetch returns only inactive waivers', async () => {
+    it('should render the no-waiver panel when waiver fetch returns only inactive waivers', async () => {
       mockGetWaiversForMembership.mockResolvedValue({
         waivers: [{ ...mockWaiver, isActive: false }],
       });
 
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -224,6 +222,32 @@ describe('MemberWaiverStep', () => {
           onCancel={mockHandlers.onCancel}
         />,
       );
+
+      await expect.element(
+        page.getByText('No waiver is required for the selected membership plan. Click Continue to proceed.'),
+      ).toBeInTheDocument();
+      expect(mockHandlers.onNext).not.toHaveBeenCalled();
+    });
+
+    it('should call onUpdate({waiverSkipped: true}) and onNext when Continue is clicked from no-waiver panel', async () => {
+      mockGetWaiversForMembership.mockResolvedValue({ waivers: [] });
+
+      render(
+        <WaiverStep
+          data={mockData}
+          onUpdate={mockHandlers.onUpdate}
+          onNext={mockHandlers.onNext}
+          onBack={mockHandlers.onBack}
+          onCancel={mockHandlers.onCancel}
+        />,
+      );
+
+      await expect.element(
+        page.getByText('No waiver is required for the selected membership plan. Click Continue to proceed.'),
+      ).toBeInTheDocument();
+
+      const continueButton = page.getByRole('button', { name: 'Continue' });
+      await userEvent.click(continueButton);
 
       await vi.waitFor(() => {
         expect(mockHandlers.onUpdate).toHaveBeenCalledWith(
@@ -233,13 +257,38 @@ describe('MemberWaiverStep', () => {
           }),
         );
       });
+
+      expect(mockHandlers.onNext).toHaveBeenCalled();
+    });
+
+    it('should call onBack when Back is clicked from no-waiver panel', async () => {
+      mockGetWaiversForMembership.mockResolvedValue({ waivers: [] });
+
+      render(
+        <WaiverStep
+          data={mockData}
+          onUpdate={mockHandlers.onUpdate}
+          onNext={mockHandlers.onNext}
+          onBack={mockHandlers.onBack}
+          onCancel={mockHandlers.onCancel}
+        />,
+      );
+
+      await expect.element(
+        page.getByText('No waiver is required for the selected membership plan. Click Continue to proceed.'),
+      ).toBeInTheDocument();
+
+      const backButton = page.getByRole('button', { name: 'Back' });
+      await userEvent.click(backButton);
+
+      expect(mockHandlers.onBack).toHaveBeenCalled();
     });
   });
 
   describe('Rendering With Waiver', () => {
     it('should render the waiver step title and subtitle', async () => {
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -254,7 +303,7 @@ describe('MemberWaiverStep', () => {
 
     it('should display the resolved waiver content', async () => {
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -268,7 +317,7 @@ describe('MemberWaiverStep', () => {
 
     it('should render the signer name input', async () => {
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -283,7 +332,7 @@ describe('MemberWaiverStep', () => {
 
     it('should render the signature canvas', async () => {
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -298,7 +347,7 @@ describe('MemberWaiverStep', () => {
 
     it('should render the agreement checkbox', async () => {
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -312,7 +361,7 @@ describe('MemberWaiverStep', () => {
 
     it('should render Back, Cancel, and Continue buttons', async () => {
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -330,7 +379,7 @@ describe('MemberWaiverStep', () => {
 
     it('should update waiver template ID when waiver is loaded', async () => {
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -354,7 +403,7 @@ describe('MemberWaiverStep', () => {
       minorDob.setFullYear(minorDob.getFullYear() - 14);
 
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -375,7 +424,7 @@ describe('MemberWaiverStep', () => {
       minorDob.setFullYear(minorDob.getFullYear() - 14);
 
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -395,7 +444,7 @@ describe('MemberWaiverStep', () => {
       adultDob.setFullYear(adultDob.getFullYear() - 25);
 
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -414,7 +463,7 @@ describe('MemberWaiverStep', () => {
 
     it('should not show guardian section when date of birth is not provided', async () => {
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -435,7 +484,7 @@ describe('MemberWaiverStep', () => {
       minorDob.setFullYear(minorDob.getFullYear() - 14);
 
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -452,7 +501,7 @@ describe('MemberWaiverStep', () => {
   describe('Signer Name Input', () => {
     it('should allow entering a signer name', async () => {
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -476,7 +525,7 @@ describe('MemberWaiverStep', () => {
       };
 
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={dataWithSignerName}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -496,7 +545,7 @@ describe('MemberWaiverStep', () => {
   describe('Validation', () => {
     it('should show signature error when submitting without signature', async () => {
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -520,7 +569,7 @@ describe('MemberWaiverStep', () => {
 
     it('should show name error when submitting without signer name', async () => {
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -540,7 +589,7 @@ describe('MemberWaiverStep', () => {
 
     it('should show agreement error when checkbox is not checked', async () => {
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -560,7 +609,7 @@ describe('MemberWaiverStep', () => {
 
     it('should clear name error when user starts typing', async () => {
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -588,7 +637,7 @@ describe('MemberWaiverStep', () => {
 
     it('should not call onNext when validation fails', async () => {
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -614,7 +663,7 @@ describe('MemberWaiverStep', () => {
   describe('Successful Submission', () => {
     it('should call onUpdate and onNext with correct data when all fields are valid', async () => {
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -660,7 +709,7 @@ describe('MemberWaiverStep', () => {
   describe('Navigation', () => {
     it('should call onBack when Back button is clicked', async () => {
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -679,7 +728,7 @@ describe('MemberWaiverStep', () => {
 
     it('should call onCancel when Cancel button is clicked', async () => {
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -700,7 +749,7 @@ describe('MemberWaiverStep', () => {
   describe('Loading State in Button', () => {
     it('should show loading indicator in Continue button when isLoading is true', async () => {
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -717,7 +766,7 @@ describe('MemberWaiverStep', () => {
 
     it('should disable Continue button when isLoading is true', async () => {
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -736,11 +785,11 @@ describe('MemberWaiverStep', () => {
   });
 
   describe('Error Handling', () => {
-    it('should auto-advance when waiver fetch fails', async () => {
+    it('should render the no-waiver panel when waiver fetch fails', async () => {
       mockGetWaiversForMembership.mockRejectedValue(new Error('Network error'));
 
       render(
-        <MemberWaiverStep
+        <WaiverStep
           data={mockData}
           onUpdate={mockHandlers.onUpdate}
           onNext={mockHandlers.onNext}
@@ -749,10 +798,50 @@ describe('MemberWaiverStep', () => {
         />,
       );
 
-      // When fetch fails, waiver is set to null, so auto-advance should trigger
-      await vi.waitFor(() => {
-        expect(mockHandlers.onNext).toHaveBeenCalled();
-      });
+      await expect.element(
+        page.getByText('No waiver is required for the selected membership plan. Click Continue to proceed.'),
+      ).toBeInTheDocument();
+      expect(mockHandlers.onNext).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Fetch Effect Stability', () => {
+    it('should fetch the waiver only once even when onUpdate reference changes between renders', async () => {
+      // Parent that triggers re-renders by clicking a button. Each render
+      // creates a fresh `onUpdate` arrow function — pre-fix, this caused the
+      // fetch effect to re-run infinitely (#143). After the onUpdateRef fix,
+      // the effect only depends on data.membershipPlanId.
+      function Parent() {
+        const [, setTick] = useState(0);
+        return (
+          <div>
+            <button type="button" data-testid="rerender" onClick={() => setTick(t => t + 1)}>
+              Rerender
+            </button>
+            <WaiverStep
+              data={mockData}
+              onUpdate={(...args) => mockHandlers.onUpdate(...args)}
+              onNext={mockHandlers.onNext}
+              onBack={mockHandlers.onBack}
+              onCancel={mockHandlers.onCancel}
+            />
+          </div>
+        );
+      }
+
+      render(<Parent />);
+
+      await expect.element(page.getByText('Sign Waiver')).toBeInTheDocument();
+
+      const rerenderBtn = page.getByTestId('rerender');
+      await userEvent.click(rerenderBtn);
+      await userEvent.click(rerenderBtn);
+      await userEvent.click(rerenderBtn);
+
+      // Give effects time to flush
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      expect(mockGetWaiversForMembership).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/features/members/wizard/WaiverStep.tsx
+++ b/src/features/members/wizard/WaiverStep.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import type { AddMemberWizardData } from '@/hooks/useAddMemberWizard';
+import type { WizardStepData } from '@/hooks/useAddMemberWizard';
 import type { WaiverTemplate } from '@/services/WaiversService';
 import { useTranslations } from 'next-intl';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Alert } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -15,9 +15,9 @@ import { client } from '@/libs/Orpc';
 
 type SignerRelationship = 'self' | 'parent' | 'guardian' | 'legal_guardian';
 
-type MemberWaiverStepProps = {
-  data: AddMemberWizardData;
-  onUpdate: (updates: Partial<AddMemberWizardData>) => void;
+type WaiverStepProps = {
+  data: WizardStepData;
+  onUpdate: (updates: Partial<WizardStepData>) => void;
   onNext: () => void | Promise<void>;
   onBack: () => void;
   onCancel: () => void;
@@ -39,7 +39,7 @@ function calculateAge(dob: Date): number {
   return age;
 }
 
-export function MemberWaiverStep({
+export function WaiverStep({
   data,
   onUpdate,
   onNext,
@@ -47,8 +47,8 @@ export function MemberWaiverStep({
   onCancel,
   isLoading = false,
   memberDateOfBirth,
-}: MemberWaiverStepProps) {
-  const t = useTranslations('MemberWaiverStep');
+}: WaiverStepProps) {
+  const t = useTranslations('WaiverStep');
 
   const [waiver, setWaiver] = useState<WaiverTemplate | null>(null);
   const [resolvedContent, setResolvedContent] = useState<string>('');
@@ -81,7 +81,11 @@ export function MemberWaiverStep({
     return waiver.requiresGuardian && memberAge < waiver.guardianAgeThreshold;
   }, [waiver, memberAge]);
 
-  // Fetch waiver for selected membership plan
+  const onUpdateRef = useRef(onUpdate);
+  useEffect(() => {
+    onUpdateRef.current = onUpdate;
+  });
+
   useEffect(() => {
     const fetchWaiver = async () => {
       if (!data.membershipPlanId) {
@@ -91,27 +95,22 @@ export function MemberWaiverStep({
 
       setIsFetchingWaiver(true);
       try {
-        // Get waivers associated with the selected membership plan
         const result = await client.waivers.getWaiversForMembership({
           membershipPlanId: data.membershipPlanId,
         });
 
-        // Use the first active waiver
         const activeWaivers = result.waivers.filter(w => w.isActive);
         if (activeWaivers.length > 0) {
           const selectedWaiver = activeWaivers[0]!;
           setWaiver(selectedWaiver);
 
-          // Resolve placeholders
           const resolved = await client.waivers.resolvePlaceholders({
             templateId: selectedWaiver.id,
           });
           setResolvedContent(resolved.resolvedContent);
 
-          // Update data with waiver template ID
-          onUpdate({ waiverTemplateId: selectedWaiver.id });
+          onUpdateRef.current({ waiverTemplateId: selectedWaiver.id });
         } else {
-          // No waiver required for this membership
           setWaiver(null);
         }
       } catch (error) {
@@ -123,23 +122,19 @@ export function MemberWaiverStep({
     };
 
     fetchWaiver();
-  }, [data.membershipPlanId, onUpdate]);
+  }, [data.membershipPlanId]);
 
-  // Auto-advance if no waiver is required
-  useEffect(() => {
-    if (!isFetchingWaiver && !waiver) {
-      // Clear any waiver data and proceed to next step
-      onUpdate({
-        waiverTemplateId: null,
-        waiverSignatureDataUrl: undefined,
-        waiverSignedByName: undefined,
-        waiverSignedByRelationship: undefined,
-        waiverGuardianEmail: undefined,
-        waiverSkipped: true,
-      });
-      onNext();
-    }
-  }, [isFetchingWaiver, waiver, onUpdate, onNext]);
+  const handleContinueWithoutWaiver = useCallback(async () => {
+    onUpdate({
+      waiverTemplateId: null,
+      waiverSignatureDataUrl: undefined,
+      waiverSignedByName: undefined,
+      waiverSignedByRelationship: undefined,
+      waiverGuardianEmail: undefined,
+      waiverSkipped: true,
+    });
+    await onNext();
+  }, [onUpdate, onNext]);
 
   const handleSignatureChange = useCallback((dataUrl: string | null) => {
     setSignatureDataUrl(dataUrl);
@@ -203,9 +198,33 @@ export function MemberWaiverStep({
     );
   }
 
-  // If no waiver needed, component auto-advances (see useEffect above)
   if (!waiver) {
-    return null;
+    return (
+      <div className="space-y-6">
+        <div>
+          <h2 className="text-lg font-semibold">{t('title')}</h2>
+          <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
+        </div>
+
+        <div className="rounded-lg border bg-muted/30 p-6 text-center">
+          <p className="text-sm text-muted-foreground">{t('no_waiver_required_message')}</p>
+        </div>
+
+        <div className="flex justify-between gap-3 pt-6">
+          <div className="flex gap-3">
+            <Button variant="outline" onClick={onBack}>
+              {t('back_button')}
+            </Button>
+            <Button variant="outline" onClick={onCancel}>
+              {t('cancel_button')}
+            </Button>
+          </div>
+          <Button onClick={handleContinueWithoutWaiver} disabled={isLoading}>
+            {isLoading ? `${t('continue_button')}...` : t('continue_button')}
+          </Button>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/src/hooks/useAddMemberWizard.ts
+++ b/src/hooks/useAddMemberWizard.ts
@@ -18,16 +18,68 @@ export type AppliedCoupon = {
 
 export type SignerRelationship = 'self' | 'parent' | 'guardian' | 'legal_guardian';
 
-export type AddMemberWizardData = {
-  // Step 1: Member Type
-  memberType: MemberType | null;
-
-  // Step 2: Member Details
+/**
+ * Shape consumed by the shared wizard step components (`MembershipStep`,
+ * `WaiverStep`, `PaymentStep`). Both `AddMemberWizardData` and
+ * `ConvertMemberWizardData` extend this so step components can be reused
+ * without an adapter layer.
+ */
+export type WizardStepData = {
+  // Identity (used by waiver step for guardian-name defaults, etc.)
   firstName: string;
   lastName: string;
   email: string;
-  phone: string;
   dateOfBirth?: Date;
+
+  // Membership selection
+  membershipPlanId: string | null;
+  membershipPlanPrice?: number;
+  membershipPlanFrequency?: string;
+  membershipPlanName?: string;
+  membershipPlanIsTrial?: boolean;
+  membershipPlanContractLength?: string;
+  membershipPlanSignupFee?: number;
+
+  // Waiver
+  waiverTemplateId: string | null;
+  waiverSignatureDataUrl?: string;
+  waiverSignedByName?: string;
+  waiverSignedByRelationship?: SignerRelationship;
+  waiverGuardianEmail?: string;
+  waiverSignedAt?: Date;
+  waiverSkipped?: boolean;
+  waiverRenderedContent?: string;
+
+  // Payment
+  paymentMethod?: PaymentMethod;
+  billingType?: BillingType;
+  cardholderName?: string;
+  cardNumber?: string;
+  cardToken?: string;
+  cardFirstSix?: string;
+  cardLastFour?: string;
+  cardExpiry?: string;
+  cardCvc?: string;
+  achAccountHolder?: string;
+  achRoutingNumber?: string;
+  achAccountNumber?: string;
+  achAccountType?: 'Checking' | 'Savings';
+
+  // Coupon
+  appliedCoupon?: AppliedCoupon | null;
+
+  // Payment processing state
+  paymentStatus?: PaymentStatus;
+  paymentDeclineReason?: PaymentDeclineReason;
+  paymentProcessed?: boolean;
+};
+
+export type AddMemberWizardData = WizardStepData & {
+  // Step 1: Member Type
+  memberType: MemberType | null;
+
+  // Step 2: Member Details (firstName/lastName/email/dateOfBirth come from WizardStepData)
+  phone: string;
   address?: {
     street: string;
     apartment?: string;
@@ -41,42 +93,9 @@ export type AddMemberWizardData = {
   photoFile?: File | null;
   photoUrl?: string;
 
-  // Step 4: Membership
-  membershipPlanId: string | null;
-  membershipPlanPrice?: number;
-  membershipPlanFrequency?: string;
-  membershipPlanName?: string;
-  membershipPlanIsTrial?: boolean;
-  membershipPlanContractLength?: string;
-  membershipPlanSignupFee?: number;
-  // Legacy fields (kept for backwards compatibility)
+  // Legacy membership fields (kept for backwards compatibility)
   subscriptionPlan?: SubscriptionPlan | null;
   subscriptionId?: string;
-
-  // Step 5: Waiver (required when membership has associated waiver)
-  waiverTemplateId: string | null;
-  waiverSignatureDataUrl?: string;
-  waiverSignedByName?: string;
-  waiverSignedByRelationship?: SignerRelationship;
-  waiverGuardianEmail?: string;
-  waiverSignedAt?: Date;
-  waiverSkipped?: boolean;
-  waiverRenderedContent?: string;
-
-  // Step 6: Payment (only for monthly/annual plans)
-  paymentMethod?: PaymentMethod;
-  billingType?: BillingType; // autopay (recurring) or one-time payment
-  cardholderName?: string;
-  cardNumber?: string; // Fallback: raw card (local dev without IQPro)
-  cardToken?: string; // PCI-compliant: tokenized card from TokenEx iframe
-  cardFirstSix?: string; // First 6 digits (BIN) from TokenEx tokenization (for maskedCard)
-  cardLastFour?: string; // Last 4 digits from TokenEx tokenization (for maskedCard)
-  cardExpiry?: string;
-  cardCvc?: string;
-  achAccountHolder?: string;
-  achRoutingNumber?: string;
-  achAccountNumber?: string;
-  achAccountType?: 'Checking' | 'Savings';
 
   // HOH (Head of Household) fields — used when memberType is 'family-member'
   hohMemberId?: string;
@@ -88,14 +107,6 @@ export type AddMemberWizardData = {
 
   // Membership skipped (HOH only — no membership selected, card capture only)
   membershipSkipped?: boolean;
-
-  // Coupon applied to payment
-  appliedCoupon?: AppliedCoupon | null;
-
-  // Payment processing state
-  paymentStatus?: PaymentStatus;
-  paymentDeclineReason?: PaymentDeclineReason;
-  paymentProcessed?: boolean;
 };
 
 export type WizardStep = 'member-type' | 'details' | 'photo' | 'subscription' | 'waiver' | 'payment' | 'hoh-selection' | 'family-payment' | 'success';

--- a/src/hooks/useConvertMemberWizard.ts
+++ b/src/hooks/useConvertMemberWizard.ts
@@ -1,15 +1,15 @@
-import type { AppliedCoupon, BillingType, MemberType, PaymentDeclineReason, PaymentMethod, PaymentStatus, SignerRelationship } from './useAddMemberWizard';
+import type { MemberType, WizardStepData } from './useAddMemberWizard';
 import { useState } from 'react';
 
 export type ConversionType = 'hoh-to-individual' | 'individual-to-hoh' | 'family-to-individual';
 
 export type ConvertWizardStep = 'confirm' | 'subscription' | 'waiver' | 'payment' | 'success';
 
-export type ConvertMemberWizardData = {
+export type ConvertMemberWizardData = WizardStepData & {
   // Source member info (pre-populated)
   memberId: string;
-  memberName: string;
-  memberEmail: string;
+  memberName: string; // full name kept for the convert-confirm UI
+  memberEmail: string; // canonical email kept for the convert-confirm UI
   currentMemberType: MemberType;
   memberDateOfBirth?: Date;
 
@@ -25,48 +25,6 @@ export type ConvertMemberWizardData = {
   hasMembership: boolean;
   // Whether the member currently has a valid payment method
   hasPaymentMethod: boolean;
-
-  // Membership selection (when member needs a new membership)
-  membershipPlanId: string | null;
-  membershipPlanPrice?: number;
-  membershipPlanFrequency?: string;
-  membershipPlanName?: string;
-  membershipPlanIsTrial?: boolean;
-  membershipPlanContractLength?: string;
-  membershipPlanSignupFee?: number;
-
-  // Waiver
-  waiverTemplateId: string | null;
-  waiverSignatureDataUrl?: string;
-  waiverSignedByName?: string;
-  waiverSignedByRelationship?: SignerRelationship;
-  waiverGuardianEmail?: string;
-  waiverSignedAt?: Date;
-  waiverSkipped?: boolean;
-  waiverRenderedContent?: string;
-
-  // Payment
-  paymentMethod?: PaymentMethod;
-  billingType?: BillingType;
-  cardholderName?: string;
-  cardNumber?: string;
-  cardToken?: string;
-  cardFirstSix?: string;
-  cardLastFour?: string;
-  cardExpiry?: string;
-  cardCvc?: string;
-  achAccountHolder?: string;
-  achRoutingNumber?: string;
-  achAccountNumber?: string;
-  achAccountType?: 'Checking' | 'Savings';
-
-  // Coupon
-  appliedCoupon?: AppliedCoupon | null;
-
-  // Payment processing state
-  paymentStatus?: PaymentStatus;
-  paymentDeclineReason?: PaymentDeclineReason;
-  paymentProcessed?: boolean;
 };
 
 export function getStepsForConversion(
@@ -109,9 +67,24 @@ type ConvertMemberWizardInit = {
   currentHOHName?: string;
 };
 
-export const useConvertMemberWizard = (init: ConvertMemberWizardInit) => {
-  const [step, setStep] = useState<ConvertWizardStep>('confirm');
-  const [data, setData] = useState<ConvertMemberWizardData>({
+// Split full name into first/last so the shared step components (which expect
+// discrete `firstName` / `lastName` from `WizardStepData`) work without an
+// adapter. Single-word names produce an empty `lastName`.
+function splitFullName(fullName: string): { firstName: string; lastName: string } {
+  const trimmed = fullName.trim();
+  const spaceIdx = trimmed.indexOf(' ');
+  if (spaceIdx === -1) {
+    return { firstName: trimmed, lastName: '' };
+  }
+  return {
+    firstName: trimmed.slice(0, spaceIdx),
+    lastName: trimmed.slice(spaceIdx + 1).trim(),
+  };
+}
+
+function createInitialData(init: ConvertMemberWizardInit): ConvertMemberWizardData {
+  const { firstName, lastName } = splitFullName(init.memberName);
+  return {
     memberId: init.memberId,
     memberName: init.memberName,
     memberEmail: init.memberEmail,
@@ -123,9 +96,19 @@ export const useConvertMemberWizard = (init: ConvertMemberWizardInit) => {
     hasPaymentMethod: init.hasPaymentMethod,
     currentHOHId: init.currentHOHId,
     currentHOHName: init.currentHOHName,
+    // WizardStepData fields:
+    firstName,
+    lastName,
+    email: init.memberEmail,
+    dateOfBirth: init.memberDateOfBirth,
     membershipPlanId: null,
     waiverTemplateId: null,
-  });
+  };
+}
+
+export const useConvertMemberWizard = (init: ConvertMemberWizardInit) => {
+  const [step, setStep] = useState<ConvertWizardStep>('confirm');
+  const [data, setData] = useState<ConvertMemberWizardData>(() => createInitialData(init));
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -170,21 +153,7 @@ export const useConvertMemberWizard = (init: ConvertMemberWizardInit) => {
 
   const reset = () => {
     setStep('confirm');
-    setData({
-      memberId: init.memberId,
-      memberName: init.memberName,
-      memberEmail: init.memberEmail,
-      currentMemberType: init.currentMemberType,
-      memberDateOfBirth: init.memberDateOfBirth,
-      conversionType: init.conversionType,
-      targetMemberType: init.targetMemberType,
-      hasMembership: init.hasMembership,
-      hasPaymentMethod: init.hasPaymentMethod,
-      currentHOHId: init.currentHOHId,
-      currentHOHName: init.currentHOHName,
-      membershipPlanId: null,
-      waiverTemplateId: null,
-    });
+    setData(createInitialData(init));
     setError(null);
     setIsLoading(false);
   };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -375,7 +375,7 @@
       "cancel_button": "Cancel",
       "next_button": "Next"
     },
-    "MemberMembershipStep": {
+    "MembershipStep": {
       "title": "Choose Membership Plan",
       "subtitle": "Select a membership plan for this member",
       "loading_plans": "Loading membership plans...",
@@ -388,7 +388,7 @@
       "next_button": "Next",
       "skip_button": "Skip for now"
     },
-    "MemberPaymentStep": {
+    "PaymentStep": {
       "pay_amount": "Pay {amount}",
       "payment_description": "This signs up this member for a {plan} recurring membership. They will be charged {amount} every {period} on this day until they cancel.",
       "card_tab_label": "Debit / Credit Card",
@@ -486,7 +486,7 @@
       "back_button": "Back",
       "cancel_button": "Cancel"
     },
-    "MemberPaymentStep_HOHNotice": {
+    "PaymentStep_HOHNotice": {
       "notice": "Note: If family members are added to your account in the future, their membership fees will be charged to this payment method on the date they join, with recurring billing based on their join date."
     },
     "MemberSuccessStep": {
@@ -1115,8 +1115,12 @@
     "add_new_waiver_button": "Add Waiver",
     "manage_fields_button": "Manage Merge Fields",
     "search_placeholder": "Search waivers...",
+    "filter_status_label": "Status",
+    "filter_status_all": "All statuses",
+    "filter_status_active": "Active",
+    "filter_status_inactive": "Inactive",
     "no_waivers_found": "No waivers found",
-    "no_results_found": "No waivers match your search",
+    "no_results_found": "No waivers match your filters",
     "AddWaiverModal": {
       "title": "Add Waiver",
       "name_label": "Waiver Name",
@@ -1280,7 +1284,7 @@
     "content_label": "Waiver Content",
     "close_button": "Close"
   },
-  "MemberWaiverStep": {
+  "WaiverStep": {
     "title": "Sign Waiver",
     "subtitle": "Please review and sign the liability waiver",
     "loading_waiver": "Loading waiver...",
@@ -1302,7 +1306,8 @@
     "continue_button": "Continue",
     "signature_required_error": "Please provide your signature",
     "name_required_error": "Please enter your full name",
-    "agreement_required_error": "You must agree to the waiver terms"
+    "agreement_required_error": "You must agree to the waiver terms",
+    "no_waiver_required_message": "No waiver is required for the selected membership plan. Click Continue to proceed."
   },
   "SignatureCanvas": {
     "placeholder": "Sign here",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -375,7 +375,7 @@
       "cancel_button": "Annuler",
       "next_button": "Suivant"
     },
-    "MemberMembershipStep": {
+    "MembershipStep": {
       "title": "Choisir un plan d'adhésion",
       "subtitle": "Sélectionnez un plan d'adhésion pour ce membre",
       "loading_plans": "Chargement des plans d'adhésion...",
@@ -388,7 +388,7 @@
       "next_button": "Suivant",
       "skip_button": "Passer pour l'instant"
     },
-    "MemberPaymentStep": {
+    "PaymentStep": {
       "pay_amount": "Payer {amount}",
       "payment_description": "Ceci inscrit ce membre pour un abonnement récurrent {plan}. Il sera facturé {amount} tous les {period} à partir de ce jour jusqu'à l'annulation.",
       "card_tab_label": "Carte de débit / crédit",
@@ -486,7 +486,7 @@
       "back_button": "Retour",
       "cancel_button": "Annuler"
     },
-    "MemberPaymentStep_HOHNotice": {
+    "PaymentStep_HOHNotice": {
       "notice": "Remarque : Si des membres de la famille sont ajoutés à votre compte à l'avenir, leurs frais d'adhésion seront débités sur ce mode de paiement à la date de leur inscription, avec une facturation récurrente basée sur leur date d'inscription."
     },
     "MemberSuccessStep": {
@@ -1119,8 +1119,12 @@
     "add_new_waiver_button": "Ajouter une décharge",
     "manage_fields_button": "Gérer les champs de fusion",
     "search_placeholder": "Rechercher des décharges...",
+    "filter_status_label": "Statut",
+    "filter_status_all": "Tous les statuts",
+    "filter_status_active": "Actives",
+    "filter_status_inactive": "Inactives",
     "no_waivers_found": "Aucune décharge trouvée",
-    "no_results_found": "Aucune décharge ne correspond à votre recherche",
+    "no_results_found": "Aucune décharge ne correspond à vos filtres",
     "AddWaiverModal": {
       "title": "Ajouter une décharge",
       "name_label": "Nom de la décharge",
@@ -1284,7 +1288,7 @@
     "content_label": "Contenu de la décharge",
     "close_button": "Fermer"
   },
-  "MemberWaiverStep": {
+  "WaiverStep": {
     "title": "Signer la décharge",
     "subtitle": "Veuillez lire et signer la décharge de responsabilité",
     "loading_waiver": "Chargement de la décharge...",
@@ -1306,7 +1310,8 @@
     "continue_button": "Continuer",
     "signature_required_error": "Veuillez fournir votre signature",
     "name_required_error": "Veuillez entrer votre nom complet",
-    "agreement_required_error": "Vous devez accepter les termes de la décharge"
+    "agreement_required_error": "Vous devez accepter les termes de la décharge",
+    "no_waiver_required_message": "Aucune décharge n'est requise pour le plan d'adhésion sélectionné. Cliquez sur Continuer pour poursuivre."
   },
   "SignatureCanvas": {
     "placeholder": "Signez ici",

--- a/tests/e2e/add-member-wizard.e2e.ts
+++ b/tests/e2e/add-member-wizard.e2e.ts
@@ -689,6 +689,9 @@ test.describe('Add Member Wizard', () => {
       await page.locator('button[aria-pressed]').first().click();
       await page.getByRole('button', { name: 'Next', exact: true }).click();
 
+      // Waiver — click Continue on the no-waiver panel (mock plans)
+      await passNoWaiverStep(page);
+
       // HOH Selection step — verify by search input (dialog title also says "Select Head of Household")
       await expect(page.getByPlaceholder('Search by name or email...')).toBeVisible({ timeout: 10000 });
 

--- a/tests/e2e/add-member-wizard.e2e.ts
+++ b/tests/e2e/add-member-wizard.e2e.ts
@@ -117,6 +117,27 @@ async function fillDetailsStep(page: Page): Promise<MemberDetails> {
   return { firstName, lastName, email, phone };
 }
 
+/**
+ * Pass the waiver step — clicks Continue on the "No waiver required" panel
+ * (the path mock plans take in CI, since they have no waiver association).
+ * If a real waiver is shown instead, this is a no-op and the caller should
+ * sign + submit explicitly.
+ */
+async function passNoWaiverStep(page: Page) {
+  // Wait briefly for the waiver step to settle. If a waiver is present,
+  // the "Sign Waiver" heading appears and we leave the step alone.
+  // Otherwise the explicit no-waiver panel renders with a Continue button.
+  const noWaiverMessage = page.getByText(/No waiver is required for the selected membership plan/i);
+  try {
+    await expect(noWaiverMessage).toBeVisible({ timeout: 5000 });
+
+    // We're on the no-waiver panel — click Continue
+    await page.getByRole('button', { name: 'Continue', exact: true }).click();
+  } catch {
+    // No panel — assume the caller will handle the real waiver
+  }
+}
+
 /** Navigate through steps 1-3 (type → details → photo) and land on subscription step. */
 async function navigateToSubscriptionStep(page: Page, memberType: 'Individual' | 'Head of Household' | 'Family Member' = 'Individual'): Promise<MemberDetails> {
   await openWizard(page);
@@ -145,7 +166,10 @@ async function navigateToPaymentStep(page: Page, memberType: 'Individual' | 'Hea
   await page.locator('button[aria-pressed]').first().click();
   await page.getByRole('button', { name: 'Next', exact: true }).click();
 
-  // Waiver step auto-skips → lands on payment step
+  // Waiver step — for mock plans there's no waiver association, so the
+  // "No waiver required" panel is shown. Click Continue to advance.
+  await passNoWaiverStep(page);
+
   await expect(page.getByText('Payment Information')).toBeVisible({ timeout: 10000 });
 
   return details;
@@ -218,7 +242,10 @@ async function completeHOHWizardFlow(page: Page): Promise<MemberDetails> {
   await page.locator('button[aria-pressed]').first().click();
   await page.getByRole('button', { name: 'Next', exact: true }).click();
 
-  // Step 5: Waiver auto-skips → Step 6: Payment
+  // Step 5: Waiver — click Continue on the no-waiver panel (mock plans)
+  await passNoWaiverStep(page);
+
+  // Step 6: Payment
   await expect(page.getByText('Payment Information')).toBeVisible({ timeout: 10000 });
 
   await fillPaymentStep(page);
@@ -413,7 +440,10 @@ test.describe('Add Member Wizard', () => {
       await page.locator('button[aria-pressed]').first().click();
       await page.getByRole('button', { name: 'Next', exact: true }).click();
 
-      // Step 5: Waiver auto-skips → Step 6: Payment
+      // Step 5: Waiver — click Continue on the no-waiver panel (mock plans)
+      await passNoWaiverStep(page);
+
+      // Step 6: Payment
       await expect(page.getByText('Payment Information')).toBeVisible({ timeout: 10000 });
 
       // Fill payment details (handles both card fallback and ACH when iframe active)
@@ -471,7 +501,10 @@ test.describe('Add Member Wizard', () => {
       await page.locator('button[aria-pressed]').first().click();
       await page.getByRole('button', { name: 'Next', exact: true }).click();
 
-      // Step 5: Waiver auto-skips → Step 6: Payment
+      // Step 5: Waiver — click Continue on the no-waiver panel (mock plans)
+      await passNoWaiverStep(page);
+
+      // Step 6: Payment
       await expect(page.getByText('Payment Information')).toBeVisible({ timeout: 10000 });
 
       // Verify HOH billing notice is visible on the payment step
@@ -508,7 +541,10 @@ test.describe('Add Member Wizard', () => {
       await page.locator('button[aria-pressed]').first().click();
       await page.getByRole('button', { name: 'Next', exact: true }).click();
 
-      // Waiver auto-skips → should land on HOH Selection step (NOT payment)
+      // Waiver — click Continue on the no-waiver panel (mock plans), then
+      // should land on HOH Selection step (NOT payment).
+      await passNoWaiverStep(page);
+
       // Use heading role to disambiguate from dialog title (both have same text)
       await expect(page.getByPlaceholder('Search by name or email...')).toBeVisible({ timeout: 10000 });
 
@@ -550,7 +586,10 @@ test.describe('Add Member Wizard', () => {
       await page.locator('button[aria-pressed]').first().click();
       await page.getByRole('button', { name: 'Next', exact: true }).click();
 
-      // Step 5: Waiver auto-skips → Step 6: HOH Selection
+      // Step 5: Waiver — click Continue on the no-waiver panel (mock plans)
+      await passNoWaiverStep(page);
+
+      // Step 6: HOH Selection
       await expect(page.getByPlaceholder('Search by name or email...')).toBeVisible({ timeout: 10000 });
 
       // Search for and select the HOH we just created


### PR DESCRIPTION
## Summary

Closes #156 and #143. Adds a status filter to the waivers list and fixes the
broken waiver step in the family-member → individual conversion flow. Bundles
a small refactor so the shared wizard steps stop pretending to be member-only.

## What changed

### #156 — Waivers list status filter

- Added a `Status` dropdown (`All` / `Active` / `Inactive`) next to the search
  input on `/dashboard/waivers`. Status + search AND together.
- The filter only renders when both active **and** inactive waivers exist —
  if every waiver is the same status, the dropdown would be a no-op and is
  hidden.
- If the selected filter becomes inapplicable (e.g. user picks `Inactive`,
  then deletes the only inactive waiver), the filter falls back to `All` for
  filtering without resetting state, so the user isn't stranded on an empty
  list.
- New i18n keys: `WaiversPage.filter_status_label` /
  `filter_status_all` / `filter_status_active` / `filter_status_inactive`
  (en + fr).

### #143 — Convert-flow waiver step

Root cause: `ConvertMemberModal` wrapped its step components in an adapter
(`toAddMemberData` + `adaptedUpdate`) that built a new object and a new
function on every render. `MemberWaiverStep`'s fetch `useEffect` depended on
`onUpdate`, so every parent render restarted the fetch — infinite loop, the
waiver display never settled, and the user couldn't move forward.

Fix landed in three parts:

**A. Drop the adapter, share the type.**
Extracted `WizardStepData` in `useAddMemberWizard.ts` — the slice of fields
the shared step components actually consume (identity, membership, waiver,
payment). `AddMemberWizardData` and `ConvertMemberWizardData` now extend
`WizardStepData` directly, so `ConvertMemberModal` passes `wizard.data` and
`updateDataWithRef` straight through. Deleted `toAddMemberData`,
`SHARED_FIELDS`, `adaptedData`, and `adaptedUpdate` from
`ConvertMemberModal.tsx`. `useConvertMemberWizard` now splits the source
member's full name into `firstName` / `lastName` once at init.

**B. Replace the silent auto-advance with an explicit panel.**
When the chosen plan has no waiver association, `WaiverStep` previously
auto-fired `onNext()` from a `useEffect` — sometimes before the user could
react, sometimes from a stuck loop. It now renders a clear
"No waiver is required for the selected membership plan. Click Continue
to proceed." panel with **Back** + **Continue** buttons. Continue still
sets `waiverSkipped: true` and calls `onNext()`.

**C. Stabilise the fetch effect.**
The fetch `useEffect` now depends only on `data.membershipPlanId`. The
`onUpdate` callback is read through a ref (`onUpdateRef`) so identity
changes from the parent never re-fire the fetch. Verified by a new
test that re-renders the parent multiple times with a fresh `onUpdate`
arrow function each time and asserts `getWaiversForMembership` is called
exactly once.

### Renames (drop the `Member` prefix from shared step components)

These steps used to live behind a `Member` prefix because they were born in
the Add-Member wizard. They're now reused by `ConvertMemberModal` and
`AddFamilyMembersModal`, so the prefix is misleading:

- `MemberMembershipStep` → `MembershipStep`
- `MemberWaiverStep` → `WaiverStep`
- `MemberPaymentStep` → `PaymentStep`

Each rename moves the file + its co-located test, updates the exported
component name + props type, updates the i18n namespace
(`MemberPaymentStep_HOHNotice` → `PaymentStep_HOHNotice` too), and updates
every call site (`AddMemberModal`, `AddFamilyMembersModal`,
`FamilyPaymentStep`, `ConvertMemberModal`).

The `Member`-prefixed names that remain (`MemberDetailNotes`,
`MemberDetailAttendance`, etc.) genuinely are member-specific.

### Bonus fix — `AddFamilyMembersModal` captured stale HOH payment state

While smoke-testing #143 we found that an HOH who registered a payment method
via the "Skip for now" capture-only flow would still see the
collect-a-new-card UI when adding their first family member. The modal was
always mounted as soon as `hohMemberData` was truthy, which happens on first
render of the edit page — *before* the async `listPaymentMethods` call
resolves. `useFamilyMemberWizard` snapshots `hohData.hasPaymentMethod` once
via lazy `useState` init, so the wizard captured `false` and never updated.

Fix: only mount the modal when `isAddFamilyModalOpen && hohMemberData`, and
disable the "Add Family Member" button while `isLoadingPayment` is true.
The wizard now always inits with the freshest payment state.

## Files changed

- `src/app/[locale]/(auth)/dashboard/waivers/page.tsx` — status filter UI
  + dynamic visibility + AND filtering.
- `src/app/[locale]/(auth)/dashboard/waivers/page.test.tsx` (new) — 10 tests
  covering filter behaviour, dynamic visibility, search/status combination.
- `src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx` —
  gate `AddFamilyMembersModal` on `isAddFamilyModalOpen`; disable add-family
  button while payment methods load.
- `src/hooks/useAddMemberWizard.ts` — extract `WizardStepData`.
- `src/hooks/useConvertMemberWizard.ts` — extend `WizardStepData`; split
  `memberName` into `firstName` / `lastName` at init via a `createInitialData`
  factory shared by `useState` and `reset`.
- `src/features/members/wizard/{Membership,Waiver,Payment}Step.tsx` (renamed
  from `Member*Step.tsx`) — prop signatures take `WizardStepData`, i18n
  namespaces updated.
- `src/features/members/wizard/WaiverStep.tsx` — explicit no-waiver panel,
  `onUpdateRef` pattern in fetch effect.
- `src/features/members/wizard/{Membership,Waiver,Payment}Step.test.tsx`
  (renamed) — updated for new behaviour, plus a new fetch-effect-stability
  regression test in `WaiverStep.test.tsx`.
- `src/features/members/wizard/AddMemberModal.tsx`,
  `AddFamilyMembersModal.tsx`, `FamilyPaymentStep.tsx` — import + namespace
  updates.
- `src/features/members/conversion/ConvertMemberModal.tsx` — adapter dropped,
  step components receive `wizard.data` and `updateDataWithRef` directly.
- `src/features/members/conversion/ConvertConfirmStep.test.tsx`,
  `ConvertSuccessStep.test.tsx` — added `firstName`/`lastName`/`email` to
  test fixtures.
- `src/locales/en.json`, `src/locales/fr.json` — new keys
  (`WaiversPage.filter_status_*`, `WaiverStep.no_waiver_required_message`),
  renamed namespaces.

## Test plan

- [ ] `npm run lint` — clean
- [ ] `npm run check:types` — clean
- [ ] `npm run check:deps` — clean
- [ ] `npm run check:i18n` — clean
- [ ] `npm run test` — all 4059 tests pass across 206 files
- [ ] **#156 manual:**
  - [ ] `/dashboard/waivers` shows the status filter when both active and
        inactive waivers exist
  - [ ] Filter is hidden when all waivers share one status (or there are
        none)
  - [ ] Search + status combine correctly; empty state copy updates
- [ ] **#143 manual (happy path):**
  - [ ] Create a HOH and a family member from the HOH detail page
  - [ ] On the family member's detail page, Convert → Convert to Individual
  - [ ] Pick a plan with a waiver association → step populates; DevTools
        Network tab shows `getWaiversForMembership` fires **exactly once**
  - [ ] Sign + Continue → Payment → finish
- [ ] **#143 manual (no-waiver path):**
  - [ ] `DELETE FROM membership_waiver WHERE membership_plan_id = '<plan>'`
        for the test plan
  - [ ] Repeat the convert flow → waiver step shows the explicit
        "No waiver required" panel with Back + Continue
  - [ ] Continue → moves to Payment
- [ ] **Bonus fix manual:**
  - [ ] HOH skips membership but registers a payment method
  - [ ] On HOH detail page, click Add Family Member → Family Payment step
        shows the saved card on file (not the new-card form)