### PR TITLE
feat(membership wizard): fixes for membership wizard issues

### DIFF
--- a/src/features/members/conversion/ConvertMemberModal.tsx
+++ b/src/features/members/conversion/ConvertMemberModal.tsx
@@ -93,6 +93,9 @@ export const ConvertMemberModal = ({
   const cardFirstSixRef = useRef<string | undefined>(undefined);
   const cardLastFourRef = useRef<string | undefined>(undefined);
 
+  // Re-entrancy guard for handleConvert — see AddMemberModal for rationale.
+  const submittingRef = useRef(false);
+
   const updateDataWithRef = (updates: Partial<ConvertMemberWizardData>) => {
     if (updates.cardToken !== undefined) {
       cardTokenRef.current = updates.cardToken;
@@ -125,6 +128,7 @@ export const ConvertMemberModal = ({
     cardTokenRef.current = undefined;
     cardFirstSixRef.current = undefined;
     cardLastFourRef.current = undefined;
+    submittingRef.current = false;
     wizard.reset();
     onCloseAction();
   };
@@ -133,6 +137,7 @@ export const ConvertMemberModal = ({
     cardTokenRef.current = undefined;
     cardFirstSixRef.current = undefined;
     cardLastFourRef.current = undefined;
+    submittingRef.current = false;
     wizard.reset();
     onCloseAction();
     router.refresh();
@@ -144,6 +149,12 @@ export const ConvertMemberModal = ({
       wizard.setStep('success');
       return;
     }
+
+    // Re-entrancy guard — see AddMemberModal.handleFinalNext for rationale.
+    if (submittingRef.current) {
+      return;
+    }
+    submittingRef.current = true;
 
     try {
       wizard.setIsLoading(true);
@@ -307,6 +318,7 @@ export const ConvertMemberModal = ({
       wizard.setError(errorMessage);
     } finally {
       wizard.setIsLoading(false);
+      submittingRef.current = false;
     }
   };
 

--- a/src/features/members/wizard/AddFamilyMembersModal.tsx
+++ b/src/features/members/wizard/AddFamilyMembersModal.tsx
@@ -64,6 +64,9 @@ export const AddFamilyMembersModal = ({
   const cardFirstSixRef = useRef<string | undefined>(undefined);
   const cardLastFourRef = useRef<string | undefined>(undefined);
 
+  // Re-entrancy guard for handleFamilyMemberSubmit — see AddMemberModal for rationale.
+  const submittingRef = useRef(false);
+
   // Key to force TokenEx iframe re-init between family members
   const [paymentStepKey, setPaymentStepKey] = useState(0);
 
@@ -102,6 +105,7 @@ export const AddFamilyMembersModal = ({
     cardTokenRef.current = undefined;
     cardFirstSixRef.current = undefined;
     cardLastFourRef.current = undefined;
+    submittingRef.current = false;
     wizard.reset();
     onCloseAction();
     if (wizard.completedMembers.length > 0) {
@@ -113,6 +117,7 @@ export const AddFamilyMembersModal = ({
     cardTokenRef.current = undefined;
     cardFirstSixRef.current = undefined;
     cardLastFourRef.current = undefined;
+    submittingRef.current = false;
     wizard.reset();
     onCloseAction();
     router.refresh();
@@ -122,6 +127,7 @@ export const AddFamilyMembersModal = ({
     cardTokenRef.current = undefined;
     cardFirstSixRef.current = undefined;
     cardLastFourRef.current = undefined;
+    submittingRef.current = false;
     wizard.resetForNextMember();
     setPaymentStepKey(prev => prev + 1);
   };
@@ -187,6 +193,12 @@ export const AddFamilyMembersModal = ({
       wizard.setStep('member-success');
       return;
     }
+
+    // Re-entrancy guard — see AddMemberModal.handleFinalNext for rationale.
+    if (submittingRef.current) {
+      return;
+    }
+    submittingRef.current = true;
 
     try {
       wizard.setIsLoading(true);
@@ -417,6 +429,7 @@ export const AddFamilyMembersModal = ({
       wizard.setError(errorMessage);
     } finally {
       wizard.setIsLoading(false);
+      submittingRef.current = false;
     }
   };
 

--- a/src/features/members/wizard/AddMemberModal.tsx
+++ b/src/features/members/wizard/AddMemberModal.tsx
@@ -57,6 +57,10 @@ export const AddMemberModal = ({ isOpen, onCloseAction, availableCoupons = [] }:
   const cardFirstSixRef = useRef<string | undefined>(undefined);
   const cardLastFourRef = useRef<string | undefined>(undefined);
 
+  // Re-entrancy guard: flips synchronously on click to drop duplicate submissions
+  // that fire before React flushes the disabled-button state.
+  const submittingRef = useRef(false);
+
   // Wrapper around wizard.updateData that also captures card refs synchronously
   // so handleFinalNext can read them (React setState is async).
   const updateDataWithRef = (updates: Partial<typeof wizard.data>) => {
@@ -94,6 +98,7 @@ export const AddMemberModal = ({ isOpen, onCloseAction, availableCoupons = [] }:
     cardTokenRef.current = undefined;
     cardFirstSixRef.current = undefined;
     cardLastFourRef.current = undefined;
+    submittingRef.current = false;
     wizard.reset();
     onCloseAction();
   };
@@ -106,6 +111,7 @@ export const AddMemberModal = ({ isOpen, onCloseAction, availableCoupons = [] }:
     cardTokenRef.current = undefined;
     cardFirstSixRef.current = undefined;
     cardLastFourRef.current = undefined;
+    submittingRef.current = false;
     wizard.reset();
     onCloseAction();
     router.refresh();
@@ -176,6 +182,14 @@ export const AddMemberModal = ({ isOpen, onCloseAction, availableCoupons = [] }:
       wizard.setStep('success');
       return;
     }
+
+    // Re-entrancy guard: a second click that lands before React flushes the
+    // disabled-button state would otherwise fire a duplicate `member.create`.
+    // The ref flips synchronously, so the duplicate hits this early-return.
+    if (submittingRef.current) {
+      return;
+    }
+    submittingRef.current = true;
 
     try {
       wizard.setIsLoading(true);
@@ -484,6 +498,7 @@ export const AddMemberModal = ({ isOpen, onCloseAction, availableCoupons = [] }:
       wizard.setError(errorMessage);
     } finally {
       wizard.setIsLoading(false);
+      submittingRef.current = false;
     }
   };
 
@@ -495,6 +510,12 @@ export const AddMemberModal = ({ isOpen, onCloseAction, availableCoupons = [] }:
       wizard.setStep('success');
       return;
     }
+
+    // Re-entrancy guard — same rationale as handleFinalNext above.
+    if (submittingRef.current) {
+      return;
+    }
+    submittingRef.current = true;
 
     try {
       wizard.setIsLoading(true);
@@ -713,6 +734,7 @@ export const AddMemberModal = ({ isOpen, onCloseAction, availableCoupons = [] }:
       wizard.setError(errorMessage);
     } finally {
       wizard.setIsLoading(false);
+      submittingRef.current = false;
     }
   };
 

--- a/src/features/members/wizard/FamilyPaymentStep.test.tsx
+++ b/src/features/members/wizard/FamilyPaymentStep.test.tsx
@@ -1,0 +1,162 @@
+import type { AddMemberWizardData } from '@/hooks/useAddMemberWizard';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { page, userEvent } from 'vitest/browser';
+import { FamilyPaymentStep } from './FamilyPaymentStep';
+
+// Cover both the FamilyPaymentStep and PaymentStep namespaces — keys are looked
+// up under both via two `useTranslations` instances.
+const translationKeys: Record<string, string> = {
+  // FamilyPaymentStep
+  title: 'Confirm Family Member Billing',
+  subtitle_with_card: 'Pay with HOH card on file',
+  subtitle_no_card: 'Enter payment details',
+  summary_label: 'Billing Summary',
+  member_label: 'Member',
+  plan_label: 'Plan',
+  amount_label: 'Amount',
+  hoh_label: 'Head of Household',
+  payment_method_label: 'Payment Method',
+  payment_method_value: '{type} ending in {last4}',
+  billing_notice: 'HOH will be billed.',
+  no_card_notice: 'No card on file. Enter card.',
+  back_button: 'Back',
+  cancel_button: 'Cancel',
+  confirm_button: 'Confirm & Add Member',
+  processing_button: 'Processing...',
+  // PaymentStep namespace (read via tPayment)
+  card_tab_label: 'Debit / Credit Card',
+  ach_tab_label: 'ACH Bank Account',
+  cardholder_name_label: 'Name on card',
+  cardholder_name_placeholder: 'Full name',
+  card_number_label: 'Card number',
+  card_number_placeholder: '1234 5678 9012 3456',
+  card_expiry_label: 'Expiration MM/YY',
+  card_expiry_placeholder: 'MM/YY',
+  card_cvc_label: 'CVC/CVV',
+  card_cvc_placeholder: '123',
+  ach_account_holder_label: 'Account holder name',
+  ach_account_holder_placeholder: 'Full name',
+  ach_account_type_label: 'Account type',
+  ach_account_type_placeholder: 'Select account type',
+  ach_account_type_checking: 'Checking',
+  ach_account_type_savings: 'Savings',
+  ach_routing_number_label: 'Routing number',
+  ach_routing_number_placeholder: '021000021',
+  ach_account_number_label: 'Account number',
+  ach_account_number_placeholder: '123456789',
+  card_number_iframe_loading: 'Loading…',
+  card_number_iframe_error: 'Failed to load.',
+  payment_declined_title: 'Payment Declined',
+  payment_declined_continue_message: 'You can still continue.',
+  decline_reason_card_declined: 'The card was declined.',
+  decline_reason_generic: 'Payment failed.',
+  continue_without_payment_button: 'Add Member Anyway',
+  try_again_button: 'Try Again',
+};
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, params?: Record<string, string | number>) => {
+    let result = translationKeys[key] || key;
+    if (params) {
+      Object.entries(params).forEach(([k, v]) => {
+        result = result.replace(`{${k}}`, String(v));
+      });
+    }
+    return result;
+  },
+}));
+
+// Mock useTokenExIframe — inactive by default (no iframe).
+const mockTokenize = vi.fn();
+const mockIframeReturn = {
+  isLoaded: false,
+  isValid: false,
+  isCvvValid: false,
+  error: null as string | null,
+  tokenize: mockTokenize,
+};
+vi.mock('@/hooks/useTokenExIframe', () => ({
+  useTokenExIframe: () => mockIframeReturn,
+}));
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ resolvedTheme: 'light' }),
+}));
+
+const baseData: AddMemberWizardData = {
+  memberType: 'family-member',
+  firstName: 'Family',
+  lastName: 'Member',
+  email: 'fam@example.com',
+  phone: '555-0001',
+  membershipPlanId: 'plan-1',
+  membershipPlanPrice: 100,
+  membershipPlanName: 'Adult Monthly',
+  membershipPlanFrequency: 'Monthly',
+  hohMemberName: 'Head Honcho',
+  hohHasPaymentMethod: true,
+  hohPaymentMethodLast4: '4242',
+  hohPaymentMethodType: 'card',
+  paymentMethod: 'card',
+  waiverTemplateId: null,
+};
+
+const baseProps = {
+  data: baseData,
+  onUpdateAction: vi.fn(),
+  onNextAction: vi.fn(),
+  onBackAction: vi.fn(),
+  onCancelAction: vi.fn(),
+  isLoading: false,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIframeReturn.isLoaded = false;
+  mockIframeReturn.isValid = false;
+  mockIframeReturn.isCvvValid = false;
+});
+
+describe('FamilyPaymentStep — Try Again button (#131)', () => {
+  function declinedProps(overrides: Partial<typeof baseProps> = {}) {
+    return {
+      ...baseProps,
+      ...overrides,
+      data: {
+        ...baseData,
+        paymentStatus: 'declined' as const,
+        paymentDeclineReason: 'card_declined' as const,
+        paymentProcessed: true,
+        ...overrides.data,
+      },
+    };
+  }
+
+  it('does not render when paymentStatus is undefined', async () => {
+    render(<FamilyPaymentStep {...baseProps} />);
+
+    await expect.element(page.getByTestId('family-payment-try-again-button')).not.toBeInTheDocument();
+  });
+
+  it('renders when paymentStatus is declined', async () => {
+    render(<FamilyPaymentStep {...declinedProps()} />);
+
+    await expect.element(page.getByTestId('family-payment-try-again-button')).toBeInTheDocument();
+  });
+
+  it('clicking it clears decline state without calling onNextAction', async () => {
+    const onUpdateAction = vi.fn();
+    const onNextAction = vi.fn();
+    render(<FamilyPaymentStep {...declinedProps({ onUpdateAction, onNextAction })} />);
+
+    await userEvent.click(page.getByTestId('family-payment-try-again-button'));
+
+    expect(onUpdateAction).toHaveBeenCalledWith({
+      paymentStatus: undefined,
+      paymentDeclineReason: undefined,
+      paymentProcessed: false,
+    });
+    expect(onNextAction).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/members/wizard/FamilyPaymentStep.tsx
+++ b/src/features/members/wizard/FamilyPaymentStep.tsx
@@ -216,6 +216,16 @@ export const FamilyPaymentStep = ({
     onNextAction();
   }, [hohHasCard, useIframe, paymentMethod, onNextAction, onUpdateAction, iframeTokenize]);
 
+  // Try Again on a declined family payment — clear status so the user can
+  // re-submit without re-entering card details. Mirrors PaymentStep.handleTryAgain.
+  const handleTryAgain = useCallback(() => {
+    onUpdateAction({
+      paymentStatus: undefined,
+      paymentDeclineReason: undefined,
+      paymentProcessed: false,
+    });
+  }, [onUpdateAction]);
+
   return (
     <div className="space-y-6">
       <div>
@@ -619,22 +629,34 @@ export const FamilyPaymentStep = ({
             {t('cancel_button')}
           </Button>
         </div>
-        <Button
-          onClick={handleConfirm}
-          disabled={!canProceed || isLoading || tokenizing}
-          variant={paymentStatus === 'declined' ? 'outline' : 'default'}
-        >
-          {(isLoading || tokenizing)
-            ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  {t('processing_button')}
-                </>
-              )
-            : paymentStatus === 'declined'
-              ? tPayment('continue_without_payment_button')
-              : t('confirm_button')}
-        </Button>
+        <div className="flex gap-3">
+          {paymentStatus === 'declined' && (
+            <Button
+              variant="default"
+              onClick={handleTryAgain}
+              disabled={isLoading || tokenizing}
+              data-testid="family-payment-try-again-button"
+            >
+              {tPayment('try_again_button')}
+            </Button>
+          )}
+          <Button
+            onClick={handleConfirm}
+            disabled={!canProceed || isLoading || tokenizing}
+            variant={paymentStatus === 'declined' ? 'outline' : 'default'}
+          >
+            {(isLoading || tokenizing)
+              ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    {t('processing_button')}
+                  </>
+                )
+              : paymentStatus === 'declined'
+                ? tPayment('continue_without_payment_button')
+                : t('confirm_button')}
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/features/members/wizard/MembershipStep.test.tsx
+++ b/src/features/members/wizard/MembershipStep.test.tsx
@@ -590,4 +590,55 @@ describe('MembershipStep', () => {
       await expect.element(page.getByText('7-day trial with 3 classes')).toBeInTheDocument();
     });
   });
+
+  describe('Stale membershipSkipped clearing on mount (#133)', () => {
+    it('clears membershipSkipped on mount when previously true', async () => {
+      const onUpdate = vi.fn();
+      render(
+        <MembershipStep
+          data={{ ...mockData, membershipSkipped: true }}
+          onUpdate={onUpdate}
+          onNext={mockHandlers.onNext}
+          onBack={mockHandlers.onBack}
+          onCancel={mockHandlers.onCancel}
+        />,
+      );
+
+      // Title fires after fetch — gives the mount effect a moment to run.
+      await expect.element(page.getByText('Choose Membership Plan')).toBeInTheDocument();
+
+      const skipResetCall = onUpdate.mock.calls.find(
+        (call) => {
+          const arg = call[0] as Record<string, unknown> | undefined;
+          return arg?.membershipSkipped === false;
+        },
+      );
+
+      expect(skipResetCall).toBeTruthy();
+    });
+
+    it('does not call onUpdate at mount when membershipSkipped is already false', async () => {
+      const onUpdate = vi.fn();
+      render(
+        <MembershipStep
+          data={{ ...mockData, membershipSkipped: false }}
+          onUpdate={onUpdate}
+          onNext={mockHandlers.onNext}
+          onBack={mockHandlers.onBack}
+          onCancel={mockHandlers.onCancel}
+        />,
+      );
+
+      await expect.element(page.getByText('Choose Membership Plan')).toBeInTheDocument();
+
+      const skipResetCall = onUpdate.mock.calls.find(
+        (call) => {
+          const arg = call[0] as Record<string, unknown> | undefined;
+          return arg?.membershipSkipped === false;
+        },
+      );
+
+      expect(skipResetCall).toBeUndefined();
+    });
+  });
 });

--- a/src/features/members/wizard/MembershipStep.tsx
+++ b/src/features/members/wizard/MembershipStep.tsx
@@ -139,6 +139,20 @@ export const MembershipStep = ({
   const [isFetchingPlans, setIsFetchingPlans] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // #133: when the user reaches this step (which includes navigating Back from
+  // a later step after previously clicking Skip), clear the stale
+  // `membershipSkipped` flag. Without this, returning to Subscription leaves
+  // the wizard in a stuck "you skipped" state where Next is disabled and the
+  // user has to click Skip a second time to advance.
+  useEffect(() => {
+    if (data.membershipSkipped) {
+      onUpdate({ membershipSkipped: false });
+    }
+    // Run once on mount only — the click on Skip happens AFTER mount, and we
+    // don't want this effect to wipe the flag the user just set.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Fetch membership plans from database or use mocks
   useEffect(() => {
     const fetchPlans = async () => {

--- a/src/features/members/wizard/PaymentStep.test.tsx
+++ b/src/features/members/wizard/PaymentStep.test.tsx
@@ -2160,4 +2160,60 @@ describe('PaymentStep', () => {
       mockIframeReturn.isCvvValid = false;
     });
   });
+
+  describe('Try Again button (#131)', () => {
+    function declinedProps(overrides: Partial<typeof defaultProps> & { captureOnly?: boolean } = {}) {
+      const { captureOnly, ...rest } = overrides;
+      return {
+        ...defaultProps,
+        ...rest,
+        ...(captureOnly !== undefined ? { captureOnly } : {}),
+        data: {
+          ...defaultProps.data,
+          paymentStatus: 'declined' as const,
+          paymentDeclineReason: 'card_declined' as const,
+          paymentProcessed: true,
+          cardholderName: 'Jane Doe',
+          cardNumber: '4111111111111111',
+          cardExpiry: '12/30',
+          cardCvc: '123',
+          ...overrides.data,
+        },
+      };
+    }
+
+    it('does not render when paymentStatus is undefined', async () => {
+      render(<PaymentStep {...defaultProps} />);
+
+      await expect.element(page.getByTestId('payment-try-again-button')).not.toBeInTheDocument();
+    });
+
+    it('does not render when captureOnly mode is on', async () => {
+      const props = declinedProps({ captureOnly: true });
+      render(<PaymentStep {...props} />);
+
+      await expect.element(page.getByTestId('payment-try-again-button')).not.toBeInTheDocument();
+    });
+
+    it('renders when paymentStatus is declined and not captureOnly', async () => {
+      render(<PaymentStep {...declinedProps()} />);
+
+      await expect.element(page.getByTestId('payment-try-again-button')).toBeInTheDocument();
+    });
+
+    it('clicking it clears decline state without calling onNextAction', async () => {
+      const onUpdateAction = vi.fn();
+      const onNextAction = vi.fn();
+      render(<PaymentStep {...declinedProps({ onUpdateAction, onNextAction })} />);
+
+      await userEvent.click(page.getByTestId('payment-try-again-button'));
+
+      expect(onUpdateAction).toHaveBeenCalledWith({
+        paymentStatus: undefined,
+        paymentDeclineReason: undefined,
+        paymentProcessed: false,
+      });
+      expect(onNextAction).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/features/members/wizard/PaymentStep.tsx
+++ b/src/features/members/wizard/PaymentStep.tsx
@@ -273,6 +273,18 @@ export const PaymentStep = ({
     }
   }, [useIframe, paymentMethod, onNextAction, onUpdateAction, iframeTokenize]);
 
+  // Try Again: clear the declined status so the user can re-submit the form
+  // without re-entering payment fields. We deliberately do NOT auto-fire the
+  // submit — the user reviews their card details (which are preserved) and
+  // clicks the primary button explicitly.
+  const handleTryAgain = useCallback(() => {
+    onUpdateAction({
+      paymentStatus: undefined,
+      paymentDeclineReason: undefined,
+      paymentProcessed: false,
+    });
+  }, [onUpdateAction]);
+
   return (
     <div className="space-y-6">
       <div>
@@ -711,24 +723,36 @@ export const PaymentStep = ({
             {t('cancel_button')}
           </Button>
         </div>
-        <Button
-          onClick={handleNextClick}
-          disabled={!isFormValid || isLoading || tokenizing}
-          variant={paymentStatus === 'declined' ? 'outline' : 'default'}
-        >
-          {(isLoading || tokenizing)
-            ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  {t('processing_button')}
-                </>
-              )
-            : captureOnly
-              ? t('save_payment_method_button')
-              : paymentStatus === 'declined'
-                ? t('continue_without_payment_button')
-                : t('next_button')}
-        </Button>
+        <div className="flex gap-3">
+          {!captureOnly && paymentStatus === 'declined' && (
+            <Button
+              variant="default"
+              onClick={handleTryAgain}
+              disabled={isLoading || tokenizing}
+              data-testid="payment-try-again-button"
+            >
+              {t('try_again_button')}
+            </Button>
+          )}
+          <Button
+            onClick={handleNextClick}
+            disabled={!isFormValid || isLoading || tokenizing}
+            variant={paymentStatus === 'declined' ? 'outline' : 'default'}
+          >
+            {(isLoading || tokenizing)
+              ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    {t('processing_button')}
+                  </>
+                )
+              : captureOnly
+                ? t('save_payment_method_button')
+                : paymentStatus === 'declined'
+                  ? t('continue_without_payment_button')
+                  : t('next_button')}
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/features/members/wizard/reentrancyGuard.test.ts
+++ b/src/features/members/wizard/reentrancyGuard.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * Regression-test for #136. The wizard modals (AddMemberModal,
+ * AddFamilyMembersModal, ConvertMemberModal) all use a synchronous
+ * `submittingRef` flag at the top of their async submit handlers to drop
+ * duplicate clicks that fire before React flushes the disabled-button state.
+ *
+ * The actual handlers have heavy dependencies (Clerk, ORPC, wizard state)
+ * that make them awkward to unit-test in isolation. This test verifies the
+ * pattern — synchronous ref + early-return + finally-reset — behaves the
+ * way the bug fix needs it to under rapid concurrent invocation.
+ *
+ * If you change the modal handlers, mirror the structure verified here so
+ * the underlying invariant doesn't drift.
+ */
+function makeGuardedHandler(work: () => Promise<void>) {
+  const submittingRef = { current: false };
+
+  const handler = async () => {
+    if (submittingRef.current) {
+      return;
+    }
+    submittingRef.current = true;
+    try {
+      await work();
+    } finally {
+      submittingRef.current = false;
+    }
+  };
+
+  const reset = () => {
+    submittingRef.current = false;
+  };
+
+  return { handler, reset, submittingRef };
+}
+
+describe('Modal submit re-entrancy guard pattern (#136)', () => {
+  it('drops a second concurrent invocation while the first is in flight', async () => {
+    const work = vi.fn(() => new Promise<void>(resolve => setTimeout(resolve, 20)));
+    const { handler } = makeGuardedHandler(work);
+
+    // Two synchronous calls — the second hits the guard before the first resolves.
+    const p1 = handler();
+    const p2 = handler();
+    await Promise.all([p1, p2]);
+
+    expect(work).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops five rapid clicks during a single submit', async () => {
+    const work = vi.fn(() => new Promise<void>(resolve => setTimeout(resolve, 20)));
+    const { handler } = makeGuardedHandler(work);
+
+    await Promise.all([handler(), handler(), handler(), handler(), handler()]);
+
+    expect(work).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a fresh invocation after the previous resolved', async () => {
+    const work = vi.fn(() => Promise.resolve());
+    const { handler } = makeGuardedHandler(work);
+
+    await handler();
+    await handler();
+    await handler();
+
+    expect(work).toHaveBeenCalledTimes(3);
+  });
+
+  it('releases the guard when work throws', async () => {
+    const work = vi.fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(undefined);
+    const { handler } = makeGuardedHandler(work);
+
+    await expect(handler()).rejects.toThrow('boom');
+
+    await handler();
+
+    expect(work).toHaveBeenCalledTimes(2);
+  });
+
+  it('reset() unlocks the guard mid-flight (mirrors handleCancel)', async () => {
+    let release!: () => void;
+    const inflight = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const work = vi.fn(() => inflight);
+    const { handler, reset, submittingRef } = makeGuardedHandler(work);
+
+    // Start the handler but don't await — it's still in flight.
+    void handler();
+
+    expect(submittingRef.current).toBe(true);
+
+    reset();
+
+    expect(submittingRef.current).toBe(false);
+
+    // Cleanup
+    release();
+    await inflight;
+  });
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -435,6 +435,7 @@
       "cancel_button": "Cancel",
       "next_button": "Next",
       "processing_button": "Processing...",
+      "try_again_button": "Try Again",
       "continue_without_payment_button": "Add Member Anyway",
       "payment_approved_title": "Payment Approved",
       "payment_approved_message": "The payment has been successfully processed. You can now proceed to complete member registration.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -435,6 +435,7 @@
       "cancel_button": "Annuler",
       "next_button": "Suivant",
       "processing_button": "Traitement en cours...",
+      "try_again_button": "Réessayer",
       "continue_without_payment_button": "Ajouter le membre quand même",
       "payment_approved_title": "Paiement approuvé",
       "payment_approved_message": "Le paiement a été traité avec succès. Vous pouvez maintenant terminer l'inscription du membre.",


### PR DESCRIPTION
## Summary

Closes #131
Closes #133
Closes #136. 

Three filed wizard bugs in the same neighborhood (Add Member wizard's payment flow), plus one latent systemic bug (re-entrancy) that bundles cleanly with #136.

## What changed

### #136 — Skip-membership flow created a duplicate member every click

`AddMemberModal.handleFinalNext` fired `client.member.create` with no idempotency guard. Each rapid click before the first request resolved inserted a fresh member row. Reporter saw five members from five clicks.

The same pattern was latent in three other wizard handlers:

- `AddMemberModal.handleFamilyMemberFinalNext`
- `AddFamilyMembersModal.handleFamilyMemberSubmit`
- `ConvertMemberModal.handleConvert`

Fix: a synchronous `submittingRef = useRef(false)` flag at the top of each handler. The ref flips synchronously on click (before React flushes the disabled-button state), so a second click hits the early-return and bails. Released in the `finally` block and reset on cancel/done so the modal isn't permanently locked if the user cancels mid-submit.

```ts
if (submittingRef.current) return;
submittingRef.current = true;
try {
  // ...existing logic
} finally {
  submittingRef.current = false;
}
```

### #131 — No Try Again on payment decline

When a charge declined, `PaymentStep` showed Back / Cancel / "Add Member Anyway" — no way to retry the same charge without backing out and re-signing the waiver.

Added a Try Again button that renders only when `paymentStatus === 'declined'` and not in capture-only mode. Clicking it clears `paymentStatus` / `paymentDeclineReason` / `paymentProcessed` so the form re-enables; the user reviews their **preserved** card details and clicks the primary submit button explicitly. The button does not auto-fire the submit — that avoids both blind retries with the same data and any risk of re-firing requests on render.

Mirrored in `FamilyPaymentStep` so the family-payment flow has parity. The family-to-individual conversion flow inherits the fix automatically since it uses the same `PaymentStep`.

### #133 — Back didn't work after Skip on Subscription

Clicking "Skip for now" on Subscription set `membershipSkipped: true` and advanced. Returning to Subscription via Back left the page in a stuck state: `membershipPlanId` was null (Next disabled), and the lingering `membershipSkipped: true` made the wizard's state machine inconsistent — the user had to click Skip a second time to advance.

Fix: a mount-only `useEffect` in `MembershipStep` clears `membershipSkipped: false` whenever the user lands on the step. Skip still flows forward correctly; the click happens after mount so the effect doesn't wipe the just-set flag.

## Files changed

- `src/features/members/wizard/AddMemberModal.tsx` — `submittingRef` guard on `handleFinalNext` + `handleFamilyMemberFinalNext`; reset in `handleCancel` and `handleSuccess`.
- `src/features/members/wizard/AddFamilyMembersModal.tsx` — same guard on `handleFamilyMemberSubmit`; reset in `handleCancel` / `handleDone` / `handleAddAnother`.
- `src/features/members/conversion/ConvertMemberModal.tsx` — same guard on `handleConvert`; reset in `handleCancel` / `handleSuccess`.
- `src/features/members/wizard/PaymentStep.tsx` — `handleTryAgain` + Try Again button (visible only when declined, not capture-only).
- `src/features/members/wizard/FamilyPaymentStep.tsx` — same Try Again button (reuses the `PaymentStep` i18n namespace key).
- `src/features/members/wizard/MembershipStep.tsx` — mount-effect clears `membershipSkipped`.
- `src/locales/en.json` + `src/locales/fr.json` — new `try_again_button` key under `AddMemberWizard.PaymentStep`.

## Tests

- `PaymentStep.test.tsx` (+4) — Try Again does not render when `paymentStatus` is undefined; does not render in capture-only mode; renders when declined; clicking it calls `onUpdateAction` with the reset payload and does not call `onNextAction`.
- `FamilyPaymentStep.test.tsx` (new, 3 tests) — same scenarios for the family-payment variant.
- `MembershipStep.test.tsx` (+2) — mount with `membershipSkipped: true` calls `onUpdate({ membershipSkipped: false })`; mount with `false` does not.
- `reentrancyGuard.test.ts` (new, 5 tests) — pattern-level regression for the submittingRef invariant: drops a second concurrent invocation; drops 5 rapid clicks; allows fresh invocation after resolve; releases the guard when work throws; `reset()` unlocks mid-flight (mirrors `handleCancel`).
- All 4155 tests pass; lint / types / deps / i18n all clean.

## Test plan

- [ ] `npm run lint && npm run check:types && npm run check:deps && npm run check:i18n && npm run test`
- [ ] **#136 manual**: Add Member → HOH → Subscription → Skip for now → Payment (capture-only) → fill card → click Save Payment Method **rapidly five times**. Verify exactly one member is created (`SELECT COUNT(*) FROM member WHERE email = '...'`). Repeat for the family-add flow and the convert flow.
- [ ] **#131 manual**: Add Member → Individual → flow to Payment → enter a declining card → submit. Decline UI shows Try Again. Click Try Again → status clears, card fields stay populated, primary button re-enables. Click Pay again → retry fires. Same on family payment.
- [ ] **#133 manual**: Add Member → HOH → Subscription → Skip → on Waiver no-waiver panel, click Back → returns to Subscription. Click any plan → Next button enables immediately (not stuck from stale `membershipSkipped`). Continue normally.
- [ ] DevTools Network: rapid-click test produces exactly one `member/create` POST.
- [ ] No regression on the convert flow's family-to-individual path: walks confirm → subscription → waiver → payment → success.

## E2E impact

None. The existing `add-member-wizard.e2e.ts` matches "Add Member Anyway" by exact substring (`name: /Add Member Anyway/i`), unaffected by the new sibling Try Again button. No e2e coverage exists for the Skip-for-now flow or for capture-only mode, so #133 / #136 don't risk breaking existing assertions.

