### PR TITLE
Address GH issues for classes and calendar

### DIFF
--- a/src/app/[locale]/(auth)/dashboard/classes/[classId]/page.tsx
+++ b/src/app/[locale]/(auth)/dashboard/classes/[classId]/page.tsx
@@ -19,9 +19,36 @@ import { EditClassBasicsModal } from '@/features/classes/details/EditClassBasics
 import { EditClassScheduleModal } from '@/features/classes/details/EditClassScheduleModal';
 import { EditClassSettingsModal } from '@/features/classes/details/EditClassSettingsModal';
 import { EditScheduleInstanceModal } from '@/features/classes/details/EditScheduleInstanceModal';
-import { useClassesCache } from '@/hooks/useClassesCache';
+import { invalidateClassesCache, useClassesCache } from '@/hooks/useClassesCache';
 import { useHasRole } from '@/hooks/useHasRole';
+import { client } from '@/libs/Orpc';
 import { ORG_ROLE } from '@/types/Auth';
+
+// Convert wizard 12-hour {hour, minute, AM/PM} → DB 24-hour "HH:MM".
+function exceptionTo24h(hour: number | undefined, minute: number | undefined, amPm: 'AM' | 'PM' | undefined): string | null {
+  if (hour === undefined || minute === undefined || amPm === undefined) {
+    return null;
+  }
+  let h = hour % 12;
+  if (amPm === 'PM') {
+    h += 12;
+  }
+  return `${h.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`;
+}
+
+function add24hDuration(start: string | null, durationHours: number | undefined, durationMinutes: number | undefined): string | null {
+  if (start === null || durationHours === undefined || durationMinutes === undefined) {
+    return null;
+  }
+  const [hStr, mStr] = start.split(':');
+  let h = Number.parseInt(hStr ?? '0', 10);
+  let m = Number.parseInt(mStr ?? '0', 10);
+  m += durationMinutes;
+  h += durationHours + Math.floor(m / 60);
+  m %= 60;
+  h %= 24;
+  return `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`;
+}
 
 export type ClassLevel = 'Beginner' | 'Intermediate' | 'Advanced' | 'All Levels';
 export type ClassType = 'Adults' | 'Kids' | 'Women' | 'Open' | 'Competition';
