### PR TITLE
feat(payments): adjustments for payments

### DIFF
--- a/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx
+++ b/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx
@@ -23,6 +23,7 @@ import { ConvertMemberModal } from '@/features/members/conversion/ConvertMemberM
 import { ChangeMembershipModal } from '@/features/members/details/ChangeMembershipModal';
 import { EditContactInfoModal } from '@/features/members/details/EditContactInfoModal';
 import { EditMemberPhotoModal } from '@/features/members/details/EditMemberPhotoModal';
+import { EditPaymentMethodModal } from '@/features/members/details/EditPaymentMethodModal';
 import { MemberDetailAttendance } from '@/features/members/details/MemberDetailAttendance';
 import { MemberDetailNotes } from '@/features/members/details/MemberDetailNotes';
 import { AddFamilyMembersModal } from '@/features/members/wizard/AddFamilyMembersModal';
@@ -455,6 +456,7 @@ export default function EditMemberPage() {
 
   // State for edit photo modal
   const [isEditPhotoModalOpen, setIsEditPhotoModalOpen] = useState(false);
+  const [isEditPaymentMethodOpen, setIsEditPaymentMethodOpen] = useState(false);
 
   // State for change membership modal
   const [isChangeMembershipModalOpen, setIsChangeMembershipModalOpen] = useState(false);
@@ -614,25 +616,28 @@ export default function EditMemberPage() {
     fetchSignedWaivers();
   }, [memberId]);
 
-  // Fetch payment methods for this member
-  useEffect(() => {
-    const fetchPaymentMethods = async () => {
-      if (!memberId) {
-        return;
-      }
-      setIsLoadingPayment(true);
-      try {
-        const result = await client.member.listPaymentMethods({ memberId });
-        setPaymentMethods(result.paymentMethods);
-      } catch (err) {
-        console.warn('[Edit Member] Failed to fetch payment methods:', err);
-        setPaymentMethods([]);
-      } finally {
-        setIsLoadingPayment(false);
-      }
-    };
-    fetchPaymentMethods();
+  // Fetch payment methods for this member. Extracted into a useCallback so
+  // the EditPaymentMethodModal can call it via onSavedAction to refresh the
+  // displayed last-4 after saving a new card.
+  const reloadPaymentMethods = useCallback(async () => {
+    if (!memberId) {
+      return;
+    }
+    setIsLoadingPayment(true);
+    try {
+      const result = await client.member.listPaymentMethods({ memberId });
+      setPaymentMethods(result.paymentMethods);
+    } catch (err) {
+      console.warn('[Edit Member] Failed to fetch payment methods:', err);
+      setPaymentMethods([]);
+    } finally {
+      setIsLoadingPayment(false);
+    }
   }, [memberId]);
+
+  useEffect(() => {
+    void reloadPaymentMethods();
+  }, [reloadPaymentMethods]);
 
   // Fetch billing history for this member
   useEffect(() => {
@@ -1121,6 +1126,20 @@ export default function EditMemberPage() {
               }}
             />
 
+            <EditPaymentMethodModal
+              key={isEditPaymentMethodOpen ? 'pm-open' : 'pm-closed'}
+              isOpen={isEditPaymentMethodOpen}
+              onCloseAction={() => setIsEditPaymentMethodOpen(false)}
+              memberId={memberId}
+              memberEmail={state.currentData.contactInfo.email ?? ''}
+              memberFirstName={state.currentData.firstName}
+              memberLastName={state.currentData.lastName}
+              memberPhone={state.currentData.contactInfo.phone}
+              onSavedAction={() => {
+                void reloadPaymentMethods();
+              }}
+            />
+
             {/* Membership Details - Comprehensive */}
             <Card className="flex flex-col p-6">
               <div>
@@ -1243,7 +1262,33 @@ export default function EditMemberPage() {
             {/* Payment Method */}
             <Card className="flex flex-col p-6">
               <div>
-                <h2 className="mb-6 text-lg font-semibold text-foreground">Payment Method</h2>
+                <div className="mb-6 flex items-center justify-between">
+                  <h2 className="text-lg font-semibold text-foreground">Payment Method</h2>
+                  {!isLoadingPayment && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setIsEditPaymentMethodOpen(true)}
+                      aria-label={paymentMethods.length === 0 ? 'Add payment method' : 'Edit payment method'}
+                    >
+                      {paymentMethods.length === 0
+                        ? (
+                            <>
+                              <Plus className="mr-1 h-4 w-4" />
+                              {' '}
+                              Add
+                            </>
+                          )
+                        : (
+                            <>
+                              <Pencil className="mr-1 h-4 w-4" />
+                              {' '}
+                              Edit
+                            </>
+                          )}
+                    </Button>
+                  )}
+                </div>
                 {isLoadingPayment
                   ? (
                       <p className="text-sm text-muted-foreground">Loading payment methods...</p>

--- a/src/app/[locale]/webhook/iqpro/route.ts
+++ b/src/app/[locale]/webhook/iqpro/route.ts
@@ -1,11 +1,11 @@
-import { eq } from 'drizzle-orm';
+import { and, eq, ne } from 'drizzle-orm';
 import { headers } from 'next/headers';
 import { NextResponse } from 'next/server';
 import { db } from '@/libs/DB';
 import { Env } from '@/libs/Env';
 import { logger } from '@/libs/Logger';
 import { getClientIP, isRateLimitingEnabled, webhookRateLimiter } from '@/libs/RateLimit';
-import { memberMembershipSchema, organizationSchema, transactionSchema } from '@/models/Schema';
+import { memberMembershipSchema, memberSchema, organizationSchema, transactionSchema } from '@/models/Schema';
 
 // Inline type to avoid top-level import from the optional @dojo-planner/iqpro-client package
 type WebhookPayload = { type: string; id?: string; data: Record<string, unknown> };
@@ -173,6 +173,14 @@ async function handleSubscriptionPaymentSucceeded(data: Record<string, unknown>)
     ? new Date(data.nextPaymentDate as string)
     : undefined;
 
+  // Look up the member that owns this membership BEFORE the update so we can
+  // mirror the membership status onto memberSchema.status (#138). Without
+  // this, the member-detail UI keeps showing the old status.
+  const membership = await db.query.memberMembershipSchema.findFirst({
+    where: eq(memberMembershipSchema.iqproSubscriptionId, subscriptionId),
+    columns: { memberId: true },
+  });
+
   await db
     .update(memberMembershipSchema)
     .set({
@@ -180,6 +188,20 @@ async function handleSubscriptionPaymentSucceeded(data: Record<string, unknown>)
       ...(nextPaymentDate && { nextPaymentDate }),
     })
     .where(eq(memberMembershipSchema.iqproSubscriptionId, subscriptionId));
+
+  // Mirror onto member.status — only flip past_due → active. We deliberately
+  // leave 'archived' / 'cancelled' / 'hold' / 'trial' alone so that a stray
+  // payment-success webhook doesn't reactivate a member the operator
+  // explicitly archived or put on hold.
+  if (membership?.memberId) {
+    await db
+      .update(memberSchema)
+      .set({ status: 'active', statusChangedAt: new Date() })
+      .where(and(
+        eq(memberSchema.id, membership.memberId),
+        eq(memberSchema.status, 'past_due'),
+      ));
+  }
 
   logger.info('[IQPro Webhook] Subscription payment succeeded', { subscriptionId });
 }
@@ -207,10 +229,30 @@ async function handleSubscriptionPaymentFailed(data: Record<string, unknown>): P
   }
 
   // Fall back to member membership subscription
+  const membership = await db.query.memberMembershipSchema.findFirst({
+    where: eq(memberMembershipSchema.iqproSubscriptionId, subscriptionId),
+    columns: { memberId: true },
+  });
+
   await db
     .update(memberMembershipSchema)
     .set({ status: 'past_due' })
     .where(eq(memberMembershipSchema.iqproSubscriptionId, subscriptionId));
+
+  // Mirror onto member.status (#138). Only flip if the member is currently
+  // 'active' or 'trial' — leaves archived / cancelled / hold rows alone so a
+  // stray webhook can't escalate a member the operator already finalised.
+  if (membership?.memberId) {
+    await db
+      .update(memberSchema)
+      .set({ status: 'past_due', statusChangedAt: new Date() })
+      .where(and(
+        eq(memberSchema.id, membership.memberId),
+        ne(memberSchema.status, 'archived'),
+        ne(memberSchema.status, 'cancelled'),
+        ne(memberSchema.status, 'hold'),
+      ));
+  }
 
   logger.info('[IQPro Webhook] Subscription payment failed', { subscriptionId });
 }
@@ -238,10 +280,37 @@ async function handleSubscriptionCancelled(data: Record<string, unknown>): Promi
   }
 
   // Fall back to member membership subscription
