### PR TITLE
fix(all): general cleanup

### DIFF
--- a/src/features/classes/MonthlyView.tsx
+++ b/src/features/classes/MonthlyView.tsx
@@ -6,6 +6,7 @@ import { Plus } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { ButtonGroupItem, ButtonGroupRoot } from '@/components/ui/button-group';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useClassesCache } from '@/hooks/useClassesCache';
 import { useEventsCache } from '@/hooks/useEventsCache';
@@ -253,6 +254,9 @@ export function MonthlyView({ withFilters }: MonthlyViewProps = {}) {
                                 classId={event.classId}
                                 className={event.className}
                                 color={event.color}
+                                hour={event.hour}
+                                minute={event.minute}
+                                duration={event.duration}
                                 exception={event.exception}
                                 sourceView="monthly"
                                 isEvent={event.isEvent}
@@ -262,11 +266,45 @@ export function MonthlyView({ withFilters }: MonthlyViewProps = {}) {
                               </ClassEventHoverCard>
                             ))}
                             {(monthlyEvents[day.toString()]?.length ?? 0) > 3 && (
-                              <div className="text-xs text-muted-foreground">
-                                +
-                                {monthlyEvents[day.toString()]!.length - 3}
-                                {' more'}
-                              </div>
+                              <Popover>
+                                <PopoverTrigger asChild>
+                                  <button
+                                    type="button"
+                                    className="text-left text-xs text-muted-foreground hover:text-foreground hover:underline"
+                                    aria-label={`Show all ${monthlyEvents[day.toString()]!.length} events for ${monthName} ${day}`}
+                                  >
+                                    +
+                                    {monthlyEvents[day.toString()]!.length - 3}
+                                    {' more'}
+                                  </button>
+                                </PopoverTrigger>
+                                <PopoverContent align="start" className="w-72 p-2">
+                                  <div className="mb-2 text-sm font-semibold text-foreground">
+                                    {monthName}
+                                    {' '}
+                                    {day}
+                                  </div>
+                                  <div className="flex flex-col gap-1">
+                                    {monthlyEvents[day.toString()]!.map(event => (
+                                      <ClassEventHoverCard
+                                        key={`expanded-${event.classId}-${event.hour}-${event.minute}`}
+                                        classId={event.classId}
+                                        className={event.className}
+                                        color={event.color}
+                                        hour={event.hour}
+                                        minute={event.minute}
+                                        duration={event.duration}
+                                        exception={event.exception}
+                                        sourceView="monthly"
+                                        isEvent={event.isEvent}
+                                        eventId={event.eventId}
+                                      >
+                                        <span className="truncate">{event.className}</span>
+                                      </ClassEventHoverCard>
+                                    ))}
+                                  </div>
+                                </PopoverContent>
+                              </Popover>
                             )}
                           </div>
                         </>

--- a/src/features/members/conversion/ConvertConfirmStep.test.tsx
+++ b/src/features/members/conversion/ConvertConfirmStep.test.tsx
@@ -1,7 +1,7 @@
 import type { ConvertMemberWizardData } from '@/hooks/useConvertMemberWizard';
-import { page } from '@vitest/browser/context';
 import { describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
+import { page } from 'vitest/browser';
 import { I18nWrapper } from '@/lib/test-utils';
 import { ConvertConfirmStep } from './ConvertConfirmStep';
 

--- a/src/features/members/conversion/ConvertSuccessStep.test.tsx
+++ b/src/features/members/conversion/ConvertSuccessStep.test.tsx
@@ -1,7 +1,7 @@
 import type { ConvertMemberWizardData } from '@/hooks/useConvertMemberWizard';
-import { page } from '@vitest/browser/context';
 import { describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
+import { page } from 'vitest/browser';
 import { I18nWrapper } from '@/lib/test-utils';
 import { ConvertSuccessStep } from './ConvertSuccessStep';
 

--- a/src/features/members/wizard/MemberDetailsStep.test.tsx
+++ b/src/features/members/wizard/MemberDetailsStep.test.tsx
@@ -31,6 +31,7 @@ const translationKeys: Record<string, string> = {
   country_placeholder: 'United States',
   date_of_birth_label: 'Date of Birth',
   date_of_birth_placeholder: 'Select date of birth',
+  date_of_birth_picker_aria: 'Pick date of birth',
   back_button: 'Back',
   cancel_button: 'Cancel',
   next_button: 'Next',
@@ -325,5 +326,50 @@ describe('MemberDetailsStep', () => {
     await userEvent.click(nextButton);
 
     expect(mockHandlers.onNext).toHaveBeenCalled();
+  });
+
+  // #128 — replaced the native <input type="date"> with a Shadcn Popover +
+  // Calendar to fix macOS year-scroller momentum behavior. Verify the new
+  // trigger renders with the placeholder when no DOB is set, and shows the
+  // formatted date when one is set.
+  describe('Date of Birth picker (#128)', () => {
+    it('renders the picker trigger with the placeholder when no DOB is set', () => {
+      render(
+        <MemberDetailsStep
+          data={mockData}
+          onUpdate={mockHandlers.onUpdate}
+          onNext={mockHandlers.onNext}
+          onBack={mockHandlers.onBack}
+          onCancel={mockHandlers.onCancel}
+        />,
+      );
+
+      // Picker trigger is now a button with our aria-label.
+      expect(page.getByLabelText('Pick date of birth')).toBeTruthy();
+      // Native <input type="date"> should no longer exist.
+      expect(document.querySelector('input[type="date"]')).toBeNull();
+    });
+
+    it('shows the formatted date on the trigger when DOB is set', () => {
+      const dataWithDob: AddMemberWizardData = {
+        ...mockData,
+        dateOfBirth: new Date('1990-06-15T00:00:00'),
+      };
+
+      render(
+        <MemberDetailsStep
+          data={dataWithDob}
+          onUpdate={mockHandlers.onUpdate}
+          onNext={mockHandlers.onNext}
+          onBack={mockHandlers.onBack}
+          onCancel={mockHandlers.onCancel}
+        />,
+      );
+
+      const trigger = page.getByLabelText('Pick date of birth').element() as HTMLButtonElement;
+
+      // toLocaleDateString formatting includes the year.
+      expect(trigger.textContent).toContain('1990');
+    });
   });
 });

--- a/src/features/members/wizard/MemberDetailsStep.tsx
+++ b/src/features/members/wizard/MemberDetailsStep.tsx
@@ -1,10 +1,13 @@
 'use client';
 
 import type { AddMemberWizardData } from '@/hooks/useAddMemberWizard';
+import { CalendarIcon } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
 import { Input } from '@/components/ui/input';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
   Select,
   SelectContent,
@@ -163,14 +166,44 @@ export const MemberDetailsStep = ({ data, onUpdate, onNext, onBack, onCancel, er
 
         <div className="space-y-1.5">
           <label className="text-sm font-medium text-foreground">{t('date_of_birth_label')}</label>
-          <Input
-            type="date"
-            placeholder={t('date_of_birth_placeholder')}
-            value={data.dateOfBirth ? data.dateOfBirth.toISOString().split('T')[0] : ''}
-            onChange={e => onUpdate({ dateOfBirth: e.target.value ? new Date(e.target.value) : undefined })}
-            onBlur={() => handleInputBlur('dateOfBirth')}
-            error={isDateOfBirthInvalid}
-          />
+          {/*
+            #128 — replaces the native <input type="date"> whose macOS year
+            scroller had a confusing momentum/snap-back behavior. Shadcn
+            Calendar uses Radix Select for month/year dropdowns and a
+            standard click-grid for days, so navigation is predictable.
+          */}
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                onBlur={() => handleInputBlur('dateOfBirth')}
+                aria-invalid={isDateOfBirthInvalid}
+                aria-label={t('date_of_birth_picker_aria')}
+                className={`w-full justify-start font-normal ${data.dateOfBirth ? 'text-foreground' : 'text-muted-foreground'}`}
+              >
+                <CalendarIcon className="mr-2 h-4 w-4 text-muted-foreground" />
+                {data.dateOfBirth
+                  ? data.dateOfBirth.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+                  : t('date_of_birth_placeholder')}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="start" className="w-auto p-0">
+              <Calendar
+                mode="single"
+                selected={data.dateOfBirth}
+                onSelect={(date) => {
+                  if (date) {
+                    onUpdate({ dateOfBirth: date });
+                  }
+                }}
+                captionLayout="dropdown"
+                startMonth={new Date(new Date().getFullYear() - 100, 0)}
+                endMonth={new Date()}
+                defaultMonth={data.dateOfBirth ?? new Date(new Date().getFullYear() - 30, 0)}
+              />
+            </PopoverContent>
+          </Popover>
           {isDateOfBirthInvalid && (
             <p className="text-xs text-destructive">Please enter a date of birth.</p>
           )}

--- a/src/features/members/wizard/WaiverStep.test.tsx
+++ b/src/features/members/wizard/WaiverStep.test.tsx
@@ -26,6 +26,7 @@ const translationKeys: Record<string, string> = {
   back_button: 'Back',
   cancel_button: 'Cancel',
   continue_button: 'Continue',
+  continue_without_signing_button: 'Continue without signing',
   signature_required_error: 'Please provide your signature',
   name_required_error: 'Please enter your full name',
   agreement_required_error: 'You must agree to the waiver terms',
@@ -180,7 +181,7 @@ describe('WaiverStep', () => {
         page.getByText('No waiver is required for the selected membership plan. Click Continue to proceed.'),
       ).toBeInTheDocument();
       expect(page.getByRole('button', { name: 'Back' })).toBeTruthy();
-      expect(page.getByRole('button', { name: 'Continue' })).toBeTruthy();
+      expect(page.getByRole('button', { name: 'Continue', exact: true })).toBeTruthy();
 
       // It should NOT auto-advance
       expect(mockHandlers.onNext).not.toHaveBeenCalled();
@@ -246,7 +247,7 @@ describe('WaiverStep', () => {
         page.getByText('No waiver is required for the selected membership plan. Click Continue to proceed.'),
       ).toBeInTheDocument();
 
-      const continueButton = page.getByRole('button', { name: 'Continue' });
+      const continueButton = page.getByRole('button', { name: 'Continue', exact: true });
       await userEvent.click(continueButton);
 
       await vi.waitFor(() => {
@@ -374,7 +375,7 @@ describe('WaiverStep', () => {
 
       expect(page.getByRole('button', { name: 'Back' })).toBeTruthy();
       expect(page.getByRole('button', { name: 'Cancel' })).toBeTruthy();
-      expect(page.getByRole('button', { name: 'Continue' })).toBeTruthy();
+      expect(page.getByRole('button', { name: 'Continue', exact: true })).toBeTruthy();
     });
 
     it('should update waiver template ID when waiver is loaded', async () => {
@@ -561,7 +562,7 @@ describe('WaiverStep', () => {
       await userEvent.type(nameInput, 'John Doe');
 
       // Click Continue without signing
-      const continueButton = page.getByRole('button', { name: 'Continue' });
+      const continueButton = page.getByRole('button', { name: 'Continue', exact: true });
       await userEvent.click(continueButton);
 
       await expect.element(page.getByText('Please provide your signature')).toBeInTheDocument();
@@ -581,7 +582,7 @@ describe('WaiverStep', () => {
       await expect.element(page.getByText('Sign Waiver')).toBeInTheDocument();
 
       // Click Continue without entering name
-      const continueButton = page.getByRole('button', { name: 'Continue' });
+      const continueButton = page.getByRole('button', { name: 'Continue', exact: true });
       await userEvent.click(continueButton);
 
       await expect.element(page.getByText('Please enter your full name')).toBeInTheDocument();
@@ -601,7 +602,7 @@ describe('WaiverStep', () => {
       await expect.element(page.getByText('Sign Waiver')).toBeInTheDocument();
 
       // Click Continue without checking the agreement
-      const continueButton = page.getByRole('button', { name: 'Continue' });
+      const continueButton = page.getByRole('button', { name: 'Continue', exact: true });
       await userEvent.click(continueButton);
 
       await expect.element(page.getByText('You must agree to the waiver terms')).toBeInTheDocument();
@@ -621,7 +622,7 @@ describe('WaiverStep', () => {
       await expect.element(page.getByText('Sign Waiver')).toBeInTheDocument();
 
       // Click Continue to trigger errors
-      const continueButton = page.getByRole('button', { name: 'Continue' });
+      const continueButton = page.getByRole('button', { name: 'Continue', exact: true });
       await userEvent.click(continueButton);
 
       await expect.element(page.getByText('Please enter your full name')).toBeInTheDocument();
@@ -648,7 +649,7 @@ describe('WaiverStep', () => {
 
       await expect.element(page.getByText('Sign Waiver')).toBeInTheDocument();
 
-      const continueButton = page.getByRole('button', { name: 'Continue' });
+      const continueButton = page.getByRole('button', { name: 'Continue', exact: true });
       await userEvent.click(continueButton);
 
       // onNext should NOT be called when there are validation errors
@@ -687,7 +688,7 @@ describe('WaiverStep', () => {
       await userEvent.click(checkbox);
 
       // Click Continue
-      const continueButton = page.getByRole('button', { name: 'Continue' });
+      const continueButton = page.getByRole('button', { name: 'Continue', exact: true });
       await userEvent.click(continueButton);
 
       await vi.waitFor(() => {
@@ -842,6 +843,103 @@ describe('WaiverStep', () => {
       await new Promise(resolve => setTimeout(resolve, 50));
 
       expect(mockGetWaiversForMembership).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // #143: when resolvePlaceholders returns empty content (e.g. an org with
+  // no merge fields configured against a placeholder-using template), the
+  // user used to see an empty box with no escape. The fallback shows raw
+  // template content; the new "Continue without signing" button on the
+  // rendered-waiver path is a separate escape hatch.
+  describe('Resolve-failure fallback + escape hatch (#143)', () => {
+    it('falls back to raw template content when resolvePlaceholders returns empty', async () => {
+      mockResolvePlaceholders.mockResolvedValueOnce({ resolvedContent: '' });
+      render(
+        <WaiverStep
+          data={mockData}
+          onUpdate={mockHandlers.onUpdate}
+          onNext={mockHandlers.onNext}
+          onBack={mockHandlers.onBack}
+          onCancel={mockHandlers.onCancel}
+        />,
+      );
+
+      // Wait for the waiver fetch + resolve to complete and the box to render.
+      await vi.waitFor(() => {
+        expect(page.getByText(mockWaiver.content)).toBeTruthy();
+      });
+    });
+
+    it('falls back to raw template content when resolvePlaceholders throws', async () => {
+      mockResolvePlaceholders.mockRejectedValueOnce(new Error('resolver exploded'));
+      render(
+        <WaiverStep
+          data={mockData}
+          onUpdate={mockHandlers.onUpdate}
+          onNext={mockHandlers.onNext}
+          onBack={mockHandlers.onBack}
+          onCancel={mockHandlers.onCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(page.getByText(mockWaiver.content)).toBeTruthy();
+      });
+    });
+
+    it('renders a "Continue without signing" button on the rendered-waiver path', async () => {
+      render(
+        <WaiverStep
+          data={mockData}
+          onUpdate={mockHandlers.onUpdate}
+          onNext={mockHandlers.onNext}
+          onBack={mockHandlers.onBack}
+          onCancel={mockHandlers.onCancel}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        const skipBtn = Array.from(document.querySelectorAll('button'))
+          .find(b => b.textContent?.includes('Continue without signing'));
+
+        expect(skipBtn).toBeTruthy();
+      });
+    });
+
+    it('clicking "Continue without signing" calls onUpdate with waiverSkipped:true and onNext', async () => {
+      const onUpdate = vi.fn();
+      const onNext = vi.fn();
+      render(
+        <WaiverStep
+          data={mockData}
+          onUpdate={onUpdate}
+          onNext={onNext}
+          onBack={mockHandlers.onBack}
+          onCancel={mockHandlers.onCancel}
+        />,
+      );
+
+      // Wait for the waiver fetch to settle and the skip button to render.
+      let skipBtn: HTMLButtonElement | undefined;
+      await vi.waitFor(() => {
+        skipBtn = Array.from(document.querySelectorAll('button'))
+          .find(b => b.textContent?.includes('Continue without signing')) as HTMLButtonElement | undefined;
+
+        expect(skipBtn).toBeTruthy();
+      });
+
+      await userEvent.click(skipBtn!);
+
+      // handleContinueWithoutWaiver clears signature/name/relationship and sets
+      // waiverSkipped: true, then awaits onNext.
+      await vi.waitFor(() => {
+        expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({
+          waiverTemplateId: null,
+          waiverSkipped: true,
+        }));
+      });
+
+      expect(onNext).toHaveBeenCalled();
     });
   });
 });

--- a/src/features/members/wizard/WaiverStep.tsx
+++ b/src/features/members/wizard/WaiverStep.tsx
@@ -104,10 +104,21 @@ export function WaiverStep({
           const selectedWaiver = activeWaivers[0]!;
           setWaiver(selectedWaiver);
 
-          const resolved = await client.waivers.resolvePlaceholders({
-            templateId: selectedWaiver.id,
-          });
-          setResolvedContent(resolved.resolvedContent);
+          // Resolve merge-field placeholders (e.g. <academy>). If the resolve
+          // call fails OR returns empty content (e.g. an org with no merge
+          // fields configured against a template that uses them), fall back
+          // to the raw template text so the user always sees something
+          // signable instead of an empty box (#143).
+          let resolvedText = '';
+          try {
+            const resolved = await client.waivers.resolvePlaceholders({
+              templateId: selectedWaiver.id,
+            });
+            resolvedText = resolved.resolvedContent;
+          } catch (resolveError) {
+            console.warn('[WaiverStep] Failed to resolve placeholders, falling back to raw template:', resolveError);
+          }
+          setResolvedContent(resolvedText.trim() ? resolvedText : selectedWaiver.content);
 
           onUpdateRef.current({ waiverTemplateId: selectedWaiver.id });
         } else {
@@ -342,9 +353,19 @@ export function WaiverStep({
             {t('cancel_button')}
           </Button>
         </div>
-        <Button onClick={handleNext} disabled={isLoading}>
-          {isLoading ? `${t('continue_button')}...` : t('continue_button')}
-        </Button>
+        <div className="flex gap-3">
+          {/* Escape hatch (#143): if the waiver content didn't render or
+              the user wants to sign later, let them advance without signing.
+              The membership is still created; the waiver row simply isn't
+              created and `waiverSkipped: true` is stored so the operator
+              knows to follow up. */}
+          <Button variant="outline" onClick={handleContinueWithoutWaiver} disabled={isLoading}>
+            {t('continue_without_signing_button')}
+          </Button>
+          <Button onClick={handleNext} disabled={isLoading}>
+            {isLoading ? `${t('continue_button')}...` : t('continue_button')}
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -362,6 +362,7 @@
       "country_placeholder": "United States",
       "date_of_birth_label": "Date of Birth",
       "date_of_birth_placeholder": "Select date of birth",
+      "date_of_birth_picker_aria": "Pick date of birth",
       "back_button": "Back",
       "cancel_button": "Cancel",
       "next_button": "Next"
@@ -1319,6 +1320,7 @@
     "back_button": "Back",
     "cancel_button": "Cancel",
     "continue_button": "Continue",
+    "continue_without_signing_button": "Continue without signing",
     "signature_required_error": "Please provide your signature",
     "name_required_error": "Please enter your full name",
     "agreement_required_error": "You must agree to the waiver terms",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -362,6 +362,7 @@
       "country_placeholder": "États-Unis",
       "date_of_birth_label": "Date de naissance",
       "date_of_birth_placeholder": "Sélectionner la date de naissance",
+      "date_of_birth_picker_aria": "Choisir la date de naissance",
       "back_button": "Retour",
       "cancel_button": "Annuler",
       "next_button": "Suivant"
@@ -1323,6 +1324,7 @@
     "back_button": "Retour",
     "cancel_button": "Annuler",
     "continue_button": "Continuer",
+    "continue_without_signing_button": "Continuer sans signer",
     "signature_required_error": "Veuillez fournir votre signature",
     "name_required_error": "Veuillez entrer votre nom complet",
     "agreement_required_error": "Vous devez accepter les termes de la décharge",

--- a/tests/e2e/add-member-wizard.e2e.ts
+++ b/tests/e2e/add-member-wizard.e2e.ts
@@ -98,15 +98,21 @@ async function fillDetailsStep(page: Page): Promise<MemberDetails> {
   await page.getByPlaceholder('you@example.com').fill(email);
   await page.getByPlaceholder('(555) 123-4567').fill(phone);
 
-  // Date of birth — use an adult date
-  await page.locator('input[type="date"]').fill('1990-01-15');
+  const dialog = page.getByRole('dialog');
+
+  // Date of birth — opens the Shadcn Popover + Calendar (#128 fix replaced
+  // the native <input type="date">). We don't need a specific date for the
+  // wizard flow tests; just pick any visible enabled day in the default
+  // month (which the component sets to ~30 years ago — well into adult).
+  await page.getByLabel('Pick date of birth').click();
+  // Calendar opens in a portaled popover; click the first day cell button.
+  await page.getByRole('gridcell').getByRole('button').first().click();
 
   // Address fields
   await page.getByPlaceholder('123 Main St').fill('100 Test Ave');
   await page.getByPlaceholder('San Francisco').fill('Testville');
 
   // State select — click the state trigger within the dialog, then pick CA
-  const dialog = page.getByRole('dialog');
   await dialog.locator('[data-slot="select-trigger"]').first().click();
   await page.getByRole('option', { name: 'CA', exact: true }).click();
 


### PR DESCRIPTION
## Summary

Three small unrelated UX/UI bugs in the QA backlog, bundled into one polish PR. Each fix is contained to one file in its respective feature area: a defensive escape hatch on the waiver step so users are never trapped, hour/minute/duration props threaded into the monthly calendar's event hover-card plus an interactive "+N more" popover, and a Shadcn Calendar popover replacing the native `<input type="date">` for the date-of-birth field whose macOS year scroller had confusing momentum behavior.

## Closes

Closes #143
Closes #145
Closes #128

## What changed

- **#143 — Waiver not populating during family-member→individual conversion.** [`WaiverStep.tsx`](src/features/members/wizard/WaiverStep.tsx) now wraps `resolvePlaceholders` in try/catch and falls back to the raw `template.content` when the resolve call returns empty/whitespace or throws — the user always sees something signable instead of an empty box. Separately, a "Continue without signing" button now appears on the rendered-waiver path (alongside the existing Continue button) so the operator can advance and follow up later, matching the reporter's stated expected behavior. Both improvements apply to all three flows that mount `WaiverStep` (`AddMemberModal`, `AddFamilyMembersModal`, `ConvertMemberModal`) without per-flow wiring.
- **#145 — Show class times on hover in Monthly view.** [`MonthlyView.tsx`](src/features/classes/MonthlyView.tsx) now passes `hour` / `minute` / `duration` to `ClassEventHoverCard` (those props already had render logic in the hover card; they were just dead in the monthly grid). The "+N more" indicator is now a Shadcn Popover trigger; clicking it opens a card listing every event for that day, each row reusing `ClassEventHoverCard` so the per-event hover-time still works inside the popover.
- **#128 — Date of Birth scroll feels weird.** [`MemberDetailsStep.tsx`](src/features/members/wizard/MemberDetailsStep.tsx) replaces the native `<input type="date">` with a Shadcn Popover containing the existing `Calendar` component (`captionLayout="dropdown"`, bounded to a 100-year window via `startMonth` / `endMonth`). The dropdown month/year navigation goes through Radix Select with standard scroll behavior — no momentum, no snap-back.
- **i18n:** new `WaiverStep.continue_without_signing_button` and `AddMemberWizard.MemberDetailsStep.date_of_birth_picker_aria` keys, mirrored in `fr.json`.

## Test plan

- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run check:types` — clean
- [x] `npm run check:deps` — no unused exports
- [x] `npm run check:i18n` — no missing/invalid/unused/undefined keys
- [x] `npm run test` — 4298/4298 passing (226 files), including 4 new WaiverStep tests + 2 new MemberDetailsStep tests
- [ ] Manual smoke (local PGLite):
  - Add Member → Details step → click DOB field → calendar popover opens → year/month dropdowns scroll normally (no momentum/snap-back) → pick a date → form continues
  - Add Member → pick Kids Monthly plan → advance to waiver step → confirm content renders OR (if it doesn't) "Continue without signing" is visible and works
  - Convert family-member to individual (Kids program) → waiver step → reproduces the reporter's flow; confirm escape hatch works (closes #143's actual symptom)
  - Classes → Monthly view → hover a class block → tooltip shows class times (start, end, duration) → on a busy day click "+N more" → popover opens listing every event with times
  - Dark mode: all popovers and hover cards readable