@@ -196,15 +223,26 @@ export default function ClassDetailPage({ params }: { params: Promise<PageParams
     setLastInitialId(initialClassData.id);
   }
 
-  // Handler for updating class data
+  // Handler for updating class data — currently only the local detail state
+  // is updated. The Edit Basics / Schedule / Settings modals don't post back
+  // to the server yet (out of scope for this PR; tracked separately).
   const handleUpdateClass = (updates: Partial<ClassDetailData>) => {
     if (classData) {
       setClassData({ ...classData, ...updates });
     }
   };
 
-  // Handler for deleting class
-  const handleDeleteClass = () => {
+  // Handler for deleting class — soft-deletes on the server then navigates.
+  const handleDeleteClass = async () => {
+    if (!classData) {
+      return;
+    }
+    try {
+      await client.classes.remove({ id: classData.id });
+      await invalidateClassesCache();
+    } catch (err) {
+      console.error('[Class Detail] Failed to delete class:', err);
+    }
     router.push(backToClassesUrl);
   };
 
@@ -214,30 +252,50 @@ export default function ClassDetailPage({ params }: { params: Promise<PageParams
     setIsEditInstanceOpen(true);
   };
 
-  // Handler for saving a schedule exception
-  const handleSaveException = (exception: ScheduleException) => {
+  // Persist a schedule exception to the database. Optimistically updates
+  // local state so the UI reflects the change immediately, then revalidates
+  // the cache so the calendar grid picks up the new row.
+  const handleSaveException = async (exception: ScheduleException) => {
     if (!classData) {
       return;
     }
 
     const existingIndex = classData.scheduleExceptions.findIndex(e => e.id === exception.id);
-    let updatedExceptions: ScheduleException[];
+    const updatedExceptions = existingIndex >= 0
+      ? classData.scheduleExceptions.map((e, i) => (i === existingIndex ? exception : e))
+      : [...classData.scheduleExceptions, exception];
+    setClassData({ ...classData, scheduleExceptions: updatedExceptions });
 
-    if (existingIndex >= 0) {
-      updatedExceptions = [...classData.scheduleExceptions];
-      updatedExceptions[existingIndex] = exception;
-    } else {
-      updatedExceptions = [...classData.scheduleExceptions, exception];
+    const newStartTime = exceptionTo24h(
+      exception.overrides?.timeHour,
+      exception.overrides?.timeMinute,
+      exception.overrides?.timeAmPm,
+    );
+    const newEndTime = add24hDuration(
+      newStartTime,
+      exception.overrides?.durationHours,
+      exception.overrides?.durationMinutes,
+    );
+
+    try {
+      await client.classes.upsertException({
+        classScheduleInstanceId: exception.scheduleInstanceId,
+        exceptionDate: new Date(`${exception.date}T00:00:00Z`),
+        exceptionType: exception.type,
+        newStartTime,
+        newEndTime,
+        newInstructorClerkId: exception.overrides?.staffMember || null,
+        reason: exception.note || null,
+      });
+      await invalidateClassesCache();
+    } catch (err) {
+      console.error('[Class Detail] Failed to save schedule exception:', err);
     }
-
-    setClassData({
-      ...classData,
-      scheduleExceptions: updatedExceptions,
-    });
   };
 
-  // Handler for deleting a schedule instance (creating a deletion exception)
-  const handleDeleteException = (exception: ScheduleException) => {
+  // Persist a "deleted" exception (cancellation of a recurring instance on a
+  // specific date). Same shape as save — type is just 'deleted'.
+  const handleDeleteException = async (exception: ScheduleException) => {
     if (!classData) {
       return;
     }
@@ -245,19 +303,25 @@ export default function ClassDetailPage({ params }: { params: Promise<PageParams
     const existingIndex = classData.scheduleExceptions.findIndex(
       e => e.scheduleInstanceId === exception.scheduleInstanceId && e.date === exception.date,
     );
-    let updatedExceptions: ScheduleException[];
+    const updatedExceptions = existingIndex >= 0
+      ? classData.scheduleExceptions.map((e, i) => (i === existingIndex ? exception : e))
+      : [...classData.scheduleExceptions, exception];
+    setClassData({ ...classData, scheduleExceptions: updatedExceptions });
 
-    if (existingIndex >= 0) {
-      updatedExceptions = [...classData.scheduleExceptions];
-      updatedExceptions[existingIndex] = exception;
-    } else {
-      updatedExceptions = [...classData.scheduleExceptions, exception];
+    try {
+      await client.classes.upsertException({
+        classScheduleInstanceId: exception.scheduleInstanceId,
+        exceptionDate: new Date(`${exception.date}T00:00:00Z`),
+        exceptionType: exception.type,
+        newStartTime: null,
+        newEndTime: null,
+        newInstructorClerkId: null,
+        reason: exception.note || null,
+      });
+      await invalidateClassesCache();
+    } catch (err) {
+      console.error('[Class Detail] Failed to save schedule exception:', err);
     }
-
-    setClassData({
-      ...classData,
-      scheduleExceptions: updatedExceptions,
-    });
   };
 
   if (loading) {

--- a/src/app/[locale]/(auth)/dashboard/classes/events/[eventId]/page.tsx
+++ b/src/app/[locale]/(auth)/dashboard/classes/events/[eventId]/page.tsx
@@ -23,7 +23,9 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useEventsCache } from '@/hooks/useEventsCache';
+import { EditEventModal } from '@/features/events/details/EditEventModal';
+import { invalidateEventsCache, useEventsCache } from '@/hooks/useEventsCache';
+import { client } from '@/libs/Orpc';
 import { formatPrice, getInitials } from './eventData';
 
 function formatSessionDate(date: Date): string {
@@ -94,15 +96,26 @@ export default function EventDetailPage({ params }: { params: Promise<PageParams
 
   // Modal states
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [editTab, setEditTab] = useState<'details' | 'pricing' | 'sessions' | null>(null);
 
   // Find event from cache and transform
-  const eventData = useMemo(() => {
-    const raw = events.find(e => e.id === resolvedParams.eventId);
-    return raw ? transformEventData(raw) : null;
-  }, [events, resolvedParams.eventId]);
+  const rawEvent = useMemo(
+    () => events.find(e => e.id === resolvedParams.eventId) ?? null,
+    [events, resolvedParams.eventId],
+  );
+  const eventData = useMemo(() => (rawEvent ? transformEventData(rawEvent) : null), [rawEvent]);
 
-  // Handler for deleting event
-  const handleDeleteEvent = () => {
+  // Handler for deleting event — soft-delete on the server then navigate.
+  const handleDeleteEvent = async () => {
+    if (!eventData) {
+      return;
+    }
+    try {
+      await client.events.remove({ id: eventData.id });
+      await invalidateEventsCache();
+    } catch (err) {
+      console.error('[Event Detail] Failed to delete event:', err);
+    }
     router.push(backToClassesUrl);
   };
 
@@ -194,7 +207,7 @@ export default function EventDetailPage({ params }: { params: Promise<PageParams
           <Card className="p-6">
             <div className="mb-4 flex items-center justify-between">
               <h2 className="text-lg font-semibold text-foreground">{t('details_card_title')}</h2>
-              <Button variant="outline" size="sm">
+              <Button variant="outline" size="sm" onClick={() => setEditTab('details')} aria-label={t('edit_details_aria')}>
                 <Edit className="h-4 w-4" />
               </Button>
             </div>
@@ -236,7 +249,7 @@ export default function EventDetailPage({ params }: { params: Promise<PageParams
           <Card className="p-6">
             <div className="mb-4 flex items-center justify-between">
               <h2 className="text-lg font-semibold text-foreground">{t('pricing_card_title')}</h2>
-              <Button variant="outline" size="sm">
+              <Button variant="outline" size="sm" onClick={() => setEditTab('pricing')} aria-label={t('edit_pricing_aria')}>
                 <Edit className="h-4 w-4" />
               </Button>
             </div>
@@ -282,7 +295,7 @@ export default function EventDetailPage({ params }: { params: Promise<PageParams
           <Card className="p-6">
             <div className="mb-4 flex items-center justify-between">
               <h2 className="text-lg font-semibold text-foreground">{t('sessions_card_title')}</h2>
-              <Button variant="outline" size="sm">
+              <Button variant="outline" size="sm" onClick={() => setEditTab('sessions')} aria-label={t('edit_sessions_aria')}>
                 <Edit className="h-4 w-4" />
               </Button>
             </div>
@@ -310,7 +323,7 @@ export default function EventDetailPage({ params }: { params: Promise<PageParams
           <Card className="p-6">
             <div className="mb-4 flex items-center justify-between">
               <h2 className="text-lg font-semibold text-foreground">{t('instructors_card_title')}</h2>
-              <Button variant="outline" size="sm">
+              <Button variant="outline" size="sm" onClick={() => setEditTab('sessions')} aria-label={t('edit_instructors_aria')}>
                 <Edit className="h-4 w-4" />
               </Button>
             </div>
@@ -345,6 +358,16 @@ export default function EventDetailPage({ params }: { params: Promise<PageParams
           {t('delete_button')}
         </Button>
       </div>
+
+      {/* Edit Modal — single modal with tabs, opened via the per-card Edit buttons */}
+      {rawEvent && (
+        <EditEventModal
+          isOpen={editTab !== null}
+          initialTab={editTab ?? 'details'}
+          event={rawEvent}
+          onCloseAction={() => setEditTab(null)}
+        />
+      )}
 
       {/* Delete Confirmation Dialog */}
       <AlertDialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>

--- a/src/features/classes/CalendarDateNav.test.tsx
+++ b/src/features/classes/CalendarDateNav.test.tsx
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { page, userEvent } from 'vitest/browser';
+import { CalendarDateNav } from './CalendarDateNav';
+
+const translationKeys: Record<string, string> = {
+  open_picker_aria: 'Open date picker',
+};
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => translationKeys[key] ?? key,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('CalendarDateNav', () => {
+  const defaultProps = {
+    currentDate: new Date('2026-03-15T00:00:00Z'),
+    display: 'March 15 - 21',
+  };
+
+  it('renders the display heading inside a popover trigger', () => {
+    render(
+      <CalendarDateNav
+        {...defaultProps}
+        onDateChangeAction={vi.fn()}
+      />,
+    );
+
+    const trigger = page.getByRole('button', { name: 'Open date picker' });
+
+    expect(trigger).toBeTruthy();
+    expect(trigger.element().textContent).toContain('March 15 - 21');
+  });
+
+  it('opens the popover Calendar when the heading button is clicked', async () => {
+    render(
+      <CalendarDateNav
+        {...defaultProps}
+        onDateChangeAction={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(page.getByRole('button', { name: 'Open date picker' }));
+
+    // The Shadcn Calendar renders a grid of dates. After opening, day cells
+    // should be present.
+    const dayCells = document.querySelectorAll('[role="gridcell"]');
+
+    expect(dayCells.length).toBeGreaterThan(0);
+  });
+
+  it('calls onDateChangeAction when a date is selected from the popover', async () => {
+    const onChange = vi.fn();
+    render(
+      <CalendarDateNav
+        {...defaultProps}
+        onDateChangeAction={onChange}
+      />,
+    );
+
+    await userEvent.click(page.getByRole('button', { name: 'Open date picker' }));
+
+    // Pick the first available day in the grid (a date in the current month).
+    const firstSelectableDay = Array.from(document.querySelectorAll('[role="gridcell"] button'))
+      .find(btn => !(btn as HTMLButtonElement).disabled) as HTMLButtonElement | undefined;
+
+    expect(firstSelectableDay).toBeDefined();
+
+    if (firstSelectableDay) {
+      await userEvent.click(firstSelectableDay);
+    }
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0]![0]).toBeInstanceOf(Date);
+  });
+
+  it('closes the popover after picking a date', async () => {
+    render(
+      <CalendarDateNav
+        {...defaultProps}
+        onDateChangeAction={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(page.getByRole('button', { name: 'Open date picker' }));
+
+    const firstSelectableDay = Array.from(document.querySelectorAll('[role="gridcell"] button'))
+      .find(btn => !(btn as HTMLButtonElement).disabled) as HTMLButtonElement | undefined;
+    if (firstSelectableDay) {
+      await userEvent.click(firstSelectableDay);
+    }
+
+    // After selection, the calendar grid is removed from the DOM (popover closes).
+    await new Promise(r => setTimeout(r, 100));
+
+    expect(document.querySelectorAll('[role="gridcell"]').length).toBe(0);
+  });
+});

--- a/src/features/classes/CalendarDateNav.tsx
+++ b/src/features/classes/CalendarDateNav.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { CalendarIcon } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useState } from 'react';
+import { Calendar } from '@/components/ui/calendar';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+
+type CalendarDateNavProps = {
+  currentDate: Date;
+  onDateChangeAction: (date: Date) => void;
+  display: string;
+};
+
+/**
+ * Calendar header date navigator — a clickable heading that opens a popover
+ * Calendar so the user can jump to any date without paging through Previous /
+ * Next. Addresses #149: the original header was a static `<h2>` with no way
+ * to navigate to a specific date.
+ *
+ * We deliberately do NOT expose a free-text date input — typed dates are
+ * easy to mis-parse and add a layer of error handling that doesn't earn its
+ * keep. The popover is the only entry point.
+ */
+export function CalendarDateNav({ currentDate, onDateChangeAction, display }: CalendarDateNavProps) {
+  const t = useTranslations('Calendar');
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="flex items-center gap-2 rounded-md px-2 py-1 text-lg font-semibold text-foreground hover:bg-muted"
+          aria-label={t('open_picker_aria')}
+        >
+          <CalendarIcon className="h-4 w-4 text-muted-foreground" />
+          {display}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-auto p-0">
+        <Calendar
+          mode="single"
+          selected={currentDate}
+          onSelect={(d) => {
+            if (d) {
+              onDateChangeAction(d);
+              setOpen(false);
+            }
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/features/classes/MonthlyView.tsx
+++ b/src/features/classes/MonthlyView.tsx
@@ -9,6 +9,7 @@ import { ButtonGroupItem, ButtonGroupRoot } from '@/components/ui/button-group';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useClassesCache } from '@/hooks/useClassesCache';
 import { useEventsCache } from '@/hooks/useEventsCache';
+import { CalendarDateNav } from './CalendarDateNav';
 import { buildClassColorLegend, generateMonthlyEventScheduleFromData, generateMonthlyScheduleFromData, transformClassesToCardProps } from './classDataTransformers';
 import { ClassEventHoverCard } from './ClassEventHoverCard';
 import { ClassFilterBar } from './ClassFilterBar';
@@ -189,7 +190,11 @@ export function MonthlyView({ withFilters }: MonthlyViewProps = {}) {
           >
             ← Previous
           </button>
-          <h2 className="text-lg font-semibold text-foreground">{dateDisplay}</h2>
+          <CalendarDateNav
+            currentDate={currentDate}
+            onDateChangeAction={setCurrentDate}
+            display={dateDisplay}
+          />
           <button
             type="button"
             onClick={handleNext}
@@ -224,43 +229,51 @@ export function MonthlyView({ withFilters }: MonthlyViewProps = {}) {
           <tbody className="bg-background">
             {weeks.map(week => (
               <tr key={week.key} className="border-b border-border last:border-b-0">
-                {week.days.map(day => (
-                  <td
-                    key={day ?? `empty-${week.key}`}
-                    className={`h-20 border-r border-border p-1 align-top last:border-r-0 sm:h-24 sm:p-2 ${
-                      !day ? 'bg-muted' : ''
-                    }`}
-                  >
-                    {day && (
-                      <>
-                        <div className="mb-1 text-sm font-semibold text-foreground">{day}</div>
-                        <div className="flex flex-col gap-1">
-                          {monthlyEvents[day.toString()]?.slice(0, 3).map(event => (
-                            <ClassEventHoverCard
-                              key={`${event.classId}-${day}-${event.hour}-${event.minute}`}
-                              classId={event.classId}
-                              className={event.className}
-                              color={event.color}
-                              exception={event.exception}
-                              sourceView="monthly"
-                              isEvent={event.isEvent}
-                              eventId={event.eventId}
-                            >
-                              <span className="truncate">{event.className}</span>
-                            </ClassEventHoverCard>
-                          ))}
-                          {(monthlyEvents[day.toString()]?.length ?? 0) > 3 && (
-                            <div className="text-xs text-muted-foreground">
-                              +
-                              {monthlyEvents[day.toString()]!.length - 3}
-                              {' more'}
-                            </div>
-                          )}
-                        </div>
-                      </>
-                    )}
-                  </td>
-                ))}
+                {week.days.map((day) => {
+                  const today = new Date();
+                  const isToday = day !== null
+                    && today.getFullYear() === year
+                    && today.getMonth() === month
+                    && today.getDate() === day;
+                  return (
+                    <td
+                      key={day ?? `empty-${week.key}`}
+                      className={`h-20 border-r border-border p-1 align-top last:border-r-0 sm:h-24 sm:p-2 ${
+                        !day ? 'bg-muted' : isToday ? 'bg-blue-50 dark:bg-blue-950/40' : ''
+                      }`}
+                      aria-current={isToday ? 'date' : undefined}
+                    >
+                      {day && (
+                        <>
+                          <div className={`mb-1 text-sm font-semibold ${isToday ? 'text-primary' : 'text-foreground'}`}>{day}</div>
+                          <div className="flex flex-col gap-1">
+                            {monthlyEvents[day.toString()]?.slice(0, 3).map(event => (
+                              <ClassEventHoverCard
+                                key={`${event.classId}-${day}-${event.hour}-${event.minute}`}
+                                classId={event.classId}
+                                className={event.className}
+                                color={event.color}
+                                exception={event.exception}
+                                sourceView="monthly"
+                                isEvent={event.isEvent}
+                                eventId={event.eventId}
+                              >
+                                <span className="truncate">{event.className}</span>
+                              </ClassEventHoverCard>
+                            ))}
+                            {(monthlyEvents[day.toString()]?.length ?? 0) > 3 && (
+                              <div className="text-xs text-muted-foreground">
+                                +
+                                {monthlyEvents[day.toString()]!.length - 3}
+                                {' more'}
+                              </div>
+                            )}
+                          </div>
+                        </>
+                      )}
+                    </td>
+                  );
+                })}
               </tr>
             ))}
           </tbody>

--- a/src/features/classes/WeeklyView.tsx
+++ b/src/features/classes/WeeklyView.tsx
@@ -9,6 +9,7 @@ import { ButtonGroupItem, ButtonGroupRoot } from '@/components/ui/button-group';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useClassesCache } from '@/hooks/useClassesCache';
 import { useEventsCache } from '@/hooks/useEventsCache';
+import { CalendarDateNav } from './CalendarDateNav';
 import { buildClassColorLegend, generateWeeklyEventScheduleFromData, generateWeeklyScheduleFromData, transformClassesToCardProps } from './classDataTransformers';
 import { ClassEventHoverCard } from './ClassEventHoverCard';
 import { ClassFilterBar } from './ClassFilterBar';
@@ -199,7 +200,11 @@ export function WeeklyView({ withFilters }: WeeklyViewProps = {}) {
           >
             ← Previous
           </button>
-          <h2 className="text-lg font-semibold text-foreground">{dateDisplay}</h2>
+          <CalendarDateNav
+            currentDate={currentDate}
+            onDateChangeAction={setCurrentDate}
+            display={dateDisplay}
+          />
           <button
             type="button"
             onClick={handleNext}
@@ -223,10 +228,18 @@ export function WeeklyView({ withFilters }: WeeklyViewProps = {}) {
               {Array.from({ length: 7 }).map((_, i) => {
                 const date = new Date(weekStart);
                 date.setDate(weekStart.getDate() + i);
+                const today = new Date();
+                const isToday
+                  = date.getFullYear() === today.getFullYear()
+                    && date.getMonth() === today.getMonth()
+                    && date.getDate() === today.getDate();
                 return (
                   <th
                     key={date.toISOString()}
-                    className="border-r border-border p-2 text-center text-xs font-semibold text-foreground last:border-r-0 sm:text-sm"
+                    className={`border-r border-border p-2 text-center text-xs font-semibold last:border-r-0 sm:text-sm ${
+                      isToday ? 'bg-blue-50 text-primary dark:bg-blue-950/40' : 'text-foreground'
+                    }`}
+                    aria-current={isToday ? 'date' : undefined}
                   >
                     <div>{DAYS_OF_WEEK[i]}</div>
                     <div>{date.getDate()}</div>

--- a/src/features/classes/wizard/AddClassModal.tsx
+++ b/src/features/classes/wizard/AddClassModal.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { DayOfWeek } from '@/hooks/useAddClassWizard';
 import type { ClassCardProps, ScheduleItem } from '@/templates/ClassCard';
 import type { EventCardProps, EventSession as EventCardSession } from '@/templates/EventCard';
 import { useOrganization } from '@clerk/nextjs';
@@ -8,6 +9,7 @@ import { useRouter } from 'next/navigation';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { useAddClassWizard } from '@/hooks/useAddClassWizard';
 import { useTagsCache } from '@/hooks/useTagsCache';
+import { client } from '@/libs/Orpc';
 import { ClassBasicsStep } from './ClassBasicsStep';
 import { ClassScheduleStep } from './ClassScheduleStep';
 import { ClassSuccessStep } from './ClassSuccessStep';
@@ -42,6 +44,46 @@ const MOCK_STAFF: Record<string, { name: string; photoUrl: string }> = {
   'professor-ivan': { name: 'Professor Ivan', photoUrl: 'https://api.dicebear.com/7.x/avataaars/svg?seed=Ivan' },
 };
 
+const DAY_OF_WEEK_INDEX: Record<DayOfWeek, number> = {
+  Sunday: 0,
+  Monday: 1,
+  Tuesday: 2,
+  Wednesday: 3,
+  Thursday: 4,
+  Friday: 5,
+  Saturday: 6,
+};
+
+// Convert wizard's 12-hour {hour, minute, AM/PM} to 24-hour "HH:MM".
+function to24h(hour: number, minute: number, amPm: 'AM' | 'PM'): string {
+  let h = hour % 12;
+  if (amPm === 'PM') {
+    h += 12;
+  }
+  return `${h.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`;
+}
+
+// Add hours+minutes to a "HH:MM" string, returning a "HH:MM" string. Used to
+// derive endTime from startTime + duration.
+function addDuration(start: string, durationHours: number, durationMinutes: number): string {
+  const [hStr, mStr] = start.split(':');
+  let h = Number.parseInt(hStr ?? '0', 10);
+  let m = Number.parseInt(mStr ?? '0', 10);
+  m += durationMinutes;
+  h += durationHours + Math.floor(m / 60);
+  m %= 60;
+  h %= 24;
+  return `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`;
+}
+
+const EVENT_TYPE_TO_API: Record<string, 'seminar' | 'workshop' | 'tournament' | 'camp' | 'other'> = {
+  'Seminar': 'seminar',
+  'Workshop': 'workshop',
+  'Guest Instructor': 'other',
+  'Tournament': 'tournament',
+  'Other': 'other',
+};
+
 export const AddClassModal = ({ isOpen, onCloseAction, onClassCreated, onEventCreated }: AddClassModalProps) => {
   const router = useRouter();
   const wizard = useAddClassWizard();
@@ -72,17 +114,64 @@ export const AddClassModal = ({ isOpen, onCloseAction, onClassCreated, onEventCr
 
       const isEvent = wizard.data.itemType === 'event';
 
-      // Log creation (mock)
-      console.info(`[Add Class/Event Wizard] Starting ${isEvent ? 'event' : 'class'} creation:`, {
-        timestamp: new Date().toISOString(),
-        wizardData: wizard.data,
-      });
-
-      // Mock API call delay
-      await new Promise(resolve => setTimeout(resolve, 500));
-
       if (isEvent) {
-        // Create event object
+        // Build the API payload from the wizard's 12-hour-with-AM/PM shape.
+        const sessions = wizard.data.eventSchedule.sessions.map((s) => {
+          const start = to24h(s.timeHour, s.timeMinute, s.timeAmPm);
+          const end = addDuration(start, s.durationHours, s.durationMinutes);
+          return {
+            sessionDate: new Date(s.date),
+            startTime: start,
+            endTime: end,
+            primaryInstructorClerkId: s.staffMember || null,
+            room: wizard.data.eventSchedule.location || null,
+          };
+        });
+
+        const billing = wizard.data.eventBilling.hasFee && wizard.data.eventBilling.price !== null
+          ? [{
+              name: 'Regular',
+              price: wizard.data.eventBilling.price,
+              memberOnly: false,
+              sortOrder: 0,
+              ...(wizard.data.eventBilling.hasEarlyBird
+                && wizard.data.eventBilling.earlyBirdPrice !== null
+                && wizard.data.eventBilling.earlyBirdDeadline
+                ? { validUntil: new Date(wizard.data.eventBilling.earlyBirdDeadline) }
+                : {}),
+            }]
+          : [];
+        if (wizard.data.eventBilling.hasFee
+          && wizard.data.eventBilling.hasEarlyBird
+          && wizard.data.eventBilling.earlyBirdPrice !== null) {
+          billing.push({
+            name: 'Early Bird',
+            price: wizard.data.eventBilling.earlyBirdPrice,
+            memberOnly: false,
+            sortOrder: 1,
+            ...(wizard.data.eventBilling.earlyBirdDeadline
+              ? { validUntil: new Date(wizard.data.eventBilling.earlyBirdDeadline) }
+              : {}),
+          });
+        }
+
+        const apiEventType = EVENT_TYPE_TO_API[wizard.data.eventType || 'Other'] ?? 'other';
+
+        const result = await client.events.create({
+          name: wizard.data.eventName,
+          description: wizard.data.eventDescription || null,
+          eventType: apiEventType,
+          maxCapacity: wizard.data.eventMaxCapacity ?? null,
+          isPublic: true,
+          isActive: true,
+          sessions,
+          billing,
+          tagIds: wizard.data.tags,
+        });
+
+        // Build the EventCardProps from the wizard data for the success-step
+        // preview. The server has the canonical id; everything else is what
+        // the user just entered, formatted for display.
         const formatEventSessions = (): EventCardSession[] => {
           return wizard.data.eventSchedule.sessions.map((session) => {
             const hour = session.timeHour;
@@ -91,15 +180,12 @@ export const AddClassModal = ({ isOpen, onCloseAction, onClassCreated, onEventCr
             const endMinute = (session.timeMinute + session.durationMinutes) % 60;
             const endAmPm = session.timeAmPm === 'AM' && endHour >= 12 ? 'PM' : session.timeAmPm;
             const displayEndHour = endHour > 12 ? endHour - 12 : endHour;
-
-            // Format the date for display
             const dateObj = new Date(session.date);
             const formattedDate = dateObj.toLocaleDateString('en-US', {
               month: 'long',
               day: 'numeric',
               year: 'numeric',
             });
-
             return {
               date: formattedDate,
               time: `${hour}:${minute} ${session.timeAmPm} - ${displayEndHour}:${endMinute.toString().padStart(2, '0')} ${endAmPm}`,
@@ -107,25 +193,19 @@ export const AddClassModal = ({ isOpen, onCloseAction, onClassCreated, onEventCr
           });
         };
 
-        // Get unique staff members from all sessions
         const uniqueStaffIds = [...new Set(wizard.data.eventSchedule.sessions.flatMap(s => [s.staffMember, s.assistantStaff].filter(Boolean)))];
         const eventInstructors = uniqueStaffIds
           .map(id => MOCK_STAFF[id])
           .filter((staff): staff is { name: string; photoUrl: string } => staff !== undefined);
 
-        // Format dates for display
         const formatDate = (dateStr: string) => {
           const dateObj = new Date(dateStr);
-          return dateObj.toLocaleDateString('en-US', {
-            month: 'long',
-            day: 'numeric',
-            year: 'numeric',
-          });
+          return dateObj.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
         };
 
         const newEvent: EventCardProps = {
-          id: `event-${Date.now()}`,
-          name: wizard.data.eventName,
+          id: result.event.id,
+          name: result.event.name,
           description: wizard.data.eventDescription,
           eventType: wizard.data.eventType || 'Other',
           startDate: formatDate(wizard.data.eventSchedule.startDate),
@@ -136,20 +216,35 @@ export const AddClassModal = ({ isOpen, onCloseAction, onClassCreated, onEventCr
           price: wizard.data.eventBilling.hasFee ? wizard.data.eventBilling.price : null,
         };
 
-        console.info('[Add Class/Event Wizard] Event created successfully:', {
-          timestamp: new Date().toISOString(),
-          newEvent,
-        });
-
-        // Notify parent about the new event
         if (onEventCreated) {
           onEventCreated(newEvent);
         }
       } else {
-        // Create the mock class object
+        const schedule = wizard.data.schedule.instances.map((i) => {
+          const start = to24h(i.timeHour, i.timeMinute, i.timeAmPm);
+          const end = addDuration(start, i.durationHours, i.durationMinutes);
+          return {
+            dayOfWeek: DAY_OF_WEEK_INDEX[i.dayOfWeek],
+            startTime: start,
+            endTime: end,
+            primaryInstructorClerkId: i.staffMember || null,
+            room: wizard.data.schedule.location || null,
+          };
+        });
+
+        const result = await client.classes.create({
+          name: wizard.data.className,
+          description: wizard.data.description || null,
+          color: wizard.data.calendarColor || null,
+          maxCapacity: wizard.data.maximumCapacity ?? null,
+          minAge: wizard.data.minimumAge ?? null,
+          isActive: true,
+          schedule,
+          tagIds: wizard.data.tags,
+        });
+
         const formatSchedule = (): ScheduleItem[] => {
-          const instances = wizard.data.schedule.instances;
-          return instances.map((instance) => {
+          return wizard.data.schedule.instances.map((instance) => {
             const hour = instance.timeHour;
             const minute = instance.timeMinute.toString().padStart(2, '0');
             const endHour = hour + instance.durationHours + Math.floor((instance.timeMinute + instance.durationMinutes) / 60);
@@ -163,43 +258,35 @@ export const AddClassModal = ({ isOpen, onCloseAction, onClassCreated, onEventCr
           });
         };
 
-        // Get unique staff members from all instances
         const uniqueStaffIds = [...new Set(wizard.data.schedule.instances.flatMap(i => [i.staffMember, i.assistantStaff].filter(Boolean)))];
         const classInstructors = uniqueStaffIds
           .map(id => MOCK_STAFF[id])
           .filter((staff): staff is { name: string; photoUrl: string } => staff !== undefined);
 
         const newClass: ClassCardProps = {
-          id: `class-${Date.now()}`,
-          name: wizard.data.className,
+          id: result.class.id,
+          name: result.class.name,
           description: wizard.data.description,
-          level: 'All Levels', // Default for new classes
+          level: 'All Levels',
           type: MOCK_PROGRAMS[wizard.data.program]?.split(' ')[0] || 'Adults',
-          style: 'Gi', // Default
+          style: 'Gi',
           schedule: formatSchedule(),
-          location: 'Current Location', // Uses the selected location from app context
+          location: wizard.data.schedule.location || 'Current Location',
           instructors: classInstructors,
         };
 
-        console.info('[Add Class/Event Wizard] Class created successfully:', {
-          timestamp: new Date().toISOString(),
-          newClass,
-        });
-
-        // Notify parent about the new class
         if (onClassCreated) {
           onClassCreated(newClass);
         }
       }
 
-      // Move to success step
       wizard.setStep('success');
     } catch (err) {
       console.error('[Add Class/Event Wizard] Failed to create:', {
         timestamp: new Date().toISOString(),
         error: err instanceof Error ? err.message : String(err),
       });
-      wizard.setError('Failed to create. Please try again.');
+      wizard.setError(err instanceof Error ? err.message : 'Failed to create. Please try again.');
     } finally {
       wizard.setIsLoading(false);
     }

--- a/src/features/events/details/EditEventModal.test.tsx
+++ b/src/features/events/details/EditEventModal.test.tsx
@@ -1,0 +1,188 @@
+import type { EventData } from '@/hooks/useEventsCache';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { page, userEvent } from 'vitest/browser';
+import { EditEventModal } from './EditEventModal';
+
+const translationKeys: Record<string, string> = {
+  title: 'Edit Event',
+  tab_details: 'Details',
+  tab_pricing: 'Pricing',
+  tab_sessions: 'Sessions',
+  name_label: 'Event Name',
+  name_placeholder: 'e.g. Black Belt Seminar',
+  event_type_label: 'Event Type',
+  event_type_seminar: 'Seminar',
+  event_type_workshop: 'Workshop',
+  event_type_tournament: 'Tournament',
+  event_type_camp: 'Camp',
+  event_type_other: 'Other',
+  max_capacity_label: 'Maximum Capacity',
+  max_capacity_placeholder: 'Leave blank for unlimited',
+  description_label: 'Description',
+  description_placeholder: 'What is this event about?',
+  description_character_count: '{count} / {max}',
+  tier_name_label: 'Tier Name',
+  tier_name_placeholder: 'e.g. Regular',
+  price_label: 'Price',
+  remove_tier_aria: 'Remove pricing tier',
+  add_tier_button: 'Add Pricing Tier',
+  session_date_label: 'Date',
+  session_start_label: 'Starts',
+  session_end_label: 'Ends',
+  remove_session_aria: 'Remove session',
+  add_session_button: 'Add Session',
+  cancel_button: 'Cancel',
+  save_button: 'Save Changes',
+  saving_button: 'Saving...',
+};
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, params?: Record<string, string | number>) => {
+    let result = translationKeys[key] ?? key;
+    if (params) {
+      Object.entries(params).forEach(([k, v]) => {
+        result = result.replace(`{${k}}`, String(v));
+      });
+    }
+    return result;
+  },
+}));
+
+const mockUpdate = vi.fn();
+const mockInvalidate = vi.fn();
+
+vi.mock('@/libs/Orpc', () => ({
+  client: {
+    events: {
+      update: (input: unknown) => mockUpdate(input),
+    },
+  },
+}));
+
+vi.mock('@/hooks/useEventsCache', () => ({
+  invalidateEventsCache: () => mockInvalidate(),
+}));
+
+const baseEvent: EventData = {
+  id: 'event-123',
+  name: 'Black Belt Seminar',
+  slug: 'black-belt-seminar',
+  description: 'A weekend seminar.',
+  eventType: 'seminar',
+  maxCapacity: 50,
+  isActive: true,
+  tags: [],
+  sessions: [
+    {
+      id: 'sess-1',
+      sessionDate: new Date('2026-06-15T00:00:00Z'),
+      startTime: '10:00',
+      endTime: '14:00',
+      instructorClerkId: null,
+    },
+  ],
+  billing: [
+    { id: 'bill-1', name: 'Regular', price: 99.99, memberOnly: false, validUntil: null },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUpdate.mockResolvedValue({ event: baseEvent });
+  mockInvalidate.mockResolvedValue(undefined);
+});
+
+describe('EditEventModal', () => {
+  it('does not render when isOpen is false', () => {
+    render(
+      <EditEventModal
+        isOpen={false}
+        event={baseEvent}
+        onCloseAction={vi.fn()}
+      />,
+    );
+
+    expect(document.body.textContent).not.toContain('Edit Event');
+  });
+
+  it('renders the title and pre-populates the name field', () => {
+    render(
+      <EditEventModal
+        isOpen={true}
+        event={baseEvent}
+        onCloseAction={vi.fn()}
+      />,
+    );
+
+    expect(page.getByText('Edit Event')).toBeTruthy();
+
+    const nameInput = page.getByLabelText('Event Name').element() as HTMLInputElement;
+
+    expect(nameInput.value).toBe('Black Belt Seminar');
+  });
+
+  it('opens on the initial tab and switches between tabs', async () => {
+    render(
+      <EditEventModal
+        isOpen={true}
+        event={baseEvent}
+        onCloseAction={vi.fn()}
+        initialTab="pricing"
+      />,
+    );
+
+    expect(page.getByText('Tier Name')).toBeTruthy();
+
+    await page.getByRole('tab', { name: 'Sessions' }).click();
+
+    expect(page.getByText('Date')).toBeTruthy();
+  });
+
+  it('calls client.events.update with the canonical payload on save', async () => {
+    const onClose = vi.fn();
+    render(
+      <EditEventModal
+        isOpen={true}
+        event={baseEvent}
+        onCloseAction={onClose}
+      />,
+    );
+
+    const saveButton = Array.from(document.querySelectorAll('button')).find(
+      btn => btn.textContent === 'Save Changes',
+    ) as HTMLButtonElement;
+    await userEvent.click(saveButton);
+
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+
+    const payload = mockUpdate.mock.calls[0]![0] as Record<string, unknown>;
+
+    expect(payload.id).toBe('event-123');
+    expect(payload.name).toBe('Black Belt Seminar');
+    expect(payload.eventType).toBe('seminar');
+    expect(payload.maxCapacity).toBe(50);
+    expect(Array.isArray(payload.sessions)).toBe(true);
+    expect(Array.isArray(payload.billing)).toBe(true);
+
+    expect(mockInvalidate).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('coerces unknown event types to "other" on open', () => {
+    const oddEvent = { ...baseEvent, eventType: 'something-weird' };
+    render(
+      <EditEventModal
+        isOpen={true}
+        event={oddEvent}
+        onCloseAction={vi.fn()}
+      />,
+    );
+
+    // The Select trigger shows the localized label; "Other" comes from
+    // event_type_other in our mock translations.
+    const trigger = page.getByLabelText('Event Type').element();
+
+    expect(trigger.textContent).toContain('Other');
+  });
+});

--- a/src/features/events/details/EditEventModal.tsx
+++ b/src/features/events/details/EditEventModal.tsx
@@ -1,0 +1,347 @@
+'use client';
+
+import type { EventData } from '@/hooks/useEventsCache';
+import { Plus, Trash2 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Textarea } from '@/components/ui/textarea';
+import { invalidateEventsCache } from '@/hooks/useEventsCache';
+import { client } from '@/libs/Orpc';
+
+const MAX_DESCRIPTION_LENGTH = 2000;
+
+type ApiEventType = 'seminar' | 'workshop' | 'tournament' | 'camp' | 'other';
+
+const ALLOWED_EVENT_TYPES: readonly ApiEventType[] = ['seminar', 'workshop', 'tournament', 'camp', 'other'];
+
+function normalizeEventType(raw: string): ApiEventType {
+  return ALLOWED_EVENT_TYPES.includes(raw as ApiEventType) ? (raw as ApiEventType) : 'other';
+}
+
+export type EditEventModalTab = 'details' | 'pricing' | 'sessions';
+
+type SessionRow = {
+  sessionDate: string; // YYYY-MM-DD
+  startTime: string; // HH:MM
+  endTime: string; // HH:MM
+};
+
+type BillingRow = {
+  name: string;
+  price: string; // string in form, parsed on save
+};
+
+type EditEventModalProps = {
+  isOpen: boolean;
+  onCloseAction: () => void;
+  initialTab?: EditEventModalTab;
+  event: EventData;
+  onSavedAction?: () => void;
+};
+
+function dateToInputValue(date: Date): string {
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(date.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function emptySession(): SessionRow {
+  return { sessionDate: '', startTime: '10:00', endTime: '12:00' };
+}
+
+function emptyBilling(): BillingRow {
+  return { name: 'Regular', price: '0' };
+}
+
+export function EditEventModal({
+  isOpen,
+  onCloseAction,
+  initialTab = 'details',
+  event,
+  onSavedAction,
+}: EditEventModalProps) {
+  const t = useTranslations('EventDetailPage.EditEventModal');
+
+  const [name, setName] = useState(event.name);
+  const [description, setDescription] = useState(event.description ?? '');
+  const [eventType, setEventType] = useState<ApiEventType>(normalizeEventType(event.eventType));
+  const [maxCapacity, setMaxCapacity] = useState<string>(
+    event.maxCapacity !== null ? String(event.maxCapacity) : '',
+  );
+  const [sessions, setSessions] = useState<SessionRow[]>([]);
+  const [billing, setBilling] = useState<BillingRow[]>([]);
+  const [tab, setTab] = useState<EditEventModalTab>(initialTab);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset form when modal opens — important because the parent reuses this
+  // component across multiple edit-button entry points and the event prop
+  // may change between opens.
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    setName(event.name);
+    setDescription(event.description ?? '');
+    setEventType(normalizeEventType(event.eventType));
+    setMaxCapacity(event.maxCapacity !== null ? String(event.maxCapacity) : '');
+    setSessions(
+      event.sessions.length > 0
+        ? event.sessions.map(s => ({
+            sessionDate: dateToInputValue(new Date(s.sessionDate)),
+            startTime: s.startTime,
+            endTime: s.endTime,
+          }))
+        : [emptySession()],
+    );
+    setBilling(
+      event.billing.length > 0
+        ? event.billing.map(b => ({ name: b.name, price: String(b.price) }))
+        : [emptyBilling()],
+    );
+    setTab(initialTab);
+    setError(null);
+  }, [isOpen, event, initialTab]);
+
+  const isNameValid = name.trim().length > 0;
+  const isFormValid
+    = isNameValid
+      && sessions.every(s => s.sessionDate && s.startTime && s.endTime)
+      && billing.every(b => b.name.trim() && !Number.isNaN(Number.parseFloat(b.price)));
+
+  const handleSubmit = async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      await client.events.update({
+        id: event.id,
+        name: name.trim(),
+        description: description.trim() || null,
+        eventType,
+        maxCapacity: maxCapacity ? Number.parseInt(maxCapacity, 10) : null,
+        isPublic: true,
+        isActive: event.isActive ?? true,
+        sessions: sessions.map(s => ({
+          sessionDate: new Date(`${s.sessionDate}T00:00:00Z`),
+          startTime: s.startTime,
+          endTime: s.endTime,
+        })),
+        billing: billing.map((b, idx) => ({
+          name: b.name.trim(),
+          price: Number.parseFloat(b.price) || 0,
+          memberOnly: false,
+          sortOrder: idx,
+        })),
+        tagIds: event.tags.map(tg => tg.id),
+      });
+      await invalidateEventsCache();
+      if (onSavedAction) {
+        onSavedAction();
+      }
+      onCloseAction();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save event.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={open => !open && onCloseAction()}>
+      <DialogContent className="max-h-[calc(100dvh-2rem)] max-w-3xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{t('title')}</DialogTitle>
+        </DialogHeader>
+
+        <Tabs value={tab} onValueChange={v => setTab(v as EditEventModalTab)} className="w-full">
+          <TabsList className="grid w-full grid-cols-3">
+            <TabsTrigger value="details">{t('tab_details')}</TabsTrigger>
+            <TabsTrigger value="pricing">{t('tab_pricing')}</TabsTrigger>
+            <TabsTrigger value="sessions">{t('tab_sessions')}</TabsTrigger>
+          </TabsList>
+
+          {/* Details tab */}
+          <TabsContent value="details" className="space-y-4 py-4">
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium" htmlFor="event-name">{t('name_label')}</label>
+              <Input
+                id="event-name"
+                value={name}
+                onChange={e => setName(e.target.value)}
+                placeholder={t('name_placeholder')}
+                error={!isNameValid && name.length > 0}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium" htmlFor="event-type">{t('event_type_label')}</label>
+              <Select value={eventType} onValueChange={v => setEventType(v as ApiEventType)}>
+                <SelectTrigger id="event-type">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="seminar">{t('event_type_seminar')}</SelectItem>
+                  <SelectItem value="workshop">{t('event_type_workshop')}</SelectItem>
+                  <SelectItem value="tournament">{t('event_type_tournament')}</SelectItem>
+                  <SelectItem value="camp">{t('event_type_camp')}</SelectItem>
+                  <SelectItem value="other">{t('event_type_other')}</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium" htmlFor="event-capacity">{t('max_capacity_label')}</label>
+              <Input
+                id="event-capacity"
+                type="number"
+                min={1}
+                value={maxCapacity}
+                onChange={e => setMaxCapacity(e.target.value)}
+                placeholder={t('max_capacity_placeholder')}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium" htmlFor="event-description">{t('description_label')}</label>
+              <Textarea
+                id="event-description"
+                value={description}
+                onChange={e => setDescription(e.target.value.slice(0, MAX_DESCRIPTION_LENGTH))}
+                rows={4}
+                placeholder={t('description_placeholder')}
+              />
+              <p className="text-xs text-muted-foreground">
+                {t('description_character_count', { count: description.length, max: MAX_DESCRIPTION_LENGTH })}
+              </p>
+            </div>
+          </TabsContent>
+
+          {/* Pricing tab */}
+          <TabsContent value="pricing" className="space-y-4 py-4">
+            <div className="space-y-3">
+              {billing.map((b, idx) => (
+                <div key={idx} className="flex items-end gap-2">
+                  <div className="flex-1 space-y-1.5">
+                    <label className="text-sm font-medium">{t('tier_name_label')}</label>
+                    <Input
+                      value={b.name}
+                      onChange={e => setBilling(prev => prev.map((row, i) => (i === idx ? { ...row, name: e.target.value } : row)))}
+                      placeholder={t('tier_name_placeholder')}
+                    />
+                  </div>
+                  <div className="w-32 space-y-1.5">
+                    <label className="text-sm font-medium">{t('price_label')}</label>
+                    <Input
+                      type="number"
+                      min={0}
+                      step="0.01"
+                      value={b.price}
+                      onChange={e => setBilling(prev => prev.map((row, i) => (i === idx ? { ...row, price: e.target.value } : row)))}
+                    />
+                  </div>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    onClick={() => setBilling(prev => prev.filter((_, i) => i !== idx))}
+                    disabled={billing.length <= 1}
+                    aria-label={t('remove_tier_aria')}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))}
+              <Button
+                variant="outline"
+                onClick={() => setBilling(prev => [...prev, emptyBilling()])}
+              >
+                <Plus className="mr-2 h-4 w-4" />
+                {t('add_tier_button')}
+              </Button>
+            </div>
+          </TabsContent>
+
+          {/* Sessions tab */}
+          <TabsContent value="sessions" className="space-y-4 py-4">
+            <div className="space-y-3">
+              {sessions.map((s, idx) => (
+                <div key={idx} className="flex items-end gap-2">
+                  <div className="flex-1 space-y-1.5">
+                    <label className="text-sm font-medium">{t('session_date_label')}</label>
+                    <Input
+                      type="date"
+                      value={s.sessionDate}
+                      onChange={e => setSessions(prev => prev.map((row, i) => (i === idx ? { ...row, sessionDate: e.target.value } : row)))}
+                    />
+                  </div>
+                  <div className="w-28 space-y-1.5">
+                    <label className="text-sm font-medium">{t('session_start_label')}</label>
+                    <Input
+                      type="time"
+                      value={s.startTime}
+                      onChange={e => setSessions(prev => prev.map((row, i) => (i === idx ? { ...row, startTime: e.target.value } : row)))}
+                    />
+                  </div>
+                  <div className="w-28 space-y-1.5">
+                    <label className="text-sm font-medium">{t('session_end_label')}</label>
+                    <Input
+                      type="time"
+                      value={s.endTime}
+                      onChange={e => setSessions(prev => prev.map((row, i) => (i === idx ? { ...row, endTime: e.target.value } : row)))}
+                    />
+                  </div>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    onClick={() => setSessions(prev => prev.filter((_, i) => i !== idx))}
+                    disabled={sessions.length <= 1}
+                    aria-label={t('remove_session_aria')}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))}
+              <Button
+                variant="outline"
+                onClick={() => setSessions(prev => [...prev, emptySession()])}
+              >
+                <Plus className="mr-2 h-4 w-4" />
+                {t('add_session_button')}
+              </Button>
+            </div>
+          </TabsContent>
+        </Tabs>
+
+        {error && (
+          <p className="text-sm text-destructive">{error}</p>
+        )}
+
+        <div className="flex justify-end gap-3 pt-4">
+          <Button variant="outline" onClick={onCloseAction} disabled={isLoading}>
+            {t('cancel_button')}
+          </Button>
+          <Button onClick={handleSubmit} disabled={!isFormValid || isLoading}>
+            {isLoading ? t('saving_button') : t('save_button')}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/events/details/EditEventModal.tsx
+++ b/src/features/events/details/EditEventModal.tsx
@@ -3,7 +3,7 @@
 import type { EventData } from '@/hooks/useEventsCache';
 import { Plus, Trash2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -37,12 +37,14 @@ function normalizeEventType(raw: string): ApiEventType {
 export type EditEventModalTab = 'details' | 'pricing' | 'sessions';
 
 type SessionRow = {
+  id: string;
   sessionDate: string; // YYYY-MM-DD
   startTime: string; // HH:MM
   endTime: string; // HH:MM
 };
 
 type BillingRow = {
+  id: string;
   name: string;
   price: string; // string in form, parsed on save
 };
@@ -63,11 +65,51 @@ function dateToInputValue(date: Date): string {
 }
 
 function emptySession(): SessionRow {
-  return { sessionDate: '', startTime: '10:00', endTime: '12:00' };
+  return { id: crypto.randomUUID(), sessionDate: '', startTime: '10:00', endTime: '12:00' };
 }
 
 function emptyBilling(): BillingRow {
-  return { name: 'Regular', price: '0' };
+  return { id: crypto.randomUUID(), name: 'Regular', price: '0' };
+}
+
+type FormState = {
+  name: string;
+  description: string;
+  eventType: ApiEventType;
+  maxCapacity: string;
+  sessions: SessionRow[];
+  billing: BillingRow[];
+  tab: EditEventModalTab;
+  // Tracks the (eventId, initialTab) tuple this state was built for. Used
+  // during render to detect when the parent has reopened the modal with a
+  // different event/tab and we need to rebuild the form.
+  syncKey: string;
+};
+
+function buildFormState(event: EventData, initialTab: EditEventModalTab): FormState {
+  return {
+    name: event.name,
+    description: event.description ?? '',
+    eventType: normalizeEventType(event.eventType),
+    maxCapacity: event.maxCapacity !== null ? String(event.maxCapacity) : '',
+    sessions: event.sessions.length > 0
+      ? event.sessions.map(s => ({
+          id: crypto.randomUUID(),
+          sessionDate: dateToInputValue(new Date(s.sessionDate)),
+          startTime: s.startTime,
+          endTime: s.endTime,
+        }))
+      : [emptySession()],
+    billing: event.billing.length > 0
+      ? event.billing.map(b => ({
+          id: crypto.randomUUID(),
+          name: b.name,
+          price: String(b.price),
+        }))
+      : [emptyBilling()],
+    tab: initialTab,
+    syncKey: `${event.id}|${initialTab}`,
+  };
 }
 
 export function EditEventModal({
@@ -79,52 +121,31 @@ export function EditEventModal({
 }: EditEventModalProps) {
   const t = useTranslations('EventDetailPage.EditEventModal');
 
-  const [name, setName] = useState(event.name);
-  const [description, setDescription] = useState(event.description ?? '');
-  const [eventType, setEventType] = useState<ApiEventType>(normalizeEventType(event.eventType));
-  const [maxCapacity, setMaxCapacity] = useState<string>(
-    event.maxCapacity !== null ? String(event.maxCapacity) : '',
-  );
-  const [sessions, setSessions] = useState<SessionRow[]>([]);
-  const [billing, setBilling] = useState<BillingRow[]>([]);
-  const [tab, setTab] = useState<EditEventModalTab>(initialTab);
+  // Single state object so the parent reopening the modal with a different
+  // event or tab triggers exactly one re-sync (during render) instead of an
+  // 8-call useEffect cascade. See React docs on "deriving state from props".
+  const [form, setForm] = useState<FormState>(() => buildFormState(event, initialTab));
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Reset form when modal opens — important because the parent reuses this
-  // component across multiple edit-button entry points and the event prop
-  // may change between opens.
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-    setName(event.name);
-    setDescription(event.description ?? '');
-    setEventType(normalizeEventType(event.eventType));
-    setMaxCapacity(event.maxCapacity !== null ? String(event.maxCapacity) : '');
-    setSessions(
-      event.sessions.length > 0
-        ? event.sessions.map(s => ({
-            sessionDate: dateToInputValue(new Date(s.sessionDate)),
-            startTime: s.startTime,
-            endTime: s.endTime,
-          }))
-        : [emptySession()],
-    );
-    setBilling(
-      event.billing.length > 0
-        ? event.billing.map(b => ({ name: b.name, price: String(b.price) }))
-        : [emptyBilling()],
-    );
-    setTab(initialTab);
+  // Re-sync during render when the modal opens or the event/initialTab change.
+  // React explicitly supports calling setState during render to derive state
+  // from props — it bails out without scheduling an extra render.
+  const desiredSyncKey = `${event.id}|${initialTab}`;
+  if (isOpen && form.syncKey !== desiredSyncKey) {
+    setForm(buildFormState(event, initialTab));
     setError(null);
-  }, [isOpen, event, initialTab]);
+  }
 
-  const isNameValid = name.trim().length > 0;
+  const isNameValid = form.name.trim().length > 0;
   const isFormValid
     = isNameValid
-      && sessions.every(s => s.sessionDate && s.startTime && s.endTime)
-      && billing.every(b => b.name.trim() && !Number.isNaN(Number.parseFloat(b.price)));
+      && form.sessions.every(s => s.sessionDate && s.startTime && s.endTime)
+      && form.billing.every(b => b.name.trim() && !Number.isNaN(Number.parseFloat(b.price)));
+
+  const updateForm = <K extends keyof FormState>(key: K, value: FormState[K]) => {
+    setForm(prev => ({ ...prev, [key]: value }));
+  };
 
   const handleSubmit = async () => {
     setIsLoading(true);
@@ -133,18 +154,18 @@ export function EditEventModal({
     try {
       await client.events.update({
         id: event.id,
-        name: name.trim(),
-        description: description.trim() || null,
-        eventType,
-        maxCapacity: maxCapacity ? Number.parseInt(maxCapacity, 10) : null,
+        name: form.name.trim(),
+        description: form.description.trim() || null,
+        eventType: form.eventType,
+        maxCapacity: form.maxCapacity ? Number.parseInt(form.maxCapacity, 10) : null,
         isPublic: true,
         isActive: event.isActive ?? true,
-        sessions: sessions.map(s => ({
+        sessions: form.sessions.map(s => ({
           sessionDate: new Date(`${s.sessionDate}T00:00:00Z`),
           startTime: s.startTime,
           endTime: s.endTime,
         })),
-        billing: billing.map((b, idx) => ({
+        billing: form.billing.map((b, idx) => ({
           name: b.name.trim(),
           price: Number.parseFloat(b.price) || 0,
           memberOnly: false,
@@ -171,7 +192,7 @@ export function EditEventModal({
           <DialogTitle>{t('title')}</DialogTitle>
         </DialogHeader>
 
-        <Tabs value={tab} onValueChange={v => setTab(v as EditEventModalTab)} className="w-full">
+        <Tabs value={form.tab} onValueChange={v => updateForm('tab', v as EditEventModalTab)} className="w-full">
           <TabsList className="grid w-full grid-cols-3">
             <TabsTrigger value="details">{t('tab_details')}</TabsTrigger>
             <TabsTrigger value="pricing">{t('tab_pricing')}</TabsTrigger>
@@ -184,16 +205,16 @@ export function EditEventModal({
               <label className="text-sm font-medium" htmlFor="event-name">{t('name_label')}</label>
               <Input
                 id="event-name"
-                value={name}
-                onChange={e => setName(e.target.value)}
+                value={form.name}
+                onChange={e => updateForm('name', e.target.value)}
                 placeholder={t('name_placeholder')}
-                error={!isNameValid && name.length > 0}
+                error={!isNameValid && form.name.length > 0}
               />
             </div>
 
             <div className="space-y-1.5">
               <label className="text-sm font-medium" htmlFor="event-type">{t('event_type_label')}</label>
-              <Select value={eventType} onValueChange={v => setEventType(v as ApiEventType)}>
+              <Select value={form.eventType} onValueChange={v => updateForm('eventType', v as ApiEventType)}>
                 <SelectTrigger id="event-type">
                   <SelectValue />
                 </SelectTrigger>
@@ -213,8 +234,8 @@ export function EditEventModal({
                 id="event-capacity"
                 type="number"
                 min={1}
-                value={maxCapacity}
-                onChange={e => setMaxCapacity(e.target.value)}
+                value={form.maxCapacity}
+                onChange={e => updateForm('maxCapacity', e.target.value)}
                 placeholder={t('max_capacity_placeholder')}
               />
             </div>
@@ -223,13 +244,13 @@ export function EditEventModal({
               <label className="text-sm font-medium" htmlFor="event-description">{t('description_label')}</label>
               <Textarea
                 id="event-description"
-                value={description}
-                onChange={e => setDescription(e.target.value.slice(0, MAX_DESCRIPTION_LENGTH))}
+                value={form.description}
+                onChange={e => updateForm('description', e.target.value.slice(0, MAX_DESCRIPTION_LENGTH))}
                 rows={4}
                 placeholder={t('description_placeholder')}
               />
               <p className="text-xs text-muted-foreground">
-                {t('description_character_count', { count: description.length, max: MAX_DESCRIPTION_LENGTH })}
+                {t('description_character_count', { count: form.description.length, max: MAX_DESCRIPTION_LENGTH })}
               </p>
             </div>
           </TabsContent>
@@ -237,13 +258,13 @@ export function EditEventModal({
           {/* Pricing tab */}
           <TabsContent value="pricing" className="space-y-4 py-4">
             <div className="space-y-3">
-              {billing.map((b, idx) => (
-                <div key={idx} className="flex items-end gap-2">
+              {form.billing.map(b => (
+                <div key={b.id} className="flex items-end gap-2">
                   <div className="flex-1 space-y-1.5">
                     <label className="text-sm font-medium">{t('tier_name_label')}</label>
                     <Input
                       value={b.name}
-                      onChange={e => setBilling(prev => prev.map((row, i) => (i === idx ? { ...row, name: e.target.value } : row)))}
+                      onChange={e => updateForm('billing', form.billing.map(row => (row.id === b.id ? { ...row, name: e.target.value } : row)))}
                       placeholder={t('tier_name_placeholder')}
                     />
                   </div>
@@ -254,14 +275,14 @@ export function EditEventModal({
                       min={0}
                       step="0.01"
                       value={b.price}
-                      onChange={e => setBilling(prev => prev.map((row, i) => (i === idx ? { ...row, price: e.target.value } : row)))}
+                      onChange={e => updateForm('billing', form.billing.map(row => (row.id === b.id ? { ...row, price: e.target.value } : row)))}
                     />
                   </div>
                   <Button
                     variant="outline"
                     size="icon"
-                    onClick={() => setBilling(prev => prev.filter((_, i) => i !== idx))}
-                    disabled={billing.length <= 1}
+                    onClick={() => updateForm('billing', form.billing.filter(row => row.id !== b.id))}
+                    disabled={form.billing.length <= 1}
                     aria-label={t('remove_tier_aria')}
                   >
                     <Trash2 className="h-4 w-4" />
@@ -270,7 +291,7 @@ export function EditEventModal({
               ))}
               <Button
                 variant="outline"
-                onClick={() => setBilling(prev => [...prev, emptyBilling()])}
+                onClick={() => updateForm('billing', [...form.billing, emptyBilling()])}
               >
                 <Plus className="mr-2 h-4 w-4" />
                 {t('add_tier_button')}
@@ -281,14 +302,14 @@ export function EditEventModal({
           {/* Sessions tab */}
           <TabsContent value="sessions" className="space-y-4 py-4">
             <div className="space-y-3">
-              {sessions.map((s, idx) => (
-                <div key={idx} className="flex items-end gap-2">
+              {form.sessions.map(s => (
+                <div key={s.id} className="flex items-end gap-2">
                   <div className="flex-1 space-y-1.5">
                     <label className="text-sm font-medium">{t('session_date_label')}</label>
                     <Input
                       type="date"
                       value={s.sessionDate}
-                      onChange={e => setSessions(prev => prev.map((row, i) => (i === idx ? { ...row, sessionDate: e.target.value } : row)))}
+                      onChange={e => updateForm('sessions', form.sessions.map(row => (row.id === s.id ? { ...row, sessionDate: e.target.value } : row)))}
                     />
                   </div>
                   <div className="w-28 space-y-1.5">
@@ -296,7 +317,7 @@ export function EditEventModal({
                     <Input
                       type="time"
                       value={s.startTime}
-                      onChange={e => setSessions(prev => prev.map((row, i) => (i === idx ? { ...row, startTime: e.target.value } : row)))}
+                      onChange={e => updateForm('sessions', form.sessions.map(row => (row.id === s.id ? { ...row, startTime: e.target.value } : row)))}
                     />
                   </div>
                   <div className="w-28 space-y-1.5">
@@ -304,14 +325,14 @@ export function EditEventModal({
                     <Input
                       type="time"
                       value={s.endTime}
-                      onChange={e => setSessions(prev => prev.map((row, i) => (i === idx ? { ...row, endTime: e.target.value } : row)))}
+                      onChange={e => updateForm('sessions', form.sessions.map(row => (row.id === s.id ? { ...row, endTime: e.target.value } : row)))}
                     />
                   </div>
                   <Button
                     variant="outline"
                     size="icon"
-                    onClick={() => setSessions(prev => prev.filter((_, i) => i !== idx))}
-                    disabled={sessions.length <= 1}
+                    onClick={() => updateForm('sessions', form.sessions.filter(row => row.id !== s.id))}
+                    disabled={form.sessions.length <= 1}
                     aria-label={t('remove_session_aria')}
                   >
                     <Trash2 className="h-4 w-4" />
@@ -320,7 +341,7 @@ export function EditEventModal({
               ))}
               <Button
                 variant="outline"
-                onClick={() => setSessions(prev => [...prev, emptySession()])}
+                onClick={() => updateForm('sessions', [...form.sessions, emptySession()])}
               >
                 <Plus className="mr-2 h-4 w-4" />
                 {t('add_session_button')}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3,6 +3,9 @@
     "meta_title": "Dojo Planner",
     "meta_description": "An easy way to manage your academy."
   },
+  "Calendar": {
+    "open_picker_aria": "Open date picker"
+  },
   "Hero": {
     "title": "Dojo Planner",
     "primary_button": "Get Started"
@@ -2015,7 +2018,43 @@
     "delete_dialog_title": "Are you absolutely sure?",
     "delete_dialog_description": "This action cannot be undone. This will permanently delete the \"{eventName}\" event and remove the data from the servers.",
     "cancel_button": "Cancel",
-    "delete_confirm_button": "Delete"
+    "delete_confirm_button": "Delete",
+    "edit_details_aria": "Edit event details",
+    "edit_pricing_aria": "Edit event pricing",
+    "edit_sessions_aria": "Edit event sessions",
+    "edit_instructors_aria": "Edit event instructors",
+    "EditEventModal": {
+      "title": "Edit Event",
+      "tab_details": "Details",
+      "tab_pricing": "Pricing",
+      "tab_sessions": "Sessions",
+      "name_label": "Event Name",
+      "name_placeholder": "e.g. Black Belt Seminar",
+      "event_type_label": "Event Type",
+      "event_type_seminar": "Seminar",
+      "event_type_workshop": "Workshop",
+      "event_type_tournament": "Tournament",
+      "event_type_camp": "Camp",
+      "event_type_other": "Other",
+      "max_capacity_label": "Maximum Capacity",
+      "max_capacity_placeholder": "Leave blank for unlimited",
+      "description_label": "Description",
+      "description_placeholder": "What is this event about?",
+      "description_character_count": "{count} / {max}",
+      "tier_name_label": "Tier Name",
+      "tier_name_placeholder": "e.g. Regular, Early Bird",
+      "price_label": "Price",
+      "remove_tier_aria": "Remove pricing tier",
+      "add_tier_button": "Add Pricing Tier",
+      "session_date_label": "Date",
+      "session_start_label": "Starts",
+      "session_end_label": "Ends",
+      "remove_session_aria": "Remove session",
+      "add_session_button": "Add Session",
+      "cancel_button": "Cancel",
+      "save_button": "Save Changes",
+      "saving_button": "Saving..."
+    }
   },
   "MemberDetailAttendance": {
     "title": "Attendance History",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -3,6 +3,9 @@
     "meta_title": "Dojo Planner",
     "meta_description": "Un moyen facile de gérer votre académie."
   },
+  "Calendar": {
+    "open_picker_aria": "Ouvrir le sélecteur de date"
+  },
   "Hero": {
     "title": "Dojo Planner",
     "primary_button": "Démarrer"
@@ -2020,7 +2023,43 @@
     "delete_dialog_title": "Êtes-vous absolument sûr ?",
     "delete_dialog_description": "Cette action est irréversible. L'événement \"{eventName}\" sera supprimé définitivement des serveurs.",
     "cancel_button": "Annuler",
-    "delete_confirm_button": "Supprimer"
+    "delete_confirm_button": "Supprimer",
+    "edit_details_aria": "Modifier les détails de l'événement",
+    "edit_pricing_aria": "Modifier les tarifs de l'événement",
+    "edit_sessions_aria": "Modifier les séances de l'événement",
+    "edit_instructors_aria": "Modifier les instructeurs de l'événement",
+    "EditEventModal": {
+      "title": "Modifier l'événement",
+      "tab_details": "Détails",
+      "tab_pricing": "Tarifs",
+      "tab_sessions": "Séances",
+      "name_label": "Nom de l'événement",
+      "name_placeholder": "ex. Séminaire Ceinture Noire",
+      "event_type_label": "Type d'événement",
+      "event_type_seminar": "Séminaire",
+      "event_type_workshop": "Atelier",
+      "event_type_tournament": "Tournoi",
+      "event_type_camp": "Stage",
+      "event_type_other": "Autre",
+      "max_capacity_label": "Capacité maximale",
+      "max_capacity_placeholder": "Laisser vide pour illimité",
+      "description_label": "Description",
+      "description_placeholder": "De quoi s'agit-il ?",
+      "description_character_count": "{count} / {max}",
+      "tier_name_label": "Nom du tarif",
+      "tier_name_placeholder": "ex. Standard, Lève-tôt",
+      "price_label": "Prix",
+      "remove_tier_aria": "Supprimer le tarif",
+      "add_tier_button": "Ajouter un tarif",
+      "session_date_label": "Date",
+      "session_start_label": "Début",
+      "session_end_label": "Fin",
+      "remove_session_aria": "Supprimer la séance",
+      "add_session_button": "Ajouter une séance",
+      "cancel_button": "Annuler",
+      "save_button": "Enregistrer",
+      "saving_button": "Enregistrement..."
+    }
   },
   "MemberDetailAttendance": {
     "title": "Historique de présence",

--- a/src/routers/Classes.ts
+++ b/src/routers/Classes.ts
@@ -1,6 +1,24 @@
-import { os } from '@orpc/server';
-import { getClassTags, getOrganizationClasses } from '@/services/ClassesService';
+import { ORPCError, os } from '@orpc/server';
+import { audit } from '@/services/AuditService';
+import {
+  ClassSlugAlreadyExistsError,
+  createClass,
+  deleteScheduleException,
+  getClassTags,
+  getOrganizationClasses,
+  softDeleteClass,
+  updateClass,
+  upsertScheduleException,
+} from '@/services/ClassesService';
+import { AUDIT_ACTION, AUDIT_ENTITY_TYPE } from '@/types/Audit';
 import { ORG_ROLE } from '@/types/Auth';
+import {
+  CreateClassValidation,
+  DeleteClassValidation,
+  DeleteScheduleExceptionValidation,
+  UpdateClassValidation,
+  UpsertScheduleExceptionValidation,
+} from '@/validations/ClassesValidation';
 import { guardRole } from './AuthGuards';
 
 export const list = os.handler(async () => {
@@ -18,3 +36,178 @@ export const tags = os.handler(async () => {
 
   return { tags: classTags };
 });
+
+export const create = os
+  .input(CreateClassValidation)
+  .handler(async ({ input }) => {
+    const context = await guardRole(ORG_ROLE.FRONT_DESK);
+
+    try {
+      const created = await createClass({
+        name: input.name,
+        description: input.description ?? null,
+        programId: input.programId ?? null,
+        color: input.color ?? null,
+        defaultDurationMinutes: input.defaultDurationMinutes ?? null,
+        maxCapacity: input.maxCapacity ?? null,
+        minAge: input.minAge ?? null,
+        maxAge: input.maxAge ?? null,
+        isActive: input.isActive,
+        schedule: input.schedule,
+        tagIds: input.tagIds,
+      }, context.orgId);
+
+      await audit(context, AUDIT_ACTION.CLASS_CREATE, AUDIT_ENTITY_TYPE.CLASS, {
+        entityId: created.id,
+        status: 'success',
+      });
+
+      return { class: created };
+    } catch (error) {
+      await audit(context, AUDIT_ACTION.CLASS_CREATE, AUDIT_ENTITY_TYPE.CLASS, {
+        status: 'failure',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      if (error instanceof ClassSlugAlreadyExistsError) {
+        throw new ORPCError('Conflict', { status: 409, message: error.message });
+      }
+      throw error;
+    }
+  });
+
+export const update = os
+  .input(UpdateClassValidation)
+  .handler(async ({ input }) => {
+    const context = await guardRole(ORG_ROLE.FRONT_DESK);
+
+    try {
+      const updated = await updateClass(input.id, {
+        name: input.name,
+        description: input.description ?? null,
+        programId: input.programId ?? null,
+        color: input.color ?? null,
+        defaultDurationMinutes: input.defaultDurationMinutes ?? null,
+        maxCapacity: input.maxCapacity ?? null,
+        minAge: input.minAge ?? null,
+        maxAge: input.maxAge ?? null,
+        isActive: input.isActive,
+        schedule: input.schedule,
+        tagIds: input.tagIds,
+      }, context.orgId);
+
+      if (!updated) {
+        throw new ORPCError('Not Found', { status: 404 });
+      }
+
+      await audit(context, AUDIT_ACTION.CLASS_UPDATE, AUDIT_ENTITY_TYPE.CLASS, {
+        entityId: updated.id,
+        status: 'success',
+      });
+
+      return { class: updated };
+    } catch (error) {
+      await audit(context, AUDIT_ACTION.CLASS_UPDATE, AUDIT_ENTITY_TYPE.CLASS, {
+        entityId: input.id,
+        status: 'failure',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      if (error instanceof ClassSlugAlreadyExistsError) {
+        throw new ORPCError('Conflict', { status: 409, message: error.message });
+      }
+      throw error;
+    }
+  });
+
+export const remove = os
+  .input(DeleteClassValidation)
+  .handler(async ({ input }) => {
+    const context = await guardRole(ORG_ROLE.ADMIN);
+
+    try {
+      const ok = await softDeleteClass(input.id, context.orgId);
+      if (!ok) {
+        throw new ORPCError('Not Found', { status: 404 });
+      }
+
+      await audit(context, AUDIT_ACTION.CLASS_DELETE, AUDIT_ENTITY_TYPE.CLASS, {
+        entityId: input.id,
+        status: 'success',
+      });
+
+      return { success: true };
+    } catch (error) {
+      await audit(context, AUDIT_ACTION.CLASS_DELETE, AUDIT_ENTITY_TYPE.CLASS, {
+        entityId: input.id,
+        status: 'failure',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      throw error;
+    }
+  });
+
+export const upsertException = os
+  .input(UpsertScheduleExceptionValidation)
+  .handler(async ({ input }) => {
+    const context = await guardRole(ORG_ROLE.FRONT_DESK);
+
+    try {
+      const result = await upsertScheduleException({
+        classScheduleInstanceId: input.classScheduleInstanceId,
+        exceptionDate: input.exceptionDate,
+        exceptionType: input.exceptionType,
+        newStartTime: input.newStartTime ?? null,
+        newEndTime: input.newEndTime ?? null,
+        newInstructorClerkId: input.newInstructorClerkId ?? null,
+        newRoom: input.newRoom ?? null,
+        reason: input.reason ?? null,
+      }, context.orgId);
+
+      if (!result) {
+        throw new ORPCError('Not Found', { status: 404, message: 'Schedule instance not found in this organization' });
+      }
+
+      const action = result.created
+        ? AUDIT_ACTION.CLASS_SCHEDULE_EXCEPTION_CREATE
+        : AUDIT_ACTION.CLASS_SCHEDULE_EXCEPTION_UPDATE;
+
+      await audit(context, action, AUDIT_ENTITY_TYPE.CLASS_SCHEDULE_EXCEPTION, {
+        entityId: result.id,
+        status: 'success',
+      });
+
+      return { id: result.id, created: result.created };
+    } catch (error) {
+      await audit(context, AUDIT_ACTION.CLASS_SCHEDULE_EXCEPTION_CREATE, AUDIT_ENTITY_TYPE.CLASS_SCHEDULE_EXCEPTION, {
+        status: 'failure',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      throw error;
+    }
+  });
+
+export const removeException = os
+  .input(DeleteScheduleExceptionValidation)
+  .handler(async ({ input }) => {
+    const context = await guardRole(ORG_ROLE.FRONT_DESK);
+
+    try {
+      const ok = await deleteScheduleException(input.id, context.orgId);
+      if (!ok) {
+        throw new ORPCError('Not Found', { status: 404 });
+      }
+
+      await audit(context, AUDIT_ACTION.CLASS_SCHEDULE_EXCEPTION_DELETE, AUDIT_ENTITY_TYPE.CLASS_SCHEDULE_EXCEPTION, {
+        entityId: input.id,
+        status: 'success',
+      });
+
+      return { success: true };
+    } catch (error) {
+      await audit(context, AUDIT_ACTION.CLASS_SCHEDULE_EXCEPTION_DELETE, AUDIT_ENTITY_TYPE.CLASS_SCHEDULE_EXCEPTION, {
+        entityId: input.id,
+        status: 'failure',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      throw error;
+    }
+  });

--- a/src/routers/Events.ts
+++ b/src/routers/Events.ts
@@ -1,6 +1,19 @@
-import { os } from '@orpc/server';
-import { getOrganizationEvents } from '@/services/EventsService';
+import { ORPCError, os } from '@orpc/server';
+import { audit } from '@/services/AuditService';
+import {
+  createEvent,
+  EventSlugAlreadyExistsError,
+  getOrganizationEvents,
+  softDeleteEvent,
+  updateEvent,
+} from '@/services/EventsService';
+import { AUDIT_ACTION, AUDIT_ENTITY_TYPE } from '@/types/Audit';
 import { ORG_ROLE } from '@/types/Auth';
+import {
+  CreateEventValidation,
+  DeleteEventValidation,
+  UpdateEventValidation,
+} from '@/validations/EventsValidation';
 import { guardRole } from './AuthGuards';
 
 export const list = os.handler(async () => {
@@ -10,3 +23,113 @@ export const list = os.handler(async () => {
 
   return { events };
 });
+
+export const create = os
+  .input(CreateEventValidation)
+  .handler(async ({ input }) => {
+    const context = await guardRole(ORG_ROLE.FRONT_DESK);
+
+    try {
+      const created = await createEvent({
+        name: input.name,
+        description: input.description ?? null,
+        eventType: input.eventType,
+        programId: input.programId ?? null,
+        imageUrl: input.imageUrl ?? null,
+        maxCapacity: input.maxCapacity ?? null,
+        registrationDeadline: input.registrationDeadline ?? null,
+        isPublic: input.isPublic,
+        isActive: input.isActive,
+        sessions: input.sessions,
+        billing: input.billing,
+        tagIds: input.tagIds,
+      }, context.orgId);
+
+      await audit(context, AUDIT_ACTION.EVENT_CREATE, AUDIT_ENTITY_TYPE.EVENT, {
+        entityId: created.id,
+        status: 'success',
+      });
+
+      return { event: created };
+    } catch (error) {
+      await audit(context, AUDIT_ACTION.EVENT_CREATE, AUDIT_ENTITY_TYPE.EVENT, {
+        status: 'failure',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      if (error instanceof EventSlugAlreadyExistsError) {
+        throw new ORPCError('Conflict', { status: 409, message: error.message });
+      }
+      throw error;
+    }
+  });
+
+export const update = os
+  .input(UpdateEventValidation)
+  .handler(async ({ input }) => {
+    const context = await guardRole(ORG_ROLE.FRONT_DESK);
+
+    try {
+      const updated = await updateEvent(input.id, {
+        name: input.name,
+        description: input.description ?? null,
+        eventType: input.eventType,
+        programId: input.programId ?? null,
+        imageUrl: input.imageUrl ?? null,
+        maxCapacity: input.maxCapacity ?? null,
+        registrationDeadline: input.registrationDeadline ?? null,
+        isPublic: input.isPublic,
+        isActive: input.isActive,
+        sessions: input.sessions,
+        billing: input.billing,
+        tagIds: input.tagIds,
+      }, context.orgId);
+
+      if (!updated) {
+        throw new ORPCError('Not Found', { status: 404 });
+      }
+
+      await audit(context, AUDIT_ACTION.EVENT_UPDATE, AUDIT_ENTITY_TYPE.EVENT, {
+        entityId: updated.id,
+        status: 'success',
+      });
+
+      return { event: updated };
+    } catch (error) {
+      await audit(context, AUDIT_ACTION.EVENT_UPDATE, AUDIT_ENTITY_TYPE.EVENT, {
+        entityId: input.id,
+        status: 'failure',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      if (error instanceof EventSlugAlreadyExistsError) {
+        throw new ORPCError('Conflict', { status: 409, message: error.message });
+      }
+      throw error;
+    }
+  });
+
+export const remove = os
+  .input(DeleteEventValidation)
+  .handler(async ({ input }) => {
+    const context = await guardRole(ORG_ROLE.ADMIN);
+
+    try {
+      const ok = await softDeleteEvent(input.id, context.orgId);
+      if (!ok) {
+        throw new ORPCError('Not Found', { status: 404 });
+      }
+
+      await audit(context, AUDIT_ACTION.EVENT_DELETE, AUDIT_ENTITY_TYPE.EVENT, {
+        entityId: input.id,
+        status: 'success',
+      });
+
+      return { success: true };
+    } catch (error) {
+      await audit(context, AUDIT_ACTION.EVENT_DELETE, AUDIT_ENTITY_TYPE.EVENT, {
+        entityId: input.id,
+        status: 'failure',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      throw error;
+    }
+  });

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -17,10 +17,10 @@ import {
   variantRemove,
   variantUpdate,
 } from './Catalog';
-import { tags as classTags, list as listClasses } from './Classes';
+import { tags as classTags, create as createClass, list as listClasses, remove as removeClass, removeException as removeClassException, update as updateClass, upsertException as upsertClassException } from './Classes';
 import { create as createCoupon, listActive as listActiveCoupons, list as listCoupons, remove as removeCoupon, update as updateCoupon } from './Coupons';
 import { earningsChart, financialStats, memberAverageChart, membershipStats } from './Dashboard';
-import { list as listEvents } from './Events';
+import { create as createEvent, list as listEvents, remove as removeEvent, update as updateEvent } from './Events';
 import { addMembership, changeMembership, create as createMember, getHOHForMember, getHOHPaymentMethods, linkFamily, listAllMembershipPlans, listFamily, listMembershipPlans, listMemberTransactions, listPaymentMethods, remove as removeMember, restore as restoreMember, searchHOH, sendConfirmationEmail, unlinkFamily, updateLastAccessed, update as updateMember, updateContactInfo as updateMemberContactInfo, updatePhoto as updateMemberPhoto, updateMemberType } from './Member';
 import { list as listMembers } from './Members';
 import { create as createMembershipPlan, remove as removeMembershipPlan, update as updateMembershipPlan } from './MembershipPlans';
@@ -85,9 +85,17 @@ export const router = {
   classes: {
     list: listClasses,
     tags: classTags,
+    create: createClass,
+    update: updateClass,
+    remove: removeClass,
+    upsertException: upsertClassException,
+    removeException: removeClassException,
   },
   events: {
     list: listEvents,
+    create: createEvent,
+    update: updateEvent,
+    remove: removeEvent,
   },
   attendance: {
     list: listAttendance,

--- a/src/services/ClassesService.ts
+++ b/src/services/ClassesService.ts
@@ -1,6 +1,8 @@
-import { eq, inArray } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+import { and, eq, inArray } from 'drizzle-orm';
 import { db } from '@/libs/DB';
 import {
+  attendanceSchema,
   classScheduleExceptionSchema,
   classScheduleInstanceSchema,
   classSchema,
@@ -198,6 +200,358 @@ export async function getOrganizationClasses(organizationId: string): Promise<Cl
 export async function getClassById(classId: string, organizationId: string): Promise<ClassData | null> {
   const classes = await getOrganizationClasses(organizationId);
   return classes.find(c => c.id === classId) || null;
+}
+
+// =============================================================================
+// SERVICE FUNCTIONS — WRITES
+// =============================================================================
+
+export class ClassSlugAlreadyExistsError extends Error {
+  constructor(slug: string) {
+    super(`A class with slug "${slug}" already exists.`);
+    this.name = 'ClassSlugAlreadyExistsError';
+  }
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && (error as { code: string }).code === '23505'
+  );
+}
+
+function slugify(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export type ScheduleInstanceInput = {
+  dayOfWeek: number;
+  startTime: string;
+  endTime: string;
+  primaryInstructorClerkId?: string | null;
+  room?: string | null;
+};
+
+export type CreateClassServiceInput = {
+  name: string;
+  description?: string | null;
+  programId?: string | null;
+  color?: string | null;
+  defaultDurationMinutes?: number | null;
+  maxCapacity?: number | null;
+  minAge?: number | null;
+  maxAge?: number | null;
+  isActive: boolean;
+  schedule: ScheduleInstanceInput[];
+  tagIds: string[];
+};
+
+export type UpdateClassServiceInput = CreateClassServiceInput;
+
+/**
+ * Create a class with its schedule instances and tag links.
+ * Slug is derived from the name. Throws ClassSlugAlreadyExistsError on
+ * (organizationId, slug) collision.
+ */
+export async function createClass(input: CreateClassServiceInput, organizationId: string): Promise<ClassData> {
+  const id = randomUUID();
+  const slug = slugify(input.name);
+
+  try {
+    await db.insert(classSchema).values({
+      id,
+      organizationId,
+      programId: input.programId ?? null,
+      name: input.name,
+      slug,
+      description: input.description ?? null,
+      color: input.color ?? null,
+      defaultDurationMinutes: input.defaultDurationMinutes ?? 60,
+      maxCapacity: input.maxCapacity ?? null,
+      minAge: input.minAge ?? null,
+      maxAge: input.maxAge ?? null,
+      isActive: input.isActive,
+    });
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      throw new ClassSlugAlreadyExistsError(slug);
+    }
+    throw error;
+  }
+
+  if (input.schedule.length > 0) {
+    await db.insert(classScheduleInstanceSchema).values(
+      input.schedule.map(s => ({
+        id: randomUUID(),
+        classId: id,
+        primaryInstructorClerkId: s.primaryInstructorClerkId ?? null,
+        dayOfWeek: s.dayOfWeek,
+        startTime: s.startTime,
+        endTime: s.endTime,
+        room: s.room ?? null,
+        isActive: true,
+      })),
+    );
+  }
+
+  if (input.tagIds.length > 0) {
+    await db.insert(classTagSchema).values(
+      input.tagIds.map(tagId => ({ classId: id, tagId })),
+    );
+  }
+
+  const created = await getClassById(id, organizationId);
+  if (!created) {
+    throw new Error('Class created but could not be re-read');
+  }
+  return created;
+}
+
+/**
+ * Update class basics + replace schedule instances + replace tag links. We
+ * use the "delete-and-reinsert" pattern for schedule because matching old
+ * instances to new ones by (dayOfWeek, time) is fragile when the operator
+ * intentionally moved a class. Returns null when the class doesn't belong
+ * to the org.
+ */
+export async function updateClass(
+  classId: string,
+  input: UpdateClassServiceInput,
+  organizationId: string,
+): Promise<ClassData | null> {
+  const existing = await db
+    .select()
+    .from(classSchema)
+    .where(and(eq(classSchema.id, classId), eq(classSchema.organizationId, organizationId)))
+    .limit(1);
+  if (existing.length === 0) {
+    return null;
+  }
+
+  const slug = slugify(input.name);
+
+  try {
+    await db
+      .update(classSchema)
+      .set({
+        programId: input.programId ?? null,
+        name: input.name,
+        slug,
+        description: input.description ?? null,
+        color: input.color ?? null,
+        defaultDurationMinutes: input.defaultDurationMinutes ?? 60,
+        maxCapacity: input.maxCapacity ?? null,
+        minAge: input.minAge ?? null,
+        maxAge: input.maxAge ?? null,
+        isActive: input.isActive,
+      })
+      .where(and(eq(classSchema.id, classId), eq(classSchema.organizationId, organizationId)));
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      throw new ClassSlugAlreadyExistsError(slug);
+    }
+    throw error;
+  }
+
+  // Replace schedule instances. We keep instances that have attendance or
+  // exception rows pointing at them (deleting would cascade-fail), and only
+  // wipe-and-recreate the rest. For the common path (no historical data),
+  // this reduces to a full delete-and-reinsert.
+  const oldInstances = await db
+    .select()
+    .from(classScheduleInstanceSchema)
+    .where(eq(classScheduleInstanceSchema.classId, classId));
+
+  if (oldInstances.length > 0) {
+    const oldIds = oldInstances.map(i => i.id);
+    const [refExceptions, refAttendance] = await Promise.all([
+      db.select({ id: classScheduleExceptionSchema.classScheduleInstanceId })
+        .from(classScheduleExceptionSchema)
+        .where(inArray(classScheduleExceptionSchema.classScheduleInstanceId, oldIds)),
+      db.select({ id: attendanceSchema.classScheduleInstanceId })
+        .from(attendanceSchema)
+        .where(inArray(attendanceSchema.classScheduleInstanceId, oldIds)),
+    ]);
+    const referenced = new Set([
+      ...refExceptions.map(r => r.id),
+      ...refAttendance.map(r => r.id).filter((id): id is string => id !== null),
+    ]);
+    const deletable = oldIds.filter(id => !referenced.has(id));
+    if (deletable.length > 0) {
+      await db
+        .delete(classScheduleInstanceSchema)
+        .where(inArray(classScheduleInstanceSchema.id, deletable));
+    }
+    // Mark referenced (but no-longer-current) instances inactive so the
+    // calendar stops showing them, but historical joins still resolve.
+    const referencedIds = oldIds.filter(id => referenced.has(id));
+    if (referencedIds.length > 0) {
+      await db
+        .update(classScheduleInstanceSchema)
+        .set({ isActive: false })
+        .where(inArray(classScheduleInstanceSchema.id, referencedIds));
+    }
+  }
+
+  if (input.schedule.length > 0) {
+    await db.insert(classScheduleInstanceSchema).values(
+      input.schedule.map(s => ({
+        id: randomUUID(),
+        classId,
+        primaryInstructorClerkId: s.primaryInstructorClerkId ?? null,
+        dayOfWeek: s.dayOfWeek,
+        startTime: s.startTime,
+        endTime: s.endTime,
+        room: s.room ?? null,
+        isActive: true,
+      })),
+    );
+  }
+
+  // Replace tag associations.
+  await db.delete(classTagSchema).where(eq(classTagSchema.classId, classId));
+  if (input.tagIds.length > 0) {
+    await db.insert(classTagSchema).values(
+      input.tagIds.map(tagId => ({ classId, tagId })),
+    );
+  }
+
+  return getClassById(classId, organizationId);
+}
+
+/**
+ * Soft-delete a class (sets isActive = false). We never hard-delete because
+ * attendance rows reference schedule instances; deletion would either cascade
+ * or fail. Returns false when the class doesn't belong to the org.
+ */
+export async function softDeleteClass(classId: string, organizationId: string): Promise<boolean> {
+  const existing = await db
+    .select()
+    .from(classSchema)
+    .where(and(eq(classSchema.id, classId), eq(classSchema.organizationId, organizationId)))
+    .limit(1);
+  if (existing.length === 0) {
+    return false;
+  }
+
+  await db
+    .update(classSchema)
+    .set({ isActive: false })
+    .where(and(eq(classSchema.id, classId), eq(classSchema.organizationId, organizationId)));
+  return true;
+}
+
+export type UpsertScheduleExceptionServiceInput = {
+  classScheduleInstanceId: string;
+  exceptionDate: Date;
+  exceptionType: string;
+  newStartTime?: string | null;
+  newEndTime?: string | null;
+  newInstructorClerkId?: string | null;
+  newRoom?: string | null;
+  reason?: string | null;
+};
+
+/**
+ * Create or update a schedule exception keyed on
+ * (classScheduleInstanceId, exceptionDate). If a row already exists for that
+ * date, it's updated in place — operators can change their mind about a
+ * cancellation without piling up rows.
+ *
+ * Returns the upserted row plus a `created` flag so the router can audit
+ * create vs. update distinctly.
+ */
+export async function upsertScheduleException(
+  input: UpsertScheduleExceptionServiceInput,
+  organizationId: string,
+): Promise<{ id: string; created: boolean } | null> {
+  // Verify the schedule instance belongs to a class in this org.
+  const ownership = await db
+    .select({ id: classSchema.id })
+    .from(classScheduleInstanceSchema)
+    .innerJoin(classSchema, eq(classSchema.id, classScheduleInstanceSchema.classId))
+    .where(and(
+      eq(classScheduleInstanceSchema.id, input.classScheduleInstanceId),
+      eq(classSchema.organizationId, organizationId),
+    ))
+    .limit(1);
+  if (ownership.length === 0) {
+    return null;
+  }
+
+  const existing = await db
+    .select()
+    .from(classScheduleExceptionSchema)
+    .where(and(
+      eq(classScheduleExceptionSchema.classScheduleInstanceId, input.classScheduleInstanceId),
+      eq(classScheduleExceptionSchema.exceptionDate, input.exceptionDate),
+    ))
+    .limit(1);
+
+  if (existing.length > 0) {
+    const row = existing[0]!;
+    await db
+      .update(classScheduleExceptionSchema)
+      .set({
+        exceptionType: input.exceptionType,
+        newStartTime: input.newStartTime ?? null,
+        newEndTime: input.newEndTime ?? null,
+        newInstructorClerkId: input.newInstructorClerkId ?? null,
+        newRoom: input.newRoom ?? null,
+        reason: input.reason ?? null,
+      })
+      .where(eq(classScheduleExceptionSchema.id, row.id));
+    return { id: row.id, created: false };
+  }
+
+  const id = randomUUID();
+  await db.insert(classScheduleExceptionSchema).values({
+    id,
+    classScheduleInstanceId: input.classScheduleInstanceId,
+    exceptionDate: input.exceptionDate,
+    exceptionType: input.exceptionType,
+    newStartTime: input.newStartTime ?? null,
+    newEndTime: input.newEndTime ?? null,
+    newInstructorClerkId: input.newInstructorClerkId ?? null,
+    newRoom: input.newRoom ?? null,
+    reason: input.reason ?? null,
+  });
+  return { id, created: true };
+}
+
+/**
+ * Delete a schedule exception. Verifies the exception belongs to a class
+ * owned by the org. Returns false when not found.
+ */
+export async function deleteScheduleException(
+  exceptionId: string,
+  organizationId: string,
+): Promise<boolean> {
+  const owned = await db
+    .select({ id: classScheduleExceptionSchema.id })
+    .from(classScheduleExceptionSchema)
+    .innerJoin(
+      classScheduleInstanceSchema,
+      eq(classScheduleInstanceSchema.id, classScheduleExceptionSchema.classScheduleInstanceId),
+    )
+    .innerJoin(classSchema, eq(classSchema.id, classScheduleInstanceSchema.classId))
+    .where(and(
+      eq(classScheduleExceptionSchema.id, exceptionId),
+      eq(classSchema.organizationId, organizationId),
+    ))
+    .limit(1);
+  if (owned.length === 0) {
+    return false;
+  }
+
+  await db.delete(classScheduleExceptionSchema).where(eq(classScheduleExceptionSchema.id, exceptionId));
+  return true;
 }
 
 /**

--- a/src/services/EventsService.ts
+++ b/src/services/EventsService.ts
@@ -1,6 +1,8 @@
-import { eq, inArray } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+import { and, eq, inArray } from 'drizzle-orm';
 import { db } from '@/libs/DB';
 import {
+  attendanceSchema,
   eventBillingSchema,
   eventSchema,
   eventSessionSchema,
@@ -151,4 +153,279 @@ export async function getOrganizationEvents(organizationId: string): Promise<Eve
 export async function getEventById(eventId: string, organizationId: string): Promise<EventData | null> {
   const events = await getOrganizationEvents(organizationId);
   return events.find(e => e.id === eventId) || null;
+}
+
+// =============================================================================
+// SERVICE FUNCTIONS — WRITES
+// =============================================================================
+
+export class EventSlugAlreadyExistsError extends Error {
+  constructor(slug: string) {
+    super(`An event with slug "${slug}" already exists.`);
+    this.name = 'EventSlugAlreadyExistsError';
+  }
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && (error as { code: string }).code === '23505'
+  );
+}
+
+function slugify(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export type EventSessionInput = {
+  sessionDate: Date;
+  startTime: string;
+  endTime: string;
+  primaryInstructorClerkId?: string | null;
+  room?: string | null;
+  maxCapacity?: number | null;
+};
+
+export type EventBillingInput = {
+  name: string;
+  price: number;
+  memberOnly?: boolean;
+  validFrom?: Date | null;
+  validUntil?: Date | null;
+  maxRegistrations?: number | null;
+  sortOrder?: number;
+};
+
+export type CreateEventServiceInput = {
+  name: string;
+  description?: string | null;
+  eventType: string;
+  programId?: string | null;
+  imageUrl?: string | null;
+  maxCapacity?: number | null;
+  registrationDeadline?: Date | null;
+  isPublic?: boolean;
+  isActive: boolean;
+  sessions: EventSessionInput[];
+  billing: EventBillingInput[];
+  tagIds: string[];
+};
+
+export type UpdateEventServiceInput = CreateEventServiceInput;
+
+/**
+ * Create an event with its sessions, billing tiers, and tag links.
+ */
+export async function createEvent(input: CreateEventServiceInput, organizationId: string): Promise<EventData> {
+  const id = randomUUID();
+  const slug = slugify(input.name);
+
+  try {
+    await db.insert(eventSchema).values({
+      id,
+      organizationId,
+      programId: input.programId ?? null,
+      name: input.name,
+      slug,
+      description: input.description ?? null,
+      eventType: input.eventType,
+      imageUrl: input.imageUrl ?? null,
+      maxCapacity: input.maxCapacity ?? null,
+      registrationDeadline: input.registrationDeadline ?? null,
+      isPublic: input.isPublic ?? true,
+      isActive: input.isActive,
+    });
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      throw new EventSlugAlreadyExistsError(slug);
+    }
+    throw error;
+  }
+
+  if (input.sessions.length > 0) {
+    await db.insert(eventSessionSchema).values(
+      input.sessions.map(s => ({
+        id: randomUUID(),
+        eventId: id,
+        primaryInstructorClerkId: s.primaryInstructorClerkId ?? null,
+        sessionDate: s.sessionDate,
+        startTime: s.startTime,
+        endTime: s.endTime,
+        room: s.room ?? null,
+        maxCapacity: s.maxCapacity ?? null,
+      })),
+    );
+  }
+
+  if (input.billing.length > 0) {
+    await db.insert(eventBillingSchema).values(
+      input.billing.map((b, idx) => ({
+        id: randomUUID(),
+        eventId: id,
+        name: b.name,
+        price: b.price,
+        memberOnly: b.memberOnly ?? false,
+        validFrom: b.validFrom ?? null,
+        validUntil: b.validUntil ?? null,
+        maxRegistrations: b.maxRegistrations ?? null,
+        sortOrder: b.sortOrder ?? idx,
+      })),
+    );
+  }
+
+  if (input.tagIds.length > 0) {
+    await db.insert(eventTagSchema).values(
+      input.tagIds.map(tagId => ({ eventId: id, tagId })),
+    );
+  }
+
+  const created = await getEventById(id, organizationId);
+  if (!created) {
+    throw new Error('Event created but could not be re-read');
+  }
+  return created;
+}
+
+/**
+ * Update event basics + replace sessions + replace billing + replace tags.
+ *
+ * Same delete-and-reinsert strategy as ClassesService.updateClass: sessions
+ * with attendance rows are kept (cancelled instead of removed) so historical
+ * check-ins still resolve. Billing tiers are always wiped — they don't have
+ * referencing rows.
+ */
+export async function updateEvent(
+  eventId: string,
+  input: UpdateEventServiceInput,
+  organizationId: string,
+): Promise<EventData | null> {
+  const existing = await db
+    .select()
+    .from(eventSchema)
+    .where(and(eq(eventSchema.id, eventId), eq(eventSchema.organizationId, organizationId)))
+    .limit(1);
+  if (existing.length === 0) {
+    return null;
+  }
+
+  const slug = slugify(input.name);
+
+  try {
+    await db
+      .update(eventSchema)
+      .set({
+        programId: input.programId ?? null,
+        name: input.name,
+        slug,
+        description: input.description ?? null,
+        eventType: input.eventType,
+        imageUrl: input.imageUrl ?? null,
+        maxCapacity: input.maxCapacity ?? null,
+        registrationDeadline: input.registrationDeadline ?? null,
+        isPublic: input.isPublic ?? true,
+        isActive: input.isActive,
+      })
+      .where(and(eq(eventSchema.id, eventId), eq(eventSchema.organizationId, organizationId)));
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      throw new EventSlugAlreadyExistsError(slug);
+    }
+    throw error;
+  }
+
+  // Sessions: keep ones with attendance, hard-delete the rest, then reinsert.
+  const oldSessions = await db
+    .select()
+    .from(eventSessionSchema)
+    .where(eq(eventSessionSchema.eventId, eventId));
+
+  if (oldSessions.length > 0) {
+    const oldIds = oldSessions.map(s => s.id);
+    const refAttendance = await db
+      .select({ id: attendanceSchema.eventSessionId })
+      .from(attendanceSchema)
+      .where(inArray(attendanceSchema.eventSessionId, oldIds));
+    const referenced = new Set(refAttendance.map(r => r.id).filter((id): id is string => id !== null));
+    const deletable = oldIds.filter(id => !referenced.has(id));
+    if (deletable.length > 0) {
+      await db.delete(eventSessionSchema).where(inArray(eventSessionSchema.id, deletable));
+    }
+    const referencedIds = oldIds.filter(id => referenced.has(id));
+    if (referencedIds.length > 0) {
+      await db
+        .update(eventSessionSchema)
+        .set({ isCancelled: true })
+        .where(inArray(eventSessionSchema.id, referencedIds));
+    }
+  }
+
+  if (input.sessions.length > 0) {
+    await db.insert(eventSessionSchema).values(
+      input.sessions.map(s => ({
+        id: randomUUID(),
+        eventId,
+        primaryInstructorClerkId: s.primaryInstructorClerkId ?? null,
+        sessionDate: s.sessionDate,
+        startTime: s.startTime,
+        endTime: s.endTime,
+        room: s.room ?? null,
+        maxCapacity: s.maxCapacity ?? null,
+      })),
+    );
+  }
+
+  // Billing tiers: full replace (no referencing rows).
+  await db.delete(eventBillingSchema).where(eq(eventBillingSchema.eventId, eventId));
+  if (input.billing.length > 0) {
+    await db.insert(eventBillingSchema).values(
+      input.billing.map((b, idx) => ({
+        id: randomUUID(),
+        eventId,
+        name: b.name,
+        price: b.price,
+        memberOnly: b.memberOnly ?? false,
+        validFrom: b.validFrom ?? null,
+        validUntil: b.validUntil ?? null,
+        maxRegistrations: b.maxRegistrations ?? null,
+        sortOrder: b.sortOrder ?? idx,
+      })),
+    );
+  }
+
+  // Tag associations: full replace.
+  await db.delete(eventTagSchema).where(eq(eventTagSchema.eventId, eventId));
+  if (input.tagIds.length > 0) {
+    await db.insert(eventTagSchema).values(
+      input.tagIds.map(tagId => ({ eventId, tagId })),
+    );
+  }
+
+  return getEventById(eventId, organizationId);
+}
+
+/**
+ * Soft-delete an event (sets isActive = false). Same reasoning as classes —
+ * registrations and attendance reference event/session rows.
+ */
+export async function softDeleteEvent(eventId: string, organizationId: string): Promise<boolean> {
+  const existing = await db
+    .select()
+    .from(eventSchema)
+    .where(and(eq(eventSchema.id, eventId), eq(eventSchema.organizationId, organizationId)))
+    .limit(1);
+  if (existing.length === 0) {
+    return false;
+  }
+
+  await db
+    .update(eventSchema)
+    .set({ isActive: false })
+    .where(and(eq(eventSchema.id, eventId), eq(eventSchema.organizationId, organizationId)));
+  return true;
 }

--- a/src/types/Audit.test.ts
+++ b/src/types/Audit.test.ts
@@ -18,14 +18,14 @@ describe('Audit Types', () => {
     it('should have correct number of action types', () => {
       const actionCount = Object.keys(AUDIT_ACTION).length;
 
-      // 8 member + 3 membership plan + 3 program + 7 class (3+3+1 exception) + 6 event
+      // 8 member + 3 membership plan + 3 program + 9 class (3+3+3 exception) + 6 event
       // + 4 coupon + 4 enrollment/registration + 2 attendance + 3 transaction + 3 tag + 2 image
       // + 12 catalog (6 item + 3 variant + 3 category + 1 stock + 2 image)
       // + 8 waiver (4 template + 1 signed + 3 membership waiver)
       // + 3 merge field + 1 payment + 1 payment method register + 1 family member link
       // + 1 family member unlink + 1 member convert + 3 saas subscription
-      // + 3 note (create + update + delete) + 3 staff (invite + update + remove) = 82
-      expect(actionCount).toBe(82);
+      // + 3 note (create + update + delete) + 3 staff (invite + update + remove) = 84
+      expect(actionCount).toBe(84);
     });
   });
 

--- a/src/types/Audit.ts
+++ b/src/types/Audit.ts
@@ -33,6 +33,8 @@ export const AUDIT_ACTION = {
   CLASS_SCHEDULE_UPDATE: 'classSchedule.update',
   CLASS_SCHEDULE_DELETE: 'classSchedule.delete',
   CLASS_SCHEDULE_EXCEPTION_CREATE: 'classScheduleException.create',
+  CLASS_SCHEDULE_EXCEPTION_UPDATE: 'classScheduleException.update',
+  CLASS_SCHEDULE_EXCEPTION_DELETE: 'classScheduleException.delete',
 
   // Event operations
   EVENT_CREATE: 'event.create',

--- a/src/validations/ClassesValidation.test.ts
+++ b/src/validations/ClassesValidation.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CreateClassValidation,
+  DeleteClassValidation,
+  DeleteScheduleExceptionValidation,
+  UpdateClassValidation,
+  UpsertScheduleExceptionValidation,
+} from './ClassesValidation';
+
+const validClass = {
+  name: 'BJJ Fundamentals',
+  description: 'Beginner-friendly BJJ.',
+  programId: 'prog-1',
+  color: '#4f46e5',
+  defaultDurationMinutes: 60,
+  maxCapacity: 30,
+  minAge: 18,
+  maxAge: null,
+  isActive: true,
+  schedule: [
+    { dayOfWeek: 1, startTime: '18:00', endTime: '19:00', primaryInstructorClerkId: 'user_1', room: 'Mat 1' },
+  ],
+  tagIds: ['tag-1'],
+};
+
+describe('CreateClassValidation', () => {
+  it('accepts a valid payload', () => {
+    expect(CreateClassValidation.safeParse(validClass).success).toBe(true);
+  });
+
+  it('rejects empty name', () => {
+    expect(CreateClassValidation.safeParse({ ...validClass, name: '' }).success).toBe(false);
+  });
+
+  it('rejects invalid hex color', () => {
+    expect(CreateClassValidation.safeParse({ ...validClass, color: 'red' }).success).toBe(false);
+  });
+
+  it('allows null color and description', () => {
+    const r = CreateClassValidation.safeParse({ ...validClass, color: null, description: null });
+
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects negative ages', () => {
+    expect(CreateClassValidation.safeParse({ ...validClass, minAge: -1 }).success).toBe(false);
+  });
+
+  it('rejects malformed time-of-day', () => {
+    expect(CreateClassValidation.safeParse({
+      ...validClass,
+      schedule: [{ dayOfWeek: 1, startTime: '25:00', endTime: '26:00' }],
+    }).success).toBe(false);
+  });
+
+  it('rejects out-of-range dayOfWeek', () => {
+    expect(CreateClassValidation.safeParse({
+      ...validClass,
+      schedule: [{ dayOfWeek: 7, startTime: '18:00', endTime: '19:00' }],
+    }).success).toBe(false);
+  });
+
+  it('defaults schedule and tagIds when omitted', () => {
+    const { schedule: _s, tagIds: _t, ...minimal } = validClass;
+    const r = CreateClassValidation.safeParse(minimal);
+
+    expect(r.success).toBe(true);
+
+    if (r.success) {
+      expect(r.data.schedule).toEqual([]);
+      expect(r.data.tagIds).toEqual([]);
+    }
+  });
+});
+
+describe('UpdateClassValidation', () => {
+  it('requires id', () => {
+    expect(UpdateClassValidation.safeParse(validClass).success).toBe(false);
+    expect(UpdateClassValidation.safeParse({ id: 'c-1', ...validClass }).success).toBe(true);
+  });
+});
+
+describe('DeleteClassValidation', () => {
+  it('rejects empty id', () => {
+    expect(DeleteClassValidation.safeParse({ id: '' }).success).toBe(false);
+  });
+
+  it('accepts a non-empty id', () => {
+    expect(DeleteClassValidation.safeParse({ id: 'c-1' }).success).toBe(true);
+  });
+});
+
+describe('UpsertScheduleExceptionValidation', () => {
+  const valid = {
+    classScheduleInstanceId: 'sched-1',
+    exceptionDate: new Date('2026-05-15T00:00:00Z'),
+    exceptionType: 'cancelled' as const,
+  };
+
+  it('accepts a minimal cancellation', () => {
+    expect(UpsertScheduleExceptionValidation.safeParse(valid).success).toBe(true);
+  });
+
+  it('coerces ISO strings to dates', () => {
+    const r = UpsertScheduleExceptionValidation.safeParse({ ...valid, exceptionDate: '2026-05-15' });
+
+    expect(r.success).toBe(true);
+
+    if (r.success) {
+      expect(r.data.exceptionDate).toBeInstanceOf(Date);
+    }
+  });
+
+  it('rejects unknown exception types', () => {
+    expect(UpsertScheduleExceptionValidation.safeParse({
+      ...valid,
+      exceptionType: 'whatever',
+    }).success).toBe(false);
+  });
+
+  it('accepts time_change with new start/end', () => {
+    expect(UpsertScheduleExceptionValidation.safeParse({
+      ...valid,
+      exceptionType: 'time_change',
+      newStartTime: '19:00',
+      newEndTime: '20:00',
+    }).success).toBe(true);
+  });
+
+  it('rejects malformed new time', () => {
+    expect(UpsertScheduleExceptionValidation.safeParse({
+      ...valid,
+      exceptionType: 'time_change',
+      newStartTime: '25:00',
+    }).success).toBe(false);
+  });
+});
+
+describe('DeleteScheduleExceptionValidation', () => {
+  it('rejects empty id', () => {
+    expect(DeleteScheduleExceptionValidation.safeParse({ id: '' }).success).toBe(false);
+  });
+
+  it('accepts non-empty id', () => {
+    expect(DeleteScheduleExceptionValidation.safeParse({ id: 'exc-1' }).success).toBe(true);
+  });
+});

--- a/src/validations/ClassesValidation.ts
+++ b/src/validations/ClassesValidation.ts
@@ -1,0 +1,80 @@
+import * as z from 'zod';
+
+const NAME_MAX = 100;
+const DESCRIPTION_MAX = 1000;
+const ROOM_MAX = 100;
+const REASON_MAX = 500;
+
+const HexColor = z
+  .string()
+  .regex(/^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i, 'Color must be a hex value like #4f46e5');
+
+// HH:MM (24-hour). Accepts 0:00 through 23:59.
+const TimeOfDay = z
+  .string()
+  .regex(/^([01]?\d|2[0-3]):[0-5]\d$/, 'Time must be HH:MM (24-hour)');
+
+const DayOfWeek = z.number().int().min(0).max(6);
+
+const ScheduleInstanceShape = z.object({
+  dayOfWeek: DayOfWeek,
+  startTime: TimeOfDay,
+  endTime: TimeOfDay,
+  primaryInstructorClerkId: z.string().min(1).nullable().optional(),
+  room: z.string().max(ROOM_MAX).nullable().optional(),
+});
+
+const ClassShape = z.object({
+  name: z.string().min(1).max(NAME_MAX),
+  description: z.string().max(DESCRIPTION_MAX).nullable().optional(),
+  programId: z.string().min(1).nullable().optional(),
+  color: HexColor.nullable().optional(),
+  defaultDurationMinutes: z.number().int().min(1).max(24 * 60).nullable().optional(),
+  maxCapacity: z.number().int().min(1).nullable().optional(),
+  minAge: z.number().int().min(0).max(120).nullable().optional(),
+  maxAge: z.number().int().min(0).max(120).nullable().optional(),
+  isActive: z.boolean(),
+  schedule: z.array(ScheduleInstanceShape).optional().default([]),
+  tagIds: z.array(z.string().min(1)).optional().default([]),
+});
+
+export const CreateClassValidation = ClassShape;
+
+export const UpdateClassValidation = ClassShape.extend({
+  id: z.string().min(1),
+});
+
+export const DeleteClassValidation = z.object({
+  id: z.string().min(1),
+});
+
+// Accepts both the original schema vocabulary and the UI's vocabulary —
+// the column is a text field and existing seeded data uses the second set.
+const ExceptionType = z.enum([
+  'cancelled',
+  'time_change',
+  'instructor_change',
+  'room_change',
+  'deleted',
+  'modified',
+  'modified-forward',
+]);
+
+export const UpsertScheduleExceptionValidation = z.object({
+  classScheduleInstanceId: z.string().min(1),
+  exceptionDate: z.coerce.date(),
+  exceptionType: ExceptionType,
+  newStartTime: TimeOfDay.nullable().optional(),
+  newEndTime: TimeOfDay.nullable().optional(),
+  newInstructorClerkId: z.string().min(1).nullable().optional(),
+  newRoom: z.string().max(ROOM_MAX).nullable().optional(),
+  reason: z.string().max(REASON_MAX).nullable().optional(),
+});
+
+export const DeleteScheduleExceptionValidation = z.object({
+  id: z.string().min(1),
+});
+
+export type CreateClassInput = z.infer<typeof CreateClassValidation>;
+export type UpdateClassInput = z.infer<typeof UpdateClassValidation>;
+export type UpsertScheduleExceptionInput = z.infer<typeof UpsertScheduleExceptionValidation>;

--- a/src/validations/EventsValidation.test.ts
+++ b/src/validations/EventsValidation.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CreateEventValidation,
+  DeleteEventValidation,
+  UpdateEventValidation,
+} from './EventsValidation';
+
+const validEvent = {
+  name: 'Black Belt Seminar',
+  description: 'A weekend seminar.',
+  eventType: 'seminar' as const,
+  programId: 'prog-1',
+  imageUrl: 'https://example.com/banner.jpg',
+  maxCapacity: 50,
+  registrationDeadline: new Date('2026-06-01T00:00:00Z'),
+  isPublic: true,
+  isActive: true,
+  sessions: [
+    {
+      sessionDate: new Date('2026-06-15T00:00:00Z'),
+      startTime: '10:00',
+      endTime: '14:00',
+      primaryInstructorClerkId: 'user_1',
+      room: 'Main Mat',
+      maxCapacity: 50,
+    },
+  ],
+  billing: [
+    { name: 'Early Bird', price: 99.99, memberOnly: false, sortOrder: 0 },
+  ],
+  tagIds: ['tag-1'],
+};
+
+describe('CreateEventValidation', () => {
+  it('accepts a valid payload', () => {
+    expect(CreateEventValidation.safeParse(validEvent).success).toBe(true);
+  });
+
+  it('rejects empty name', () => {
+    expect(CreateEventValidation.safeParse({ ...validEvent, name: '' }).success).toBe(false);
+  });
+
+  it('rejects unknown eventType', () => {
+    expect(CreateEventValidation.safeParse({ ...validEvent, eventType: 'party' }).success).toBe(false);
+  });
+
+  it('rejects malformed imageUrl', () => {
+    expect(CreateEventValidation.safeParse({ ...validEvent, imageUrl: 'not-a-url' }).success).toBe(false);
+  });
+
+  it('allows null imageUrl', () => {
+    expect(CreateEventValidation.safeParse({ ...validEvent, imageUrl: null }).success).toBe(true);
+  });
+
+  it('rejects negative price', () => {
+    expect(CreateEventValidation.safeParse({
+      ...validEvent,
+      billing: [{ name: 'Bad', price: -10 }],
+    }).success).toBe(false);
+  });
+
+  it('rejects malformed session times', () => {
+    expect(CreateEventValidation.safeParse({
+      ...validEvent,
+      sessions: [{
+        sessionDate: new Date(),
+        startTime: '99:99',
+        endTime: '14:00',
+      }],
+    }).success).toBe(false);
+  });
+
+  it('coerces ISO strings to dates', () => {
+    const r = CreateEventValidation.safeParse({
+      ...validEvent,
+      registrationDeadline: '2026-06-01',
+    });
+
+    expect(r.success).toBe(true);
+
+    if (r.success) {
+      expect(r.data.registrationDeadline).toBeInstanceOf(Date);
+    }
+  });
+
+  it('defaults sessions, billing, and tagIds when omitted', () => {
+    const { sessions: _s, billing: _b, tagIds: _t, ...minimal } = validEvent;
+    const r = CreateEventValidation.safeParse(minimal);
+
+    expect(r.success).toBe(true);
+
+    if (r.success) {
+      expect(r.data.sessions).toEqual([]);
+      expect(r.data.billing).toEqual([]);
+      expect(r.data.tagIds).toEqual([]);
+    }
+  });
+});
+
+describe('UpdateEventValidation', () => {
+  it('requires id', () => {
+    expect(UpdateEventValidation.safeParse(validEvent).success).toBe(false);
+    expect(UpdateEventValidation.safeParse({ id: 'e-1', ...validEvent }).success).toBe(true);
+  });
+});
+
+describe('DeleteEventValidation', () => {
+  it('rejects empty id', () => {
+    expect(DeleteEventValidation.safeParse({ id: '' }).success).toBe(false);
+  });
+
+  it('accepts non-empty id', () => {
+    expect(DeleteEventValidation.safeParse({ id: 'e-1' }).success).toBe(true);
+  });
+});

--- a/src/validations/EventsValidation.ts
+++ b/src/validations/EventsValidation.ts
@@ -1,0 +1,58 @@
+import * as z from 'zod';
+
+const NAME_MAX = 100;
+const DESCRIPTION_MAX = 2000;
+const TIER_NAME_MAX = 100;
+
+const TimeOfDay = z
+  .string()
+  .regex(/^([01]?\d|2[0-3]):[0-5]\d$/, 'Time must be HH:MM (24-hour)');
+
+const EventType = z.enum(['seminar', 'workshop', 'tournament', 'camp', 'other']);
+
+const SessionShape = z.object({
+  sessionDate: z.coerce.date(),
+  startTime: TimeOfDay,
+  endTime: TimeOfDay,
+  primaryInstructorClerkId: z.string().min(1).nullable().optional(),
+  room: z.string().max(100).nullable().optional(),
+  maxCapacity: z.number().int().min(1).nullable().optional(),
+});
+
+const BillingTierShape = z.object({
+  name: z.string().min(1).max(TIER_NAME_MAX),
+  price: z.number().min(0),
+  memberOnly: z.boolean().optional().default(false),
+  validFrom: z.coerce.date().nullable().optional(),
+  validUntil: z.coerce.date().nullable().optional(),
+  maxRegistrations: z.number().int().min(1).nullable().optional(),
+  sortOrder: z.number().int().min(0).optional().default(0),
+});
+
+const EventShape = z.object({
+  name: z.string().min(1).max(NAME_MAX),
+  description: z.string().max(DESCRIPTION_MAX).nullable().optional(),
+  eventType: EventType,
+  programId: z.string().min(1).nullable().optional(),
+  imageUrl: z.string().url().nullable().optional(),
+  maxCapacity: z.number().int().min(1).nullable().optional(),
+  registrationDeadline: z.coerce.date().nullable().optional(),
+  isPublic: z.boolean().optional().default(true),
+  isActive: z.boolean(),
+  sessions: z.array(SessionShape).optional().default([]),
+  billing: z.array(BillingTierShape).optional().default([]),
+  tagIds: z.array(z.string().min(1)).optional().default([]),
+});
+
+export const CreateEventValidation = EventShape;
+
+export const UpdateEventValidation = EventShape.extend({
+  id: z.string().min(1),
+});
+
+export const DeleteEventValidation = z.object({
+  id: z.string().min(1),
+});
+
+export type CreateEventInput = z.infer<typeof CreateEventValidation>;
+export type UpdateEventInput = z.infer<typeof UpdateEventValidation>;


### PR DESCRIPTION
## Summary

The calendar / classes / events feature was mocked end-to-end — the Add Class wizard returned an in-memory object with a `class-${Date.now()}` id, the class detail edit handlers only mutated local state, the event detail Edit buttons had no `onClick` at all, and the schedule-exception save flow never persisted. This PR replaces the mocks with real ORPC endpoints + service-layer writes, builds the missing event-edit modal, and adds a popover date picker to the weekly/monthly calendar headers so the user can jump to any date instead of paging through Previous/Next.

## Closes

Closes #146
Closes #147
Closes #148
Closes #149

## What changed

- **Backend CRUD (new):** `classes.create`, `classes.update`, `classes.remove`, `classes.upsertException`, `classes.removeException`, `events.create`, `events.update`, `events.remove`. All gated by `guardRole` (FRONT_DESK for writes, ADMIN for soft-deletes), all audited via `AuditService`. Soft-delete on classes/events to preserve attendance history. Schedule instances + sessions referenced by attendance are kept (marked inactive/cancelled) instead of hard-deleted.
- **New audit actions:** `CLASS_SCHEDULE_EXCEPTION_UPDATE`, `CLASS_SCHEDULE_EXCEPTION_DELETE`.
- **Validations (new):** `ClassesValidation.ts` + `EventsValidation.ts` with Zod schemas for create / update / delete / upsert-exception, plus 30 co-located tests covering edge cases (negative ages, malformed time-of-day, unknown event types, etc.).
- **#148 — Add Class/Event wizard (`AddClassModal.tsx`):** replaced the in-memory mock construction with `client.classes.create` / `client.events.create`. Existing `invalidateClassesCache()` / `invalidateEventsCache()` calls now actually have something to fetch.
- **#146 — Class detail (`classes/[classId]/page.tsx`):** `handleSaveException`, `handleDeleteException`, and `handleDeleteClass` now persist to the server and revalidate the cache. Optimistic local update so the UI reflects changes immediately.
- **#147 — Event detail (`classes/events/[eventId]/page.tsx`):** built `EditEventModal.tsx` (tabbed: Details / Pricing / Sessions) and wired all four previously-unwired Edit buttons to open the modal at the right tab. `handleDeleteEvent` now soft-deletes via `client.events.remove`.
- **#149 — Calendar date picker (`CalendarDateNav.tsx`):** new component renders the week/month heading as a Shadcn Popover trigger that opens a Calendar for date selection. Per review feedback the free-text date input was removed (typed dates are too error-prone) — popover is the only entry point.
- **Today-cell highlight (review feedback):** today's column header in WeeklyView and today's date cell in MonthlyView are tinted `bg-blue-50 dark:bg-blue-950/40` so they stand out in both light and dark mode without relying on opacity tricks.
- **i18n:** new `Calendar.open_picker_aria` key; new `EventDetailPage.EditEventModal.*` namespace; new `EventDetailPage.edit_*_aria` keys for the four Edit-button labels. All keys mirrored in `fr.json`.

## Out of scope

- **Class basics/schedule/settings server-side wiring.** The Edit Basics / Schedule / Settings modals on the class detail page still update local state only — that flow wasn't reported broken in this cluster and the wiring is non-trivial (instance-by-instance schedule diffing). Tracked separately.
- **Restore UI for soft-deleted classes/events.** Backend supports it (`isActive = true`), but no admin UI yet.
- **Recurring events.** The data model is one-off; not changing here.
- **Cluster D (#173, #153, #154 — delete member/membership/role).** Same root cause (mocked mutations) but in different feature areas; better as a follow-up PR.

## Test plan

- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run check:types` — clean
- [x] `npm run check:deps` — no unused deps/exports
- [x] `npm run check:i18n` — no missing/invalid/unused/undefined keys
- [x] `npm run test` — 4279/4279 passing (225 files), including 30 new validation tests, 4 new CalendarDateNav tests, 5 new EditEventModal tests
- [x] `npx playwright test classes.e2e.ts navigation.e2e.ts` — 17/17 pass
- [ ] Manual smoke (local PGLite): create a class via the wizard → appears on the calendar → refresh → still there
- [ ] Manual smoke: create an event → appears on the calendar → refresh → still there
- [ ] Manual smoke: on a class detail, cancel a recurring instance for a specific date → refresh → exception persists, calendar shows it
- [ ] Manual smoke: on an event detail, click any Edit button → modal opens at the right tab → change a field → save → refresh → change persists
- [ ] Manual smoke: in weekly view, click the date heading → popover Calendar opens → click a date → calendar jumps. Verify today's column header is tinted blue. Repeat for monthly view (today's cell tinted)
- [ ] Manual smoke (dark mode): the today-cell tint is visible but not garish