+  const membership = await db.query.memberMembershipSchema.findFirst({
+    where: eq(memberMembershipSchema.iqproSubscriptionId, subscriptionId),
+    columns: { memberId: true },
+  });
+
   await db
     .update(memberMembershipSchema)
     .set({ status: 'cancelled' })
     .where(eq(memberMembershipSchema.iqproSubscriptionId, subscriptionId));
+
+  // Mirror onto member.status (#138) only if the cancelled membership was the
+  // member's last active one. We don't want to cancel a member who still has
+  // a different active membership in the same org.
+  if (membership?.memberId) {
+    const activeOther = await db.query.memberMembershipSchema.findFirst({
+      where: and(
+        eq(memberMembershipSchema.memberId, membership.memberId),
+        eq(memberMembershipSchema.status, 'active'),
+      ),
+      columns: { id: true },
+    });
+    if (!activeOther) {
+      await db
+        .update(memberSchema)
+        .set({ status: 'cancelled', statusChangedAt: new Date() })
+        .where(and(
+          eq(memberSchema.id, membership.memberId),
+          ne(memberSchema.status, 'archived'),
+        ));
+    }
+  }
 
   logger.info('[IQPro Webhook] Subscription cancelled', { subscriptionId });
 }

--- a/src/features/billing/SubscriptionDialog.tsx
+++ b/src/features/billing/SubscriptionDialog.tsx
@@ -6,7 +6,7 @@ import { useOrganization, useUser } from '@clerk/nextjs';
 import { ArrowDownAZ, ArrowUpZA, Check, ChevronLeft, ChevronRight, Loader2, X } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useTheme } from 'next-themes';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
 import { ButtonGroupItem, ButtonGroupRoot } from '@/components/ui/button-group';
@@ -47,9 +47,18 @@ export function SubscriptionDialog({ open, onOpenChange }: SubscriptionDialogPro
 
   const itemsPerPage = 10;
 
+  // Whether the payment form is currently mounted in the DOM. The TokenEx
+  // container <div id={TOKENEX_CONTAINER_ID}> only renders inside the
+  // payment-form card, which itself only renders when a plan has been
+  // selected and the user isn't already subscribed (see render block below).
+  // Pass `config: null` to the hook until the container exists; otherwise
+  // useTokenExIframe's effect runs while the div doesn't exist yet and the
+  // iframe never mounts (#160).
+  const showPaymentForm = !!selectedPlanId && !currentPlan?.hasActiveSubscription;
+
   const { isLoaded: iframeLoaded, isValid: iframeValid, tokenize } = useTokenExIframe({
     containerId: TOKENEX_CONTAINER_ID,
-    config: tokenizationConfig,
+    config: showPaymentForm ? tokenizationConfig : null,
     theme: resolvedTheme === 'dark' ? 'dark' : 'light',
   });
 
@@ -66,6 +75,16 @@ export function SubscriptionDialog({ open, onOpenChange }: SubscriptionDialogPro
       // If tokenization config fails, user will use plain card input
     }
   }, [tokenizationConfig]);
+
+  // Pre-load the tokenization config when the dialog opens for a not-yet-
+  // subscribed org. By the time the user clicks a plan and the payment form
+  // renders, the config is already cached and the iframe can mount without
+  // a visible loading delay (#160).
+  useEffect(() => {
+    if (open && !currentPlan?.hasActiveSubscription) {
+      void loadTokenizationConfig();
+    }
+  }, [open, currentPlan?.hasActiveSubscription, loadTokenizationConfig]);
 
   const handleSubscribe = async (planId: SaasPlanId) => {
     const plan = SaasPlanList[planId];

--- a/src/features/members/details/EditPaymentMethodModal.test.tsx
+++ b/src/features/members/details/EditPaymentMethodModal.test.tsx
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { page, userEvent } from 'vitest/browser';
+import { EditPaymentMethodModal } from './EditPaymentMethodModal';
+
+// Use the AddMemberWizard.PaymentStep namespace for shared field labels and
+// EditPaymentMethodModal for the modal-specific keys. The component reads
+// from both namespaces — provide both via the same mock.
+const translationKeys: Record<string, string> = {
+  // EditPaymentMethodModal namespace
+  title: 'Edit payment method',
+  save_button: 'Save',
+  saving_button: 'Saving...',
+  cancel_button: 'Cancel',
+  save_error: 'Failed to save payment method.',
+  card_iframe_unavailable: 'Tokenization not available.',
+  // AddMemberWizard.PaymentStep namespace
+  card_tab_label: 'Card',
+  ach_tab_label: 'ACH',
+  cardholder_name_label: 'Cardholder Name',
+  cardholder_name_placeholder: 'Full name',
+  card_number_label: 'Card Number',
+  card_number_iframe_loading: 'Loading...',
+  card_number_iframe_error: 'iframe error',
+  card_expiry_label: 'Expiry',
+  card_expiry_placeholder: 'MM/YY',
+  card_cvc_label: 'CVC',
+  ach_account_holder_label: 'Account Holder',
+  ach_account_holder_placeholder: 'Full name',
+  ach_account_type_label: 'Account Type',
+  ach_account_type_checking: 'Checking',
+  ach_account_type_savings: 'Savings',
+  ach_routing_number_label: 'Routing Number',
+  ach_routing_number_placeholder: '021000021',
+  ach_account_number_label: 'Account Number',
+  ach_account_number_placeholder: '12345',
+};
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => translationKeys[key] ?? key,
+}));
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ resolvedTheme: 'light' }),
+}));
+
+const mockTokenize = vi.fn();
+const mockIframe = {
+  isLoaded: false,
+  isValid: false,
+  isCvvValid: false,
+  error: null as string | null,
+  tokenize: mockTokenize,
+};
+
+vi.mock('@/hooks/useTokenExIframe', () => ({
+  useTokenExIframe: () => mockIframe,
+}));
+
+const mockGetTokenizationConfig = vi.fn();
+const mockRegisterPaymentMethod = vi.fn();
+
+vi.mock('@/libs/Orpc', () => ({
+  client: {
+    payment: {
+      getTokenizationConfig: (input: unknown) => mockGetTokenizationConfig(input),
+      registerPaymentMethod: (input: unknown) => mockRegisterPaymentMethod(input),
+    },
+  },
+}));
+
+const baseProps = {
+  isOpen: true,
+  onCloseAction: vi.fn(),
+  memberId: 'member-1',
+  memberEmail: 'jane@example.com',
+  memberFirstName: 'Jane',
+  memberLastName: 'Doe',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default to no IQPro config so the iframe-fallback branch is exercised
+  // (less mock setup needed for typical render tests).
+  mockGetTokenizationConfig.mockResolvedValue(null);
+  mockRegisterPaymentMethod.mockResolvedValue({ success: true, paymentMethodId: 'pm-1' });
+});
+
+describe('EditPaymentMethodModal', () => {
+  it('does not render when isOpen is false', () => {
+    render(<EditPaymentMethodModal {...baseProps} isOpen={false} />);
+
+    expect(document.body.textContent).not.toContain('Edit payment method');
+  });
+
+  it('renders the title and tab buttons when open', () => {
+    render(<EditPaymentMethodModal {...baseProps} />);
+
+    expect(page.getByText('Edit payment method')).toBeTruthy();
+
+    const cardButton = Array.from(document.querySelectorAll('button')).find(b => b.textContent === 'Card');
+    const achButton = Array.from(document.querySelectorAll('button')).find(b => b.textContent === 'ACH');
+
+    expect(cardButton).toBeTruthy();
+    expect(achButton).toBeTruthy();
+  });
+
+  it('switches to the ACH tab when the ACH button is clicked', async () => {
+    render(<EditPaymentMethodModal {...baseProps} />);
+
+    const achButton = Array.from(document.querySelectorAll('button')).find(b => b.textContent === 'ACH') as HTMLButtonElement;
+    await userEvent.click(achButton);
+
+    expect(page.getByLabelText(/account holder/i)).toBeTruthy();
+    expect(page.getByLabelText(/routing number/i)).toBeTruthy();
+  });
+
+  it('disables the Save button while form is incomplete', () => {
+    render(<EditPaymentMethodModal {...baseProps} />);
+
+    const saveButton = Array.from(document.querySelectorAll('button')).find(b => b.textContent === 'Save') as HTMLButtonElement;
+
+    expect(saveButton).toBeTruthy();
+    expect(saveButton.disabled).toBe(true);
+  });
+
+  it('submits ACH form via client.payment.registerPaymentMethod and calls onSavedAction + onCloseAction', async () => {
+    const onSaved = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <EditPaymentMethodModal
+        {...baseProps}
+        onCloseAction={onClose}
+        onSavedAction={onSaved}
+      />,
+    );
+
+    // Switch to ACH (avoids needing the iframe)
+    const achButton = Array.from(document.querySelectorAll('button')).find(b => b.textContent === 'ACH') as HTMLButtonElement;
+    await userEvent.click(achButton);
+
+    await userEvent.fill(page.getByLabelText(/account holder/i).element() as HTMLElement, 'Jane Doe');
+    await userEvent.fill(page.getByLabelText(/routing number/i).element() as HTMLElement, '021000021');
+    await userEvent.fill(page.getByLabelText(/account number/i).element() as HTMLElement, '123456789');
+
+    const saveButton = Array.from(document.querySelectorAll('button')).find(b => b.textContent === 'Save') as HTMLButtonElement;
+    await userEvent.click(saveButton);
+
+    await vi.waitFor(() => {
+      expect(mockRegisterPaymentMethod).toHaveBeenCalledTimes(1);
+    });
+
+    const payload = mockRegisterPaymentMethod.mock.calls[0]![0] as Record<string, unknown>;
+
+    expect(payload.memberId).toBe('member-1');
+    expect(payload.paymentMethod).toBe('ach');
+    expect(payload.achAccountHolder).toBe('Jane Doe');
+    expect(payload.achRoutingNumber).toBe('021000021');
+    expect(payload.achAccountNumber).toBe('123456789');
+    expect(payload.achAccountType).toBe('Checking');
+
+    expect(onSaved).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('surfaces the server error message when registerPaymentMethod returns success: false', async () => {
+    mockRegisterPaymentMethod.mockResolvedValueOnce({ success: false, error: 'Card declined by issuer' });
+
+    render(<EditPaymentMethodModal {...baseProps} />);
+
+    // Use ACH to skip the iframe path
+    const achButton = Array.from(document.querySelectorAll('button')).find(b => b.textContent === 'ACH') as HTMLButtonElement;
+    await userEvent.click(achButton);
+
+    await userEvent.fill(page.getByLabelText(/account holder/i).element() as HTMLElement, 'Jane Doe');
+    await userEvent.fill(page.getByLabelText(/routing number/i).element() as HTMLElement, '021000021');
+    await userEvent.fill(page.getByLabelText(/account number/i).element() as HTMLElement, '123456789');
+
+    const saveButton = Array.from(document.querySelectorAll('button')).find(b => b.textContent === 'Save') as HTMLButtonElement;
+    await userEvent.click(saveButton);
+
+    await vi.waitFor(() => {
+      expect(page.getByText('Card declined by issuer')).toBeTruthy();
+    });
+  });
+});

--- a/src/features/members/details/EditPaymentMethodModal.tsx
+++ b/src/features/members/details/EditPaymentMethodModal.tsx
@@ -1,0 +1,426 @@
+'use client';
+
+import type { TokenizationIframeConfig } from '@/libs/IQPro';
+import { CreditCard, Landmark, Loader2 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useTheme } from 'next-themes';
+import { useCallback, useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useTokenExIframe } from '@/hooks/useTokenExIframe';
+import { client } from '@/libs/Orpc';
+
+const TOKENEX_CONTAINER_ID = 'editPmTokenExIframeDiv';
+const TOKENEX_CVV_CONTAINER_ID = 'editPmTokenExCvvIframeDiv';
+
+type EditPaymentMethodModalProps = {
+  isOpen: boolean;
+  onCloseAction: () => void;
+  /**
+   * Identifies the member whose payment method is being edited. Required for
+   * the registerPaymentMethod RPC call.
+   */
+  memberId: string;
+  memberEmail: string;
+  memberFirstName: string;
+  memberLastName: string;
+  /** Optional but improves IQPro customer record completeness. */
+  memberPhone?: string;
+  /**
+   * Called after a successful save so the parent can refetch the saved
+   *  payment-method list and show the new last-4.
+   */
+  onSavedAction?: () => void;
+};
+
+/**
+ * Edit / add a payment method on an existing member's detail page (#134/#137).
+ *
+ * Mirrors the card-tokenization pattern used by the AddMember wizard's
+ * PaymentStep — TokenEx iframe captures the card client-side, returning a
+ * token + BIN/last4 that the server uses to register the payment method on
+ * the IQPro customer. ACH uses server-side tokenization via
+ * `client.payment.registerPaymentMethod` (which calls into IQPro's Vault API
+ * for ACH internally).
+ *
+ * No charge is processed — this only saves the payment method on file. To
+ * charge, the operator continues with the membership/transaction flow
+ * elsewhere.
+ */
+export function EditPaymentMethodModal({
+  isOpen,
+  onCloseAction,
+  memberId,
+  memberEmail,
+  memberFirstName,
+  memberLastName,
+  memberPhone,
+  onSavedAction,
+}: EditPaymentMethodModalProps) {
+  const t = useTranslations('AddMemberWizard.PaymentStep');
+  const tEdit = useTranslations('EditPaymentMethodModal');
+  const { resolvedTheme } = useTheme();
+
+  const [tokenizationConfig, setTokenizationConfig] = useState<TokenizationIframeConfig | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Single form-state object so reopening the modal triggers exactly one
+  // re-sync (during render) instead of an 8-call useEffect cascade. Same
+  // pattern as EditEventModal — see React docs on "deriving state from
+  // props".
+  type FormState = {
+    paymentMethod: 'card' | 'ach';
+    cardholderName: string;
+    cardExpiry: string;
+    achAccountHolder: string;
+    achRoutingNumber: string;
+    achAccountNumber: string;
+    achAccountType: 'Checking' | 'Savings';
+    error: string | null;
+    syncedFor: boolean; // tracks the open state we last synced from
+  };
+  const buildEmptyForm = (forOpen: boolean): FormState => ({
+    paymentMethod: 'card',
+    cardholderName: '',
+    cardExpiry: '',
+    achAccountHolder: '',
+    achRoutingNumber: '',
+    achAccountNumber: '',
+    achAccountType: 'Checking',
+    error: null,
+    syncedFor: forOpen,
+  });
+
+  const [form, setForm] = useState<FormState>(() => buildEmptyForm(isOpen));
+
+  // Re-sync during render when the modal opens. React explicitly supports
+  // calling setState during render to derive state from changing props.
+  if (isOpen && !form.syncedFor) {
+    setForm(buildEmptyForm(true));
+  } else if (!isOpen && form.syncedFor) {
+    setForm(buildEmptyForm(false));
+  }
+
+  // Fetch tokenization config when the modal opens. Returns null when IQPro
+  // isn't configured — in that case we fall back to a plain card-number
+  // input (local dev only).
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    client.payment.getTokenizationConfig({ origin: window.location.origin })
+      .then(config => setTokenizationConfig(config ?? null))
+      .catch(() => setTokenizationConfig(null));
+  }, [isOpen]);
+
+  const useIframe = !!tokenizationConfig && form.paymentMethod === 'card';
+
+  const {
+    isLoaded: iframeLoaded,
+    isValid: iframeValid,
+    isCvvValid: iframeCvvValid,
+    error: iframeError,
+    tokenize: iframeTokenize,
+  } = useTokenExIframe({
+    containerId: TOKENEX_CONTAINER_ID,
+    cvvContainerId: TOKENEX_CVV_CONTAINER_ID,
+    config: useIframe ? tokenizationConfig : null,
+    theme: resolvedTheme === 'dark' ? 'dark' : 'light',
+  });
+
+  const isCardFormValid = form.paymentMethod === 'card'
+    && form.cardholderName.trim().length > 0
+    && form.cardExpiry.trim().length > 0
+    && (useIframe ? iframeValid && iframeCvvValid : true);
+
+  const isAchFormValid = form.paymentMethod === 'ach'
+    && form.achAccountHolder.trim().length > 0
+    && form.achRoutingNumber.trim().length > 0
+    && form.achAccountNumber.trim().length > 0;
+
+  const isFormValid = isCardFormValid || isAchFormValid;
+
+  const handleSubmit = useCallback(async () => {
+    setIsSaving(true);
+    setForm(prev => ({ ...prev, error: null }));
+
+    try {
+      let cardToken: string | undefined;
+      let cardFirstSix: string | undefined;
+      let cardLastFour: string | undefined;
+
+      if (form.paymentMethod === 'card' && useIframe) {
+        const result = await iframeTokenize();
+        cardToken = result.token;
+        cardFirstSix = result.firstSix;
+        cardLastFour = result.lastFour;
+      }
+
+      const response = await client.payment.registerPaymentMethod({
+        memberId,
+        memberEmail,
+        memberFirstName,
+        memberLastName,
+        ...(memberPhone && { memberPhone }),
+        paymentMethod: form.paymentMethod,
+        ...(form.paymentMethod === 'card' && {
+          cardholderName: form.cardholderName,
+          cardExpiry: form.cardExpiry,
+          ...(cardToken && { cardToken }),
+          ...(cardFirstSix && { cardFirstSix }),
+          ...(cardLastFour && { cardLastFour }),
+        }),
+        ...(form.paymentMethod === 'ach' && {
+          achAccountHolder: form.achAccountHolder,
+          achRoutingNumber: form.achRoutingNumber,
+          achAccountNumber: form.achAccountNumber,
+          achAccountType: form.achAccountType,
+        }),
+      });
+
+      if (!response.success) {
+        setForm(prev => ({ ...prev, error: response.error || tEdit('save_error') }));
+        return;
+      }
+
+      if (onSavedAction) {
+        onSavedAction();
+      }
+      onCloseAction();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : tEdit('save_error');
+      setForm(prev => ({ ...prev, error: message }));
+    } finally {
+      setIsSaving(false);
+    }
+  }, [
+    form,
+    useIframe,
+    iframeTokenize,
+    memberId,
+    memberEmail,
+    memberFirstName,
+    memberLastName,
+    memberPhone,
+    onSavedAction,
+    onCloseAction,
+    tEdit,
+  ]);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={open => !open && onCloseAction()}>
+      <DialogContent className="max-h-[calc(100dvh-2rem)] max-w-md overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{tEdit('title')}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* Payment method tabs */}
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={() => setForm(prev => ({ ...prev, paymentMethod: 'card' }))}
+              disabled={isSaving}
+              className={`flex flex-1 items-center justify-center gap-2 rounded-lg border-2 px-4 py-3 transition-all ${
+                form.paymentMethod === 'card'
+                  ? 'border-primary bg-primary/5'
+                  : 'border-border bg-background hover:border-primary/50 hover:bg-accent/50'
+              } ${isSaving ? 'cursor-not-allowed opacity-50' : ''}`}
+            >
+              <CreditCard className="h-5 w-5" />
+              <span className="font-medium">{t('card_tab_label')}</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => setForm(prev => ({ ...prev, paymentMethod: 'ach' }))}
+              disabled={isSaving}
+              className={`flex flex-1 items-center justify-center gap-2 rounded-lg border-2 px-4 py-3 transition-all ${
+                form.paymentMethod === 'ach'
+                  ? 'border-primary bg-primary/5'
+                  : 'border-border bg-background hover:border-primary/50 hover:bg-accent/50'
+              } ${isSaving ? 'cursor-not-allowed opacity-50' : ''}`}
+            >
+              <Landmark className="h-5 w-5" />
+              <span className="font-medium">{t('ach_tab_label')}</span>
+            </button>
+          </div>
+
+          {form.paymentMethod === 'card' && (
+            <div className="space-y-3">
+              <div>
+                <label htmlFor="edit-pm-cardholder" className="block text-sm font-medium">
+                  {t('cardholder_name_label')}
+                </label>
+                <Input
+                  id="edit-pm-cardholder"
+                  value={form.cardholderName}
+                  onChange={e => setForm(prev => ({ ...prev, cardholderName: e.target.value }))}
+                  placeholder={t('cardholder_name_placeholder')}
+                  disabled={isSaving}
+                  className="mt-1"
+                />
+              </div>
+
+              <div>
+                <label htmlFor={useIframe ? TOKENEX_CONTAINER_ID : 'edit-pm-cardnumber'} className="block text-sm font-medium">
+                  {t('card_number_label')}
+                </label>
+                {useIframe
+                  ? (
+                      <div>
+                        {!iframeLoaded && !iframeError && (
+                          <div className="flex items-center gap-2 py-2 text-sm text-muted-foreground">
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                            {t('card_number_iframe_loading')}
+                          </div>
+                        )}
+                        {iframeError && (
+                          <p className="text-xs text-destructive">{t('card_number_iframe_error')}</p>
+                        )}
+                        <div
+                          id={TOKENEX_CONTAINER_ID}
+                          className={`mt-1 h-9 w-full overflow-hidden rounded-md border border-neutral-600 bg-neutral-100 shadow-xs dark:bg-input/30 [&_iframe]:border-none ${
+                            isSaving ? 'pointer-events-none opacity-50' : ''
+                          } ${!iframeLoaded && !iframeError ? 'hidden' : ''}`}
+                        />
+                      </div>
+                    )
+                  : (
+                      <p className="mt-1 text-xs text-muted-foreground">{tEdit('card_iframe_unavailable')}</p>
+                    )}
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label htmlFor="edit-pm-expiry" className="block text-sm font-medium">
+                    {t('card_expiry_label')}
+                  </label>
+                  <Input
+                    id="edit-pm-expiry"
+                    value={form.cardExpiry}
+                    onChange={e => setForm(prev => ({ ...prev, cardExpiry: e.target.value }))}
+                    placeholder={t('card_expiry_placeholder')}
+                    disabled={isSaving}
+                    className="mt-1"
+                  />
+                </div>
+                <div>
+                  <label htmlFor={useIframe ? TOKENEX_CVV_CONTAINER_ID : 'edit-pm-cvc'} className="block text-sm font-medium">
+                    {t('card_cvc_label')}
+                  </label>
+                  {useIframe
+                    ? (
+                        <div
+                          id={TOKENEX_CVV_CONTAINER_ID}
+                          className={`mt-1 h-9 w-full overflow-hidden rounded-md border border-neutral-600 bg-neutral-100 shadow-xs dark:bg-input/30 [&_iframe]:border-none ${
+                            isSaving ? 'pointer-events-none opacity-50' : ''
+                          } ${!iframeLoaded && !iframeError ? 'hidden' : ''}`}
+                        />
+                      )
+                    : (
+                        <p className="mt-1 text-xs text-muted-foreground">{tEdit('card_iframe_unavailable')}</p>
+                      )}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {form.paymentMethod === 'ach' && (
+            <div className="space-y-3">
+              <div>
+                <label htmlFor="edit-pm-ach-holder" className="block text-sm font-medium">
+                  {t('ach_account_holder_label')}
+                </label>
+                <Input
+                  id="edit-pm-ach-holder"
+                  value={form.achAccountHolder}
+                  onChange={e => setForm(prev => ({ ...prev, achAccountHolder: e.target.value }))}
+                  placeholder={t('ach_account_holder_placeholder')}
+                  disabled={isSaving}
+                  className="mt-1"
+                />
+              </div>
+              <div>
+                <label htmlFor="edit-pm-ach-type" className="block text-sm font-medium">
+                  {t('ach_account_type_label')}
+                </label>
+                <Select
+                  value={form.achAccountType}
+                  onValueChange={value => setForm(prev => ({ ...prev, achAccountType: value as 'Checking' | 'Savings' }))}
+                  disabled={isSaving}
+                >
+                  <SelectTrigger id="edit-pm-ach-type" className="mt-1">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="Checking">{t('ach_account_type_checking')}</SelectItem>
+                    <SelectItem value="Savings">{t('ach_account_type_savings')}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <label htmlFor="edit-pm-ach-routing" className="block text-sm font-medium">
+                  {t('ach_routing_number_label')}
+                </label>
+                <Input
+                  id="edit-pm-ach-routing"
+                  value={form.achRoutingNumber}
+                  onChange={e => setForm(prev => ({ ...prev, achRoutingNumber: e.target.value }))}
+                  placeholder={t('ach_routing_number_placeholder')}
+                  disabled={isSaving}
+                  className="mt-1"
+                />
+              </div>
+              <div>
+                <label htmlFor="edit-pm-ach-account" className="block text-sm font-medium">
+                  {t('ach_account_number_label')}
+                </label>
+                <Input
+                  id="edit-pm-ach-account"
+                  value={form.achAccountNumber}
+                  onChange={e => setForm(prev => ({ ...prev, achAccountNumber: e.target.value }))}
+                  placeholder={t('ach_account_number_placeholder')}
+                  disabled={isSaving}
+                  className="mt-1"
+                />
+              </div>
+            </div>
+          )}
+
+          {form.error && (
+            <p className="text-sm text-destructive">{form.error}</p>
+          )}
+
+          <div className="flex justify-end gap-3 pt-2">
+            <Button variant="outline" onClick={onCloseAction} disabled={isSaving}>
+              {tEdit('cancel_button')}
+            </Button>
+            <Button onClick={handleSubmit} disabled={!isFormValid || isSaving}>
+              {isSaving
+                ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      {tEdit('saving_button')}
+                    </>
+                  )
+                : tEdit('save_button')}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/members/wizard/AddFamilyMembersModal.tsx
+++ b/src/features/members/wizard/AddFamilyMembersModal.tsx
@@ -64,6 +64,11 @@ export const AddFamilyMembersModal = ({
   const cardFirstSixRef = useRef<string | undefined>(undefined);
   const cardLastFourRef = useRef<string | undefined>(undefined);
 
+  // Tracks the just-created family member's id between member.create and the
+  // payment call. On payment decline + cancel, this is what we pass to
+  // client.member.removeFully to roll back the half-finished signup (#132).
+  const createdMemberIdRef = useRef<string | undefined>(undefined);
+
   // Re-entrancy guard for handleFamilyMemberSubmit — see AddMemberModal for rationale.
   const submittingRef = useRef(false);
 
@@ -102,9 +107,22 @@ export const AddFamilyMembersModal = ({
   };
 
   const handleCancel = () => {
+    // #132 — if the in-progress family member was created earlier in the
+    // flow and the user is now bailing after a payment decline, roll back.
+    // Already-completed family members (in wizard.completedMembers) are
+    // left alone — those payments succeeded.
+    const memberIdToRollBack = createdMemberIdRef.current;
+    if (memberIdToRollBack && wizard.data.paymentStatus === 'declined') {
+      void client.member.removeFully({ id: memberIdToRollBack }).catch((err) => {
+        if (process.env.NODE_ENV === 'development') {
+          console.warn('[AddFamilyMembers] Rollback failed:', err);
+        }
+      });
+    }
     cardTokenRef.current = undefined;
     cardFirstSixRef.current = undefined;
     cardLastFourRef.current = undefined;
+    createdMemberIdRef.current = undefined;
     submittingRef.current = false;
     wizard.reset();
     onCloseAction();
@@ -117,6 +135,7 @@ export const AddFamilyMembersModal = ({
     cardTokenRef.current = undefined;
     cardFirstSixRef.current = undefined;
     cardLastFourRef.current = undefined;
+    createdMemberIdRef.current = undefined;
     submittingRef.current = false;
     wizard.reset();
     onCloseAction();
@@ -127,6 +146,7 @@ export const AddFamilyMembersModal = ({
     cardTokenRef.current = undefined;
     cardFirstSixRef.current = undefined;
     cardLastFourRef.current = undefined;
+    createdMemberIdRef.current = undefined;
     submittingRef.current = false;
     wizard.resetForNextMember();
     setPaymentStepKey(prev => prev + 1);
@@ -255,6 +275,9 @@ export const AddFamilyMembersModal = ({
           },
         }),
       });
+      // Track the new member's id so handleCancel can roll back the whole
+      // signup chain if the user bails after a payment decline (#132).
+      createdMemberIdRef.current = result.id;
 
       // 2. Create signed waiver if applicable
       if (

--- a/src/features/members/wizard/AddMemberModal.tsx
+++ b/src/features/members/wizard/AddMemberModal.tsx
@@ -57,6 +57,13 @@ export const AddMemberModal = ({ isOpen, onCloseAction, availableCoupons = [] }:
   const cardFirstSixRef = useRef<string | undefined>(undefined);
   const cardLastFourRef = useRef<string | undefined>(undefined);
 
+  // Tracks the just-created member's id between member.create and the payment
+  // call. On payment decline + cancel, this is what we pass to
+  // client.member.removeFully to roll back the half-finished signup (#132).
+  // We use a ref (not state) because handleCancel needs to read it
+  // synchronously after a chain of async setStates.
+  const createdMemberIdRef = useRef<string | undefined>(undefined);
+
   // Re-entrancy guard: flips synchronously on click to drop duplicate submissions
   // that fire before React flushes the disabled-button state.
   const submittingRef = useRef(false);
@@ -95,9 +102,23 @@ export const AddMemberModal = ({ isOpen, onCloseAction, availableCoupons = [] }:
   }, [isOpen]);
 
   const handleCancel = () => {
+    // #132 — if a member was created earlier in the flow and the user is now
+    // bailing (e.g. cancelled after payment decline), roll back the whole
+    // chain. Fire-and-forget; we don't block the dialog close on the network
+    // call. The endpoint is idempotent enough — if the rollback fails, the
+    // operator can hard-delete from the dashboard later.
+    const memberIdToRollBack = createdMemberIdRef.current;
+    if (memberIdToRollBack && wizard.data.paymentStatus === 'declined') {
+      void client.member.removeFully({ id: memberIdToRollBack }).catch((err) => {
+        if (process.env.NODE_ENV === 'development') {
+          console.warn('[Add Member Wizard] Rollback failed:', err);
+        }
+      });
+    }
     cardTokenRef.current = undefined;
     cardFirstSixRef.current = undefined;
     cardLastFourRef.current = undefined;
+    createdMemberIdRef.current = undefined;
     submittingRef.current = false;
     wizard.reset();
     onCloseAction();
@@ -111,6 +132,7 @@ export const AddMemberModal = ({ isOpen, onCloseAction, availableCoupons = [] }:
     cardTokenRef.current = undefined;
     cardFirstSixRef.current = undefined;
     cardLastFourRef.current = undefined;
+    createdMemberIdRef.current = undefined;
     submittingRef.current = false;
     wizard.reset();
     onCloseAction();
@@ -279,6 +301,9 @@ export const AddMemberModal = ({ isOpen, onCloseAction, availableCoupons = [] }:
       });
 
       const result = await client.member.create(createPayload);
+      // Track the new member's id so handleCancel can roll back the whole
+      // signup chain if the user bails after a payment decline (#132).
+      createdMemberIdRef.current = result.id;
       console.info('[Add Member Wizard] Member created successfully:', {
         timestamp: new Date().toISOString(),
         result,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2097,5 +2097,13 @@
       "membership_added": "Membership: {planName}",
       "done_button": "Done"
     }
+  },
+  "EditPaymentMethodModal": {
+    "title": "Edit payment method",
+    "save_button": "Save",
+    "saving_button": "Saving...",
+    "cancel_button": "Cancel",
+    "save_error": "Failed to save payment method. Please try again.",
+    "card_iframe_unavailable": "Card tokenization is not available in this environment."
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -2102,5 +2102,13 @@
       "membership_added": "Adhésion : {planName}",
       "done_button": "Terminé"
     }
+  },
+  "EditPaymentMethodModal": {
+    "title": "Modifier le mode de paiement",
+    "save_button": "Enregistrer",
+    "saving_button": "Enregistrement...",
+    "cancel_button": "Annuler",
+    "save_error": "Échec de l'enregistrement du mode de paiement. Veuillez réessayer.",
+    "card_iframe_unavailable": "La tokenisation de carte n'est pas disponible dans cet environnement."
   }
 }

--- a/src/routers/Member.ts
+++ b/src/routers/Member.ts
@@ -5,12 +5,12 @@ import { z } from 'zod';
 import { logger } from '@/libs/Logger';
 import { audit } from '@/services/AuditService';
 import { sendMemberConfirmationEmail } from '@/services/EmailService';
-import { addMemberMembership, changeMemberMembership, createMember, getAllMembershipPlans, getFamilyMembers, getHeadOfHouseholdMembers, getHOHForFamilyMember, getMemberPaymentMethods, getMembershipPlans, getMemberTransactions, linkFamilyMember, unlinkFamilyMember, updateMember, updateMemberContactInfo, updateMemberPhoto, updateMemberStatus } from '@/services/MembersService';
+import { addMemberMembership, changeMemberMembership, createMember, getAllMembershipPlans, getFamilyMembers, getHeadOfHouseholdMembers, getHOHForFamilyMember, getMemberPaymentMethods, getMembershipPlans, getMemberTransactions, linkFamilyMember, removeFully, unlinkFamilyMember, updateMember, updateMemberContactInfo, updateMemberPhoto, updateMemberStatus } from '@/services/MembersService';
 import { generatePdfFilename } from '@/services/WaiverPdfService';
 import { generateWaiverPdfBuffer } from '@/services/WaiverPdfService.server';
 import { AUDIT_ACTION, AUDIT_ENTITY_TYPE } from '@/types/Audit';
 import { ORG_ROLE } from '@/types/Auth';
-import { DeleteMemberValidation, EditMemberValidation, GetHOHForMemberValidation, GetHOHPaymentMethodsValidation, LinkFamilyMemberValidation, ListFamilyMembersValidation, MemberPaymentMethodsValidation, MemberTransactionsValidation, MemberValidation, SearchHOHValidation, SendConfirmationEmailValidation, UnlinkFamilyMemberValidation, UpdateMemberContactInfoValidation, UpdateMemberPhotoValidation, UpdateMemberTypeValidation } from '@/validations/MemberValidation';
+import { DeleteMemberValidation, EditMemberValidation, GetHOHForMemberValidation, GetHOHPaymentMethodsValidation, LinkFamilyMemberValidation, ListFamilyMembersValidation, MemberPaymentMethodsValidation, MemberTransactionsValidation, MemberValidation, RemoveFullyMemberValidation, SearchHOHValidation, SendConfirmationEmailValidation, UnlinkFamilyMemberValidation, UpdateMemberContactInfoValidation, UpdateMemberPhotoValidation, UpdateMemberTypeValidation } from '@/validations/MemberValidation';
 import { guardAuth, guardRole } from './AuthGuards';
 
 export const create = os
@@ -159,6 +159,54 @@ export const remove = os
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
 
       // Audit the failure
+      await audit(context, AUDIT_ACTION.MEMBER_REMOVE, AUDIT_ENTITY_TYPE.MEMBER, {
+        entityId: input.id,
+        status: 'failure',
+        error: errorMessage,
+      });
+
+      throw error;
+    }
+  });
+
+/**
+ * Hard-delete a member and every row that references them.
+ *
+ * Use case: payment-declined rollback in the Add Member wizard (#132). The
+ * operator chose "Cancel & Roll Back" instead of "Add Anyway" after a card
+ * decline. Unlike `remove` (which soft-archives and preserves history), this
+ * leaves no trace.
+ *
+ * Guarded by FRONT_DESK rather than ACADEMY_OWNER because this is part of
+ * the member-creation undo flow that any front-desk staff can trigger. The
+ * service-layer `removeFully` enforces org scope (no cross-tenant access).
+ */
+export const removeFullyMember = os
+  .input(RemoveFullyMemberValidation)
+  .handler(async ({ input }) => {
+    const context = await guardRole(ORG_ROLE.FRONT_DESK);
+
+    try {
+      const result = await removeFully(input.id, context.orgId);
+
+      if (!result.deleted) {
+        throw new ORPCError('Member not found', { status: 404 });
+      }
+
+      logger.info(`[Member.removeFully] Member rolled back`, {
+        memberId: input.id,
+        rowsRemoved: result.rowsRemoved,
+      });
+
+      await audit(context, AUDIT_ACTION.MEMBER_REMOVE, AUDIT_ENTITY_TYPE.MEMBER, {
+        entityId: input.id,
+        status: 'success',
+      });
+
+      return { rowsRemoved: result.rowsRemoved };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
       await audit(context, AUDIT_ACTION.MEMBER_REMOVE, AUDIT_ENTITY_TYPE.MEMBER, {
         entityId: input.id,
         status: 'failure',

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -21,7 +21,7 @@ import { tags as classTags, create as createClass, list as listClasses, remove a
 import { create as createCoupon, listActive as listActiveCoupons, list as listCoupons, remove as removeCoupon, update as updateCoupon } from './Coupons';
 import { earningsChart, financialStats, memberAverageChart, membershipStats } from './Dashboard';
 import { create as createEvent, list as listEvents, remove as removeEvent, update as updateEvent } from './Events';
-import { addMembership, changeMembership, create as createMember, getHOHForMember, getHOHPaymentMethods, linkFamily, listAllMembershipPlans, listFamily, listMembershipPlans, listMemberTransactions, listPaymentMethods, remove as removeMember, restore as restoreMember, searchHOH, sendConfirmationEmail, unlinkFamily, updateLastAccessed, update as updateMember, updateContactInfo as updateMemberContactInfo, updatePhoto as updateMemberPhoto, updateMemberType } from './Member';
+import { addMembership, changeMembership, create as createMember, getHOHForMember, getHOHPaymentMethods, linkFamily, listAllMembershipPlans, listFamily, listMembershipPlans, listMemberTransactions, listPaymentMethods, removeFullyMember, remove as removeMember, restore as restoreMember, searchHOH, sendConfirmationEmail, unlinkFamily, updateLastAccessed, update as updateMember, updateContactInfo as updateMemberContactInfo, updatePhoto as updateMemberPhoto, updateMemberType } from './Member';
 import { list as listMembers } from './Members';
 import { create as createMembershipPlan, remove as removeMembershipPlan, update as updateMembershipPlan } from './MembershipPlans';
 import { create as createNoteHandler, list as listNotes, remove as removeNoteHandler, update as updateNoteHandler } from './Notes';
@@ -71,6 +71,7 @@ export const router = {
     listPaymentMethods,
     listMemberTransactions,
     remove: removeMember,
+    removeFully: removeFullyMember,
     restore: restoreMember,
     updateLastAccessed,
     searchHOH,

--- a/src/services/MembersService.ts
+++ b/src/services/MembersService.ts
@@ -1,8 +1,8 @@
 import type { TransactionData } from '@/services/TransactionsService';
 import { randomUUID } from 'node:crypto';
-import { and, desc, eq, inArray } from 'drizzle-orm';
+import { and, desc, eq, inArray, or } from 'drizzle-orm';
 import { db } from '@/libs/DB';
-import { addressSchema, familyMemberSchema, memberMembershipSchema, memberSchema, membershipPlanSchema, paymentMethodSchema, transactionSchema } from '@/models/Schema';
+import { addressSchema, attendanceSchema, classEnrollmentSchema, couponUsageSchema, eventRegistrationSchema, familyMemberSchema, memberMembershipSchema, memberSchema, membershipPlanSchema, noteSchema, paymentMethodSchema, signedWaiverSchema, transactionSchema } from '@/models/Schema';
 
 export type MembershipPlanData = {
   id: string;
@@ -732,4 +732,134 @@ export async function getHOHForFamilyMember(familyMemberId: string): Promise<HOH
     .limit(1);
 
   return result[0] ?? null;
+}
+
+export type RemoveFullyResult = {
+  deleted: boolean;
+  rowsRemoved: {
+    signedWaiver: number;
+    paymentMethod: number;
+    transaction: number;
+    couponUsage: number;
+    classEnrollment: number;
+    eventRegistration: number;
+    attendance: number;
+    note: number;
+    memberMembership: number;
+    address: number;
+    familyMember: number;
+  };
+};
+
+/**
+ * Hard-delete a member and every row that references them, in FK-safe order,
+ * inside a single DB transaction.
+ *
+ * Use case: payment-declined rollback in the Add Member wizard (#132). The
+ * member was just created seconds ago; the operator chose "Cancel & Roll
+ * Back" instead of "Add Anyway". Unlike `softDeleteMember` (which sets
+ * status='archived' and preserves history), this leaves no trace — the
+ * member's whole signup-aftermath chain is gone.
+ *
+ * Scoped to the org for safety: returns `{ deleted: false }` if the member
+ * doesn't exist or doesn't belong to the org. Callers should check the
+ * return value to surface "member not found" errors distinctly from
+ * "permission denied".
+ */
+export async function removeFully(
+  memberId: string,
+  organizationId: string,
+): Promise<RemoveFullyResult> {
+  const existing = await db
+    .select({ id: memberSchema.id })
+    .from(memberSchema)
+    .where(and(
+      eq(memberSchema.id, memberId),
+      eq(memberSchema.organizationId, organizationId),
+    ))
+    .limit(1);
+  if (existing.length === 0) {
+    return {
+      deleted: false,
+      rowsRemoved: {
+        signedWaiver: 0,
+        paymentMethod: 0,
+        transaction: 0,
+        couponUsage: 0,
+        classEnrollment: 0,
+        eventRegistration: 0,
+        attendance: 0,
+        note: 0,
+        memberMembership: 0,
+        address: 0,
+        familyMember: 0,
+      },
+    };
+  }
+
+  return await db.transaction(async (tx) => {
+    // Delete in FK dependency order. Tables that reference member_membership
+    // (signed_waiver, transaction) come before member_membership. Tables that
+    // reference member directly come next. Member row is last.
+    const sw = await tx.delete(signedWaiverSchema)
+      .where(eq(signedWaiverSchema.memberId, memberId))
+      .returning({ id: signedWaiverSchema.id });
+    const pm = await tx.delete(paymentMethodSchema)
+      .where(eq(paymentMethodSchema.memberId, memberId))
+      .returning({ id: paymentMethodSchema.id });
+    const tr = await tx.delete(transactionSchema)
+      .where(eq(transactionSchema.memberId, memberId))
+      .returning({ id: transactionSchema.id });
+    const cu = await tx.delete(couponUsageSchema)
+      .where(eq(couponUsageSchema.memberId, memberId))
+      .returning({ id: couponUsageSchema.id });
+    const ce = await tx.delete(classEnrollmentSchema)
+      .where(eq(classEnrollmentSchema.memberId, memberId))
+      .returning({ id: classEnrollmentSchema.id });
+    const er = await tx.delete(eventRegistrationSchema)
+      .where(eq(eventRegistrationSchema.memberId, memberId))
+      .returning({ id: eventRegistrationSchema.id });
+    const at = await tx.delete(attendanceSchema)
+      .where(eq(attendanceSchema.memberId, memberId))
+      .returning({ id: attendanceSchema.id });
+    const no = await tx.delete(noteSchema)
+      .where(eq(noteSchema.memberId, memberId))
+      .returning({ id: noteSchema.id });
+    const mm = await tx.delete(memberMembershipSchema)
+      .where(eq(memberMembershipSchema.memberId, memberId))
+      .returning({ id: memberMembershipSchema.id });
+    const ad = await tx.delete(addressSchema)
+      .where(eq(addressSchema.memberId, memberId))
+      .returning({ id: addressSchema.id });
+    // family_member has TWO FKs to member (memberId + relatedMemberId); both
+    // must be cleaned up so we don't leave dangling references.
+    const fm = await tx.delete(familyMemberSchema)
+      .where(or(
+        eq(familyMemberSchema.memberId, memberId),
+        eq(familyMemberSchema.relatedMemberId, memberId),
+      ))
+      .returning({ memberId: familyMemberSchema.memberId });
+    await tx.delete(memberSchema)
+      .where(and(
+        eq(memberSchema.id, memberId),
+        eq(memberSchema.organizationId, organizationId),
+      ));
+
+    return {
+      deleted: true,
+      rowsRemoved: {
+        signedWaiver: sw.length,
+        paymentMethod: pm.length,
+        transaction: tr.length,
+        couponUsage: cu.length,
+        classEnrollment: ce.length,
+        eventRegistration: er.length,
+        attendance: at.length,
+        note: no.length,
+        memberMembership: mm.length,
+        address: ad.length,
+        familyMember: fm.length,
+      },
+    };
+  });
 }

--- a/src/validations/MemberValidation.test.ts
+++ b/src/validations/MemberValidation.test.ts
@@ -9,6 +9,7 @@ import {
   MemberPaymentMethodsValidation,
   MemberTransactionsValidation,
   MemberValidation,
+  RemoveFullyMemberValidation,
   SearchHOHValidation,
   SendConfirmationEmailValidation,
   UnlinkFamilyMemberValidation,
@@ -167,6 +168,26 @@ describe('MemberValidation', () => {
       const invalidData = {};
 
       const result = DeleteMemberValidation.safeParse(invalidData);
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('RemoveFullyMemberValidation schema', () => {
+    it('accepts a non-empty id', () => {
+      const result = RemoveFullyMemberValidation.safeParse({ id: 'member-123' });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an empty id', () => {
+      const result = RemoveFullyMemberValidation.safeParse({ id: '' });
+
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects when id is missing', () => {
+      const result = RemoveFullyMemberValidation.safeParse({});
 
       expect(result.success).toBe(false);
     });

--- a/src/validations/MemberValidation.ts
+++ b/src/validations/MemberValidation.ts
@@ -32,6 +32,10 @@ export const DeleteMemberValidation = z.object({
   id: z.string(),
 });
 
+export const RemoveFullyMemberValidation = z.object({
+  id: z.string().min(1),
+});
+
 export const UpdateMemberContactInfoValidation = z.object({
   id: z.string(),
   email: z.string().email(),


### PR DESCRIPTION
## Summary

Five distinct payment-flow bugs filed by QA, all in the same area but with different root causes. This PR addresses each surgically: rollback on declined-signup-cancel, a new Edit Payment Method modal on the member detail page, mirroring webhook membership status onto the member record, and fixing the iframe mount race in the SaaS subscription dialog.

## Closes

Closes #132
Closes #134
Closes #137
Closes #138
Closes #160

## What changed

- **#132 — Membership added w/card decline.** The Add Member wizard creates the member *before* charging. On decline, "Add Anyway" still works as before — but if the operator now cancels the dialog after a decline, the half-finished signup is rolled back via a new `client.member.removeFully` endpoint that hard-deletes the member's whole signup chain (signed_waiver → payment_method → transaction → coupon_usage → enrollments → registrations → attendance → notes → member_membership → address → family_member → member) inside a single DB transaction. Same wiring in `AddFamilyMembersModal`.
- **#134 + #137 — Can't add/change payment info / does not save.** Built `EditPaymentMethodModal` and wired Edit / Add Payment Method buttons on the member detail page. Card flow uses TokenEx iframe (same pattern as PaymentStep); ACH flow goes through server-side tokenization. On save, calls the existing `client.payment.registerPaymentMethod` endpoint and refetches the displayed last-4.
- **#138 — No past-due status after payment declined.** The IQPro webhook handlers (`subscription.payment_failed` / `payment_succeeded` / `cancelled`) now mirror the membership-status change onto `memberSchema.status`. Past-due flips happen only when the member is in `active` / `trial` / `past_due`, leaving operator-finalised states (`archived` / `cancelled` / `hold`) untouched. Cancellation only flips the member if no other active membership remains.
- **#160 — Can't fill Card number field in subscriptions.** `useTokenExIframe` was firing its mount effect before the container `<div>` rendered (the div only appears after a plan is selected). Fixed by passing `config: null` to the hook until both the container is in the DOM and the tokenization config has loaded — same pattern used by PaymentStep. Also pre-loads the config when the dialog opens, so by the time a plan is picked the iframe mounts without a visible delay.

## Test plan

- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run check:types` — clean
- [x] `npm run check:deps` — no unused exports
- [x] `npm run check:i18n` — no missing/invalid/unused/undefined keys
- [x] `npm run test` — 4288/4288 passing (226 files), including 3 new validation tests + 6 new EditPaymentMethodModal tests
- [ ] Manual smoke (local PGLite + IQPro env vars):
  - Add Member with a paid plan, force a decline, click X → verify member, member_membership, signed_waiver, address rows are all gone (sql query)
  - Add Member with a paid plan, force a decline, click "Add Member Anyway" → member persists with `status='active'` (existing behaviour, not regressed)
  - On a member detail page with no payment method, click "Add" → modal opens → enter ACH → save → confirm `payment_method` row created and the UI shows the new last-4
  - On a member detail page with an existing payment method, click "Edit" → modal opens → save with new card → confirm last-4 updates
  - Trigger an IQPro `subscription.payment_failed` webhook against a test member's subscription → confirm the member's `status` flips to `past_due`
  - Trigger `subscription.payment_succeeded` → confirm `past_due` flips back to `active` (but `archived` / `hold` are left alone)
  - Open `/dashboard/subscription` as an unsubscribed org → click a plan → the card-number field accepts input on first try (no need to click in/out)