### PR TITLE
feat(roles): adjusted roles crud with clerk api

### DIFF
--- a/src/features/roles/AddEditRoleModal.tsx
+++ b/src/features/roles/AddEditRoleModal.tsx
@@ -39,6 +39,7 @@ type AddEditRoleModalProps = {
   availablePermissions: Permission[];
   isLoading?: boolean;
   canEditSystemRoles?: boolean;
+  errorMessage?: string | null;
 };
 
 const initialFormData: RoleFormData = {
@@ -311,6 +312,7 @@ export function AddEditRoleModal({
   availablePermissions,
   isLoading = false,
   canEditSystemRoles = false,
+  errorMessage,
 }: AddEditRoleModalProps) {
   const t = useTranslations('AddEditRoleModal');
   const isEditMode = !!role?.id;
@@ -333,6 +335,12 @@ export function AddEditRoleModal({
             {isEditMode ? t('edit_title') : t('add_title')}
           </DialogTitle>
         </DialogHeader>
+
+        {errorMessage && (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive" data-testid="role-save-error">
+            {errorMessage}
+          </div>
+        )}
 
         {isOpen && (
           <AddEditRoleForm

--- a/src/features/roles/DeleteRoleAlertDialog.test.tsx
+++ b/src/features/roles/DeleteRoleAlertDialog.test.tsx
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { page, userEvent } from 'vitest/browser';
+import { DeleteRoleAlertDialog } from './DeleteRoleAlertDialog';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, vars?: Record<string, unknown>) => {
+    const map: Record<string, string> = {
+      delete_dialog_title: 'Delete Role',
+      delete_dialog_description: `Delete "${vars?.roleName ?? ''}"?`,
+      delete_cancel_button: 'Cancel',
+      delete_confirm_button: 'Delete Role',
+    };
+    return map[key] || key;
+  },
+}));
+
+describe('DeleteRoleAlertDialog', () => {
+  it('renders the role name in the description', () => {
+    render(
+      <DeleteRoleAlertDialog
+        isOpen
+        roleName="Front Desk"
+        onCloseAction={() => {}}
+        onConfirmAction={() => {}}
+      />,
+    );
+
+    expect(page.getByText('Delete "Front Desk"?')).toBeDefined();
+  });
+
+  it('calls onConfirmAction when delete is clicked', async () => {
+    const onConfirm = vi.fn();
+    render(
+      <DeleteRoleAlertDialog
+        isOpen
+        roleName="Coach"
+        onCloseAction={() => {}}
+        onConfirmAction={onConfirm}
+      />,
+    );
+
+    await userEvent.click(page.getByTestId('role-delete-confirm'));
+
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('calls onCloseAction when cancel is clicked', async () => {
+    const onClose = vi.fn();
+    render(
+      <DeleteRoleAlertDialog
+        isOpen
+        roleName="Coach"
+        onCloseAction={onClose}
+        onConfirmAction={() => {}}
+      />,
+    );
+
+    await userEvent.click(page.getByRole('button', { name: 'Cancel' }));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('renders the error banner when errorMessage is provided', () => {
+    render(
+      <DeleteRoleAlertDialog
+        isOpen
+        roleName="Coach"
+        onCloseAction={() => {}}
+        onConfirmAction={() => {}}
+        errorMessage="Role still has members"
+      />,
+    );
+
+    const banner = page.getByTestId('role-delete-error');
+
+    expect(banner).toBeDefined();
+    expect(page.getByText('Role still has members')).toBeDefined();
+  });
+
+  it('does not render when isOpen is false', () => {
+    render(
+      <DeleteRoleAlertDialog
+        isOpen={false}
+        roleName="Coach"
+        onCloseAction={() => {}}
+        onConfirmAction={() => {}}
+      />,
+    );
+
+    const titles = page.getByText('Delete Role').elements();
+
+    expect(titles.length).toBe(0);
+  });
+});

--- a/src/features/roles/DeleteRoleAlertDialog.tsx
+++ b/src/features/roles/DeleteRoleAlertDialog.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { useCallback } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+type DeleteRoleAlertDialogProps = {
+  isOpen: boolean;
+  roleName: string;
+  onCloseAction: () => void;
+  onConfirmAction: () => void;
+  errorMessage?: string | null;
+};
+
+export function DeleteRoleAlertDialog({
+  isOpen,
+  roleName,
+  onCloseAction,
+  onConfirmAction,
+  errorMessage,
+}: DeleteRoleAlertDialogProps) {
+  const t = useTranslations('Roles');
+
+  const handleOpenChange = useCallback((open: boolean) => {
+    if (!open) {
+      onCloseAction();
+    }
+  }, [onCloseAction]);
+
+  const handleConfirm = useCallback(() => {
+    onConfirmAction();
+  }, [onConfirmAction]);
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={handleOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t('delete_dialog_title')}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {t('delete_dialog_description', { roleName })}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        {errorMessage && (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive" data-testid="role-delete-error">
+            {errorMessage}
+          </div>
+        )}
+        <AlertDialogFooter>
+          <AlertDialogCancel>{t('delete_cancel_button')}</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-white hover:bg-destructive/90"
+            onClick={handleConfirm}
+            data-testid="role-delete-confirm"
+          >
+            {t('delete_confirm_button')}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/features/roles/RolesPage.test.tsx
+++ b/src/features/roles/RolesPage.test.tsx
@@ -3,6 +3,20 @@ import { render } from 'vitest-browser-react';
 import { page } from 'vitest/browser';
 import { RolesPageClient } from './RolesPageClient';
 
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock('@/libs/Orpc', () => ({
+  client: {
+    roles: {
+      create: vi.fn(),
+      update: vi.fn(),
+      remove: vi.fn(),
+    },
+  },
+}));
+
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string) => {
     const translations: Record<string, string> = {

--- a/src/features/roles/RolesPageClient.test.tsx
+++ b/src/features/roles/RolesPageClient.test.tsx
@@ -1,11 +1,30 @@
 import type { Role } from './RolesPageClient';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { page, userEvent } from 'vitest/browser';
 import { RolesPageClient } from './RolesPageClient';
 
+const mockRefresh = vi.fn();
+const mockCreate = vi.fn();
+const mockUpdate = vi.fn();
+const mockRemove = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: mockRefresh }),
+}));
+
+vi.mock('@/libs/Orpc', () => ({
+  client: {
+    roles: {
+      create: (...args: unknown[]) => mockCreate(...args),
+      update: (...args: unknown[]) => mockUpdate(...args),
+      remove: (...args: unknown[]) => mockRemove(...args),
+    },
+  },
+}));
+
 vi.mock('next-intl', () => ({
-  useTranslations: () => (key: string) => {
+  useTranslations: () => (key: string, vars?: Record<string, unknown>) => {
     const translations: Record<string, string> = {
       title: 'Roles',
       total_roles_label: 'Total Roles',
@@ -23,12 +42,28 @@ vi.mock('next-intl', () => ({
       member_plural: 'Members',
       edit_button_aria_label: 'Edit role',
       delete_button_aria_label: 'Delete role',
+      delete_dialog_title: 'Delete Role',
+      delete_dialog_description: `Are you sure you want to delete the role "${vars?.roleName ?? ''}"?`,
+      delete_cancel_button: 'Cancel',
+      delete_confirm_button: 'Delete Role',
+      save_error: 'Failed to save role.',
+      delete_error: 'Failed to delete role.',
     };
     return translations[key] || key;
   },
 }));
 
 describe('RolesPageClient', () => {
+  beforeEach(() => {
+    mockRefresh.mockReset();
+    mockCreate.mockReset();
+    mockUpdate.mockReset();
+    mockRemove.mockReset();
+    mockCreate.mockResolvedValue({ role: { id: 'role-new' } });
+    mockUpdate.mockResolvedValue({ role: { id: 'role-1' } });
+    mockRemove.mockResolvedValue({ success: true });
+  });
+
   const mockPermissions = [
     { id: 'perm-1', key: 'org:manage_members', name: 'Manage Members', description: 'Can manage member data' },
     { id: 'perm-2', key: 'org:manage_billing', name: 'Manage Billing', description: 'Can manage billing' },
@@ -432,22 +467,85 @@ describe('RolesPageClient', () => {
   });
 
   describe('Delete Role', () => {
-    it('should log delete request when delete button is clicked', async () => {
-      const consoleSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    it('opens the confirmation dialog with the role name when delete is clicked', async () => {
       render(<RolesPageClient {...defaultProps} />);
 
-      // Find and click a delete button (Coach role - non-system, non-admin)
       const deleteButtons = page.getByRole('button', { name: /delete role/i }).elements();
       await userEvent.click(deleteButtons[0]!);
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        '[Roles] Delete role requested:',
-        expect.objectContaining({
-          roleId: expect.any(String),
-        }),
-      );
+      // First non-system role visible to non-admin is Coach
+      expect(page.getByRole('alertdialog')).toBeDefined();
+      expect(page.getByText(/Are you sure you want to delete the role "Coach"/)).toBeDefined();
+    });
 
-      consoleSpy.mockRestore();
+    it('calls client.roles.remove and refreshes when confirmed', async () => {
+      render(<RolesPageClient {...defaultProps} />);
+
+      const deleteButtons = page.getByRole('button', { name: /delete role/i }).elements();
+      await userEvent.click(deleteButtons[0]!);
+
+      const confirmButton = page.getByTestId('role-delete-confirm');
+      await userEvent.click(confirmButton);
+
+      expect(mockRemove).toHaveBeenCalledWith({ id: 'role-2' });
+      expect(mockRefresh).toHaveBeenCalled();
+    });
+
+    it('surfaces the error message when remove rejects', async () => {
+      mockRemove.mockRejectedValueOnce(new Error('Clerk API error: 422 - role assigned to members'));
+      render(<RolesPageClient {...defaultProps} />);
+
+      const deleteButtons = page.getByRole('button', { name: /delete role/i }).elements();
+      await userEvent.click(deleteButtons[0]!);
+
+      const confirmButton = page.getByTestId('role-delete-confirm');
+      await userEvent.click(confirmButton);
+
+      const errorBanner = page.getByTestId('role-delete-error');
+
+      expect(errorBanner).toBeDefined();
+      expect(mockRefresh).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Save Role (Create / Update)', () => {
+    it('calls client.roles.create with permission keys and refreshes', async () => {
+      render(<RolesPageClient {...adminProps} />);
+
+      await userEvent.click(page.getByTestId('add-role-button'));
+      await userEvent.fill(page.getByTestId('role-name-input'), 'Front Desk');
+      await userEvent.fill(page.getByTestId('role-description-input'), 'Day-to-day');
+
+      // Submit: form generates the key from the name in AddEditRoleModal.
+      const saveButton = page.getByTestId('role-save-button');
+      await userEvent.click(saveButton);
+
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
+        name: 'Front Desk',
+        key: 'org:front_desk',
+        description: 'Day-to-day',
+        permissions: [],
+      }));
+      expect(mockRefresh).toHaveBeenCalled();
+    });
+
+    it('calls client.roles.update with id + present fields when editing', async () => {
+      render(<RolesPageClient {...adminProps} />);
+
+      // Edit Coach (the first non-system, non-admin role visible to admin).
+      const editButtons = page.getByRole('button', { name: /edit role/i }).elements();
+      // For admin, role 0 is Admin (system, but edit is gated on canEditSystemRoles).
+      // To avoid relying on system-role edit, click index 1 (Coach).
+      await userEvent.click(editButtons[1]!);
+
+      const saveButton = page.getByTestId('role-save-button');
+      await userEvent.click(saveButton);
+
+      expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'role-2',
+        name: 'Coach',
+      }));
+      expect(mockRefresh).toHaveBeenCalled();
     });
   });
 });

--- a/src/features/roles/RolesPageClient.tsx
+++ b/src/features/roles/RolesPageClient.tsx
@@ -4,11 +4,14 @@ import type { RoleFormData } from './AddEditRoleModal';
 import type { RolesFilters } from './RolesFilterBar';
 import { Plus } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
 import { useCallback, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { client } from '@/libs/Orpc';
 import { RoleCard } from '@/templates/RoleCard';
 import { StatsCards } from '@/templates/StatsCards';
 import { AddEditRoleModal } from './AddEditRoleModal';
+import { DeleteRoleAlertDialog } from './DeleteRoleAlertDialog';
 import { RolesFilterBar } from './RolesFilterBar';
 
 type Permission = {
@@ -40,6 +43,7 @@ const ADMIN_ROLE_KEY = 'org:admin';
 
 export function RolesPageClient({ roles, totalPermissions, availablePermissions, currentUserRole }: RolesPageClientProps) {
   const t = useTranslations('Roles');
+  const router = useRouter();
   const [filters, setFilters] = useState<RolesFilters>({
     search: '',
     permission: 'all',
@@ -47,6 +51,9 @@ export function RolesPageClient({ roles, totalPermissions, availablePermissions,
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingRole, setEditingRole] = useState<RoleFormData | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [deletingRole, setDeletingRole] = useState<{ id: string; name: string } | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   // Check if current user is an admin (can delete any non-admin role)
   const isAdmin = currentUserRole === ADMIN_ROLE_KEY;
@@ -84,6 +91,7 @@ export function RolesPageClient({ roles, totalPermissions, availablePermissions,
   // Handler for opening the Add Role modal
   const handleAddRoleClick = useCallback(() => {
     setEditingRole(null);
+    setSaveError(null);
     setIsModalOpen(true);
   }, []);
 
@@ -99,6 +107,7 @@ export function RolesPageClient({ roles, totalPermissions, availablePermissions,
         permissions: roleToEdit.permissions,
         isSystemRole: roleToEdit.isSystemRole,
       });
+      setSaveError(null);
       setIsModalOpen(true);
     }
   }, [roles]);
@@ -107,39 +116,70 @@ export function RolesPageClient({ roles, totalPermissions, availablePermissions,
   const handleModalClose = useCallback(() => {
     setIsModalOpen(false);
     setEditingRole(null);
+    setSaveError(null);
   }, []);
 
   // Handler for saving role (add or edit)
   const handleSaveRole = useCallback(async (data: RoleFormData) => {
     setIsLoading(true);
+    setSaveError(null);
     try {
-      // TODO: Implement actual API call to Clerk to create/update role
-      // For now, just log the data and close the modal
-      console.info('[Roles] Saving role:', {
-        timestamp: new Date().toISOString(),
-        isEdit: !!data.id,
-        data,
-      });
-
-      // Simulate API call delay
-      await new Promise(resolve => setTimeout(resolve, 500));
-
+      // Clerk's BAPI for /organization_roles expects permission IDs (perm_xxx),
+      // not permission keys — sending keys yields 404 "Organization permission not found".
+      const permissionIds = data.permissions.map(p => p.id);
+      if (data.id) {
+        await client.roles.update({
+          id: data.id,
+          name: data.name,
+          description: data.description,
+          permissions: permissionIds,
+        });
+      } else {
+        await client.roles.create({
+          name: data.name,
+          key: data.key,
+          description: data.description,
+          permissions: permissionIds,
+        });
+      }
+      router.refresh();
       handleModalClose();
     } catch (error) {
-      console.error('[Roles] Failed to save role:', error);
+      const message = error instanceof Error ? error.message : t('save_error');
+      setSaveError(message);
     } finally {
       setIsLoading(false);
     }
-  }, [handleModalClose]);
+  }, [handleModalClose, router, t]);
 
-  // Handler for delete role
+  // Handler for opening delete confirmation dialog
   const handleDeleteRole = useCallback((id: string) => {
-    // TODO: Implement delete confirmation dialog and API call
-    console.info('[Roles] Delete role requested:', {
-      timestamp: new Date().toISOString(),
-      roleId: id,
-    });
+    const role = roles.find(r => r.id === id);
+    if (role) {
+      setDeletingRole({ id: role.id, name: role.name });
+      setDeleteError(null);
+    }
+  }, [roles]);
+
+  const handleCloseDeleteDialog = useCallback(() => {
+    setDeletingRole(null);
+    setDeleteError(null);
   }, []);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!deletingRole) {
+      return;
+    }
+    setDeleteError(null);
+    try {
+      await client.roles.remove({ id: deletingRole.id });
+      router.refresh();
+      setDeletingRole(null);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : t('delete_error');
+      setDeleteError(message);
+    }
+  }, [deletingRole, router, t]);
 
   // Filter roles based on search and permission filter
   const filteredRoles = useMemo(() => {
@@ -241,6 +281,16 @@ export function RolesPageClient({ roles, totalPermissions, availablePermissions,
         availablePermissions={availablePermissions}
         isLoading={isLoading}
         canEditSystemRoles={isAdmin}
+        errorMessage={saveError}
+      />
+
+      {/* Delete Role Confirmation Dialog */}
+      <DeleteRoleAlertDialog
+        isOpen={deletingRole !== null}
+        roleName={deletingRole?.name ?? ''}
+        onCloseAction={handleCloseDeleteDialog}
+        onConfirmAction={handleConfirmDelete}
+        errorMessage={deleteError}
       />
     </div>
   );

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -828,7 +828,13 @@
     "access_denied_title": "Access Denied",
     "access_denied_message": "You do not have permission to view the roles list. Please sign in to an organization.",
     "error_title": "Error Loading Roles",
-    "error_message": "Failed to load roles and permissions. Please try again later."
+    "error_message": "Failed to load roles and permissions. Please try again later.",
+    "save_error": "Failed to save role. Please try again.",
+    "delete_error": "Failed to delete role. Please try again.",
+    "delete_dialog_title": "Delete Role",
+    "delete_dialog_description": "Are you sure you want to delete the role \"{roleName}\"? This action cannot be undone. Members assigned to this role will need to be reassigned.",
+    "delete_cancel_button": "Cancel",
+    "delete_confirm_button": "Delete Role"
   },
   "RoleCard": {
     "system_role_badge": "System",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -831,7 +831,13 @@
     "access_denied_title": "Accès refusé",
     "access_denied_message": "Vous n'avez pas la permission de voir la liste des rôles. Veuillez vous connecter à une organisation.",
     "error_title": "Erreur de chargement des rôles",
-    "error_message": "Impossible de charger les rôles et les permissions. Veuillez réessayer plus tard."
+    "error_message": "Impossible de charger les rôles et les permissions. Veuillez réessayer plus tard.",
+    "save_error": "Échec de l'enregistrement du rôle. Veuillez réessayer.",
+    "delete_error": "Échec de la suppression du rôle. Veuillez réessayer.",
+    "delete_dialog_title": "Supprimer le rôle",
+    "delete_dialog_description": "Êtes-vous sûr de vouloir supprimer le rôle « {roleName} » ? Cette action est irréversible. Les membres affectés à ce rôle devront être réaffectés.",
+    "delete_cancel_button": "Annuler",
+    "delete_confirm_button": "Supprimer le rôle"
   },
   "RoleCard": {
     "system_role_badge": "Système",

--- a/src/routers/Roles.test.ts
+++ b/src/routers/Roles.test.ts
@@ -1,0 +1,188 @@
+import type { AuditContext } from '@/types/Audit';
+
+import { ORPCError } from '@orpc/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AUDIT_ACTION, AUDIT_ENTITY_TYPE } from '@/types/Audit';
+import { ORG_ROLE } from '@/types/Auth';
+
+vi.mock('./AuthGuards', () => ({ guardRole: vi.fn() }));
+vi.mock('@/services/AuditService', () => ({ audit: vi.fn() }));
+vi.mock('@/services/ClerkRolesService', async () => {
+  const actual = await vi.importActual<typeof import('@/services/ClerkRolesService')>('@/services/ClerkRolesService');
+  return {
+    ...actual,
+    createOrganizationRole: vi.fn(),
+    updateOrganizationRole: vi.fn(),
+    deleteOrganizationRole: vi.fn(),
+  };
+});
+
+const adminContext: AuditContext = {
+  userId: 'user-1',
+  orgId: 'org-1',
+  role: ORG_ROLE.ADMIN,
+};
+
+function callHandler(handler: unknown, input?: unknown) {
+  const h = handler as { '~orpc': { handler: (args: Record<string, unknown>) => unknown } };
+  return h['~orpc'].handler({ input, context: undefined, errors: undefined });
+}
+
+const fakeRole = {
+  id: 'role_1',
+  key: 'org:front_desk',
+  name: 'Front Desk',
+  description: 'Day-to-day check-in.',
+  permissions: [],
+  is_creator_eligible: false,
+  created_at: 1700000000000,
+  updated_at: 1700000000000,
+};
+
+const validCreateInput = {
+  name: 'Front Desk',
+  key: 'org:front_desk',
+  description: 'Day-to-day check-in.',
+  permissions: ['org:members:read'],
+};
+
+describe('Roles Router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('create', () => {
+    it('requires the ADMIN role', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { createOrganizationRole } = await import('@/services/ClerkRolesService');
+      vi.mocked(guardRole).mockResolvedValue(adminContext);
+      vi.mocked(createOrganizationRole).mockResolvedValue(fakeRole);
+
+      const { create } = await import('./Roles');
+      await callHandler(create, validCreateInput);
+
+      expect(guardRole).toHaveBeenCalledWith(ORG_ROLE.ADMIN);
+    });
+
+    it('creates a role and emits success audit', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { createOrganizationRole } = await import('@/services/ClerkRolesService');
+      const { audit } = await import('@/services/AuditService');
+      vi.mocked(guardRole).mockResolvedValue(adminContext);
+      vi.mocked(createOrganizationRole).mockResolvedValue(fakeRole);
+
+      const { create } = await import('./Roles');
+      const result = await callHandler(create, validCreateInput);
+
+      expect(audit).toHaveBeenCalledWith(
+        adminContext,
+        AUDIT_ACTION.ROLE_CREATE,
+        AUDIT_ENTITY_TYPE.ROLE,
+        expect.objectContaining({ entityId: 'role_1', status: 'success' }),
+      );
+      expect(result).toEqual({ role: fakeRole });
+    });
+
+    it('maps Clerk 4xx to 409 Conflict', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { createOrganizationRole } = await import('@/services/ClerkRolesService');
+      vi.mocked(guardRole).mockResolvedValue(adminContext);
+      vi.mocked(createOrganizationRole).mockRejectedValue(new Error('Clerk API error: 422 - role key already exists'));
+
+      const { create } = await import('./Roles');
+
+      await expect(callHandler(create, validCreateInput)).rejects.toBeInstanceOf(ORPCError);
+    });
+
+    it('emits failure audit when service throws', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { createOrganizationRole } = await import('@/services/ClerkRolesService');
+      const { audit } = await import('@/services/AuditService');
+      vi.mocked(guardRole).mockResolvedValue(adminContext);
+      vi.mocked(createOrganizationRole).mockRejectedValue(new Error('Clerk API error: 500 - boom'));
+
+      const { create } = await import('./Roles');
+
+      await expect(callHandler(create, validCreateInput)).rejects.toBeInstanceOf(ORPCError);
+
+      expect(audit).toHaveBeenCalledWith(
+        adminContext,
+        AUDIT_ACTION.ROLE_CREATE,
+        AUDIT_ENTITY_TYPE.ROLE,
+        expect.objectContaining({ status: 'failure' }),
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('updates and returns the new role', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { updateOrganizationRole } = await import('@/services/ClerkRolesService');
+      vi.mocked(guardRole).mockResolvedValue(adminContext);
+      vi.mocked(updateOrganizationRole).mockResolvedValue({ ...fakeRole, name: 'Renamed Role' });
+
+      const { update } = await import('./Roles');
+      const result = await callHandler(update, { id: 'role_1', name: 'Renamed Role' });
+
+      expect(updateOrganizationRole).toHaveBeenCalledWith('role_1', { name: 'Renamed Role' });
+      expect(result).toEqual({ role: { ...fakeRole, name: 'Renamed Role' } });
+    });
+
+    it('only forwards fields that are present in the input', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { updateOrganizationRole } = await import('@/services/ClerkRolesService');
+      vi.mocked(guardRole).mockResolvedValue(adminContext);
+      vi.mocked(updateOrganizationRole).mockResolvedValue(fakeRole);
+
+      const { update } = await import('./Roles');
+      // Only `permissions` is set — name + description should NOT be passed
+      // through (Clerk treats omitted fields as "leave alone").
+      await callHandler(update, { id: 'role_1', permissions: ['org:foo:read'] });
+
+      expect(updateOrganizationRole).toHaveBeenCalledWith('role_1', { permissions: ['org:foo:read'] });
+    });
+
+    it('maps Clerk 4xx (e.g. system role edit attempt) to 409', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { updateOrganizationRole } = await import('@/services/ClerkRolesService');
+      vi.mocked(guardRole).mockResolvedValue(adminContext);
+      vi.mocked(updateOrganizationRole).mockRejectedValue(new Error('Clerk API error: 403 - cannot edit system role'));
+
+      const { update } = await import('./Roles');
+
+      await expect(callHandler(update, { id: 'role_admin', name: 'foo' })).rejects.toBeInstanceOf(ORPCError);
+    });
+  });
+
+  describe('remove', () => {
+    it('deletes and emits success audit', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { deleteOrganizationRole } = await import('@/services/ClerkRolesService');
+      const { audit } = await import('@/services/AuditService');
+      vi.mocked(guardRole).mockResolvedValue(adminContext);
+      vi.mocked(deleteOrganizationRole).mockResolvedValue(undefined);
+
+      const { remove } = await import('./Roles');
+      const result = await callHandler(remove, { id: 'role_1' });
+
+      expect(audit).toHaveBeenCalledWith(
+        adminContext,
+        AUDIT_ACTION.ROLE_DELETE,
+        AUDIT_ENTITY_TYPE.ROLE,
+        expect.objectContaining({ entityId: 'role_1', status: 'success' }),
+      );
+      expect(result).toEqual({ success: true });
+    });
+
+    it('maps Clerk 4xx (role still in use) to 409', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { deleteOrganizationRole } = await import('@/services/ClerkRolesService');
+      vi.mocked(guardRole).mockResolvedValue(adminContext);
+      vi.mocked(deleteOrganizationRole).mockRejectedValue(new Error('Clerk API error: 422 - role assigned to members'));
+
+      const { remove } = await import('./Roles');
+
+      await expect(callHandler(remove, { id: 'role_1' })).rejects.toBeInstanceOf(ORPCError);
+    });
+  });
+});

--- a/src/routers/Roles.ts
+++ b/src/routers/Roles.ts
@@ -1,0 +1,116 @@
+import { ORPCError, os } from '@orpc/server';
+import { audit } from '@/services/AuditService';
+import {
+  createOrganizationRole,
+  deleteOrganizationRole,
+  updateOrganizationRole,
+} from '@/services/ClerkRolesService';
+import { AUDIT_ACTION, AUDIT_ENTITY_TYPE } from '@/types/Audit';
+import { ORG_ROLE } from '@/types/Auth';
+import {
+  CreateRoleValidation,
+  DeleteRoleValidation,
+  UpdateRoleValidation,
+} from '@/validations/RolesValidation';
+import { guardRole } from './AuthGuards';
+
+/**
+ * Maps Clerk Backend API errors to ORPC errors with the right HTTP status.
+ *
+ * Clerk's API returns 4xx for: duplicate role keys, attempts to edit/delete
+ * system roles (`org:admin`, `org:member` etc.), or roles still assigned to
+ * members. We surface those as 409 Conflict so the UI can show a useful
+ * error message; everything else becomes 500.
+ */
+function mapClerkError(error: unknown): ORPCError<string, unknown> {
+  if (!(error instanceof Error)) {
+    return new ORPCError('Internal Server Error', { status: 500 });
+  }
+  const message = error.message;
+  // The service throws "Clerk API error: <status> - <body>"; sniff for 4xx.
+  const fourXxMatch = message.match(/Clerk API error: 4\d\d/);
+  if (fourXxMatch) {
+    return new ORPCError('Conflict', { status: 409, message });
+  }
+  return new ORPCError('Internal Server Error', { status: 500, message });
+}
+
+export const create = os
+  .input(CreateRoleValidation)
+  .handler(async ({ input }) => {
+    const context = await guardRole(ORG_ROLE.ADMIN);
+
+    try {
+      const role = await createOrganizationRole({
+        name: input.name,
+        key: input.key,
+        description: input.description,
+        permissions: input.permissions,
+      });
+
+      await audit(context, AUDIT_ACTION.ROLE_CREATE, AUDIT_ENTITY_TYPE.ROLE, {
+        entityId: role.id,
+        status: 'success',
+      });
+
+      return { role };
+    } catch (error) {
+      await audit(context, AUDIT_ACTION.ROLE_CREATE, AUDIT_ENTITY_TYPE.ROLE, {
+        status: 'failure',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      throw mapClerkError(error);
+    }
+  });
+
+export const update = os
+  .input(UpdateRoleValidation)
+  .handler(async ({ input }) => {
+    const context = await guardRole(ORG_ROLE.ADMIN);
+
+    try {
+      const role = await updateOrganizationRole(input.id, {
+        ...(input.name !== undefined && { name: input.name }),
+        ...(input.description !== undefined && { description: input.description }),
+        ...(input.permissions !== undefined && { permissions: input.permissions }),
+      });
+
+      await audit(context, AUDIT_ACTION.ROLE_UPDATE, AUDIT_ENTITY_TYPE.ROLE, {
+        entityId: role.id,
+        status: 'success',
+      });
+
+      return { role };
+    } catch (error) {
+      await audit(context, AUDIT_ACTION.ROLE_UPDATE, AUDIT_ENTITY_TYPE.ROLE, {
+        entityId: input.id,
+        status: 'failure',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      throw mapClerkError(error);
+    }
+  });
+
+export const remove = os
+  .input(DeleteRoleValidation)
+  .handler(async ({ input }) => {
+    const context = await guardRole(ORG_ROLE.ADMIN);
+
+    try {
+      await deleteOrganizationRole(input.id);
+
+      await audit(context, AUDIT_ACTION.ROLE_DELETE, AUDIT_ENTITY_TYPE.ROLE, {
+        entityId: input.id,
+        status: 'success',
+      });
+
+      return { success: true };
+    } catch (error) {
+      await audit(context, AUDIT_ACTION.ROLE_DELETE, AUDIT_ENTITY_TYPE.ROLE, {
+        entityId: input.id,
+        status: 'failure',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      throw mapClerkError(error);
+    }
+  });

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -28,6 +28,7 @@ import { create as createNoteHandler, list as listNotes, remove as removeNoteHan
 import { getTokenizationIframeConfig, processPayment, registerPaymentMethod } from './Payment';
 import { create as createProgram, list as listPrograms, remove as removeProgram, update as updateProgram } from './Programs';
 import { chartData as reportChartData, currentValues as reportCurrentValues, insights as reportInsights } from './Reports';
+import { create as createRole, remove as removeRole, update as updateRole } from './Roles';
 import { cancelSaasSubscription, changeSaasPlan, getCurrentPlan, getSaasBillingHistory, getSaasTokenizationConfig, subscribeToPlan } from './SaasSubscription';
 import { create as createTagHandler, listAll as listAllTags, listClassTags, listMembershipTags, remove as removeTagHandler, update as updateTagHandler } from './Tags';
 import { get as getTransaction, list as listTransactions, refund as refundTransaction } from './Transactions';
@@ -171,6 +172,11 @@ export const router = {
     categoryRemove,
     imageCreate,
     imageRemove,
+  },
+  roles: {
+    create: createRole,
+    update: updateRole,
+    remove: removeRole,
   },
   saasSubscription: {
     getCurrentPlan,

--- a/src/services/ClerkRolesService.test.ts
+++ b/src/services/ClerkRolesService.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  createOrganizationRole,
+  deleteOrganizationRole,
   getOrganizationPermission,
   getOrganizationPermissions,
   getOrganizationRole,
   getOrganizationRoles,
+  updateOrganizationRole,
 } from './ClerkRolesService';
 
 // Mock fetch globally
@@ -42,6 +45,7 @@ describe('ClerkRolesService', () => {
       expect(mockFetch).toHaveBeenCalledWith(
         'https://api.clerk.com/v1/organization_permissions?limit=100',
         {
+          method: 'GET',
           headers: {
             'Authorization': `Bearer ${TEST_SECRET_KEY}`,
             'Content-Type': 'application/json',
@@ -93,6 +97,7 @@ describe('ClerkRolesService', () => {
       expect(mockFetch).toHaveBeenCalledWith(
         'https://api.clerk.com/v1/organization_roles?limit=100',
         {
+          method: 'GET',
           headers: {
             'Authorization': `Bearer ${TEST_SECRET_KEY}`,
             'Content-Type': 'application/json',
@@ -136,6 +141,7 @@ describe('ClerkRolesService', () => {
       expect(mockFetch).toHaveBeenCalledWith(
         'https://api.clerk.com/v1/organization_roles/role-123',
         {
+          method: 'GET',
           headers: {
             'Authorization': `Bearer ${TEST_SECRET_KEY}`,
             'Content-Type': 'application/json',
@@ -153,6 +159,180 @@ describe('ClerkRolesService', () => {
       });
 
       await expect(getOrganizationRole('nonexistent')).rejects.toThrow('Clerk API error: 404 - Role not found');
+    });
+  });
+
+  describe('createOrganizationRole', () => {
+    const fakeRole = {
+      id: 'role_new',
+      key: 'org:front_desk',
+      name: 'Front Desk',
+      description: 'Day-to-day check-in.',
+      permissions: [],
+      is_creator_eligible: false,
+      created_at: 1700000000000,
+      updated_at: 1700000000000,
+    };
+
+    it('POSTs to /organization_roles with the full body', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(fakeRole),
+      });
+
+      const result = await createOrganizationRole({
+        name: 'Front Desk',
+        key: 'org:front_desk',
+        description: 'Day-to-day check-in.',
+        permissions: ['org:members:read'],
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.clerk.com/v1/organization_roles',
+        {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${TEST_SECRET_KEY}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            name: 'Front Desk',
+            key: 'org:front_desk',
+            description: 'Day-to-day check-in.',
+            permissions: ['org:members:read'],
+          }),
+        },
+      );
+      expect(result).toEqual(fakeRole);
+    });
+
+    it('throws when CLERK_SECRET_KEY is missing', async () => {
+      process.env.CLERK_SECRET_KEY = '';
+
+      await expect(createOrganizationRole({
+        name: 'x',
+        key: 'org:x',
+        description: 'x',
+        permissions: [],
+      })).rejects.toThrow('CLERK_SECRET_KEY is not configured');
+    });
+
+    it('surfaces Clerk 4xx errors with the response body', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        text: () => Promise.resolve('role key already exists'),
+      });
+
+      await expect(createOrganizationRole({
+        name: 'x',
+        key: 'org:dup',
+        description: 'x',
+        permissions: [],
+      })).rejects.toThrow('Clerk API error: 422 - role key already exists');
+    });
+  });
+
+  describe('updateOrganizationRole', () => {
+    const fakeRole = {
+      id: 'role_1',
+      key: 'org:front_desk',
+      name: 'Renamed',
+      description: 'd',
+      permissions: [],
+      is_creator_eligible: false,
+      created_at: 1,
+      updated_at: 2,
+    };
+
+    it('PATCHes only the fields that are present', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(fakeRole),
+      });
+
+      // Only `name` provided — body must NOT include description/permissions
+      // (Clerk treats omitted fields as "leave alone").
+      await updateOrganizationRole('role_1', { name: 'Renamed' });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.clerk.com/v1/organization_roles/role_1',
+        {
+          method: 'PATCH',
+          headers: {
+            'Authorization': `Bearer ${TEST_SECRET_KEY}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ name: 'Renamed' }),
+        },
+      );
+    });
+
+    it('forwards permissions as a full replacement when provided', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(fakeRole),
+      });
+
+      await updateOrganizationRole('role_1', { permissions: ['org:foo:read'] });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.clerk.com/v1/organization_roles/role_1',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ permissions: ['org:foo:read'] }),
+        }),
+      );
+    });
+
+    it('surfaces Clerk 4xx (e.g. system role edit) verbatim', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        text: () => Promise.resolve('cannot edit system role'),
+      });
+
+      await expect(updateOrganizationRole('role_admin', { name: 'x' }))
+        .rejects
+        .toThrow('Clerk API error: 403 - cannot edit system role');
+    });
+  });
+
+  describe('deleteOrganizationRole', () => {
+    it('DELETEs the role and returns void on 204', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 204,
+        text: () => Promise.resolve(''),
+      });
+
+      await expect(deleteOrganizationRole('role_1')).resolves.toBeUndefined();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.clerk.com/v1/organization_roles/role_1',
+        {
+          method: 'DELETE',
+          headers: {
+            'Authorization': `Bearer ${TEST_SECRET_KEY}`,
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+    });
+
+    it('surfaces Clerk 4xx (role still in use)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        text: () => Promise.resolve('role assigned to members'),
+      });
+
+      await expect(deleteOrganizationRole('role_1'))
+        .rejects
+        .toThrow('Clerk API error: 422 - role assigned to members');
     });
   });
 
@@ -178,6 +358,7 @@ describe('ClerkRolesService', () => {
       expect(mockFetch).toHaveBeenCalledWith(
         'https://api.clerk.com/v1/organization_permissions/perm-123',
         {
+          method: 'GET',
           headers: {
             'Authorization': `Bearer ${TEST_SECRET_KEY}`,
             'Content-Type': 'application/json',

--- a/src/services/ClerkRolesService.ts
+++ b/src/services/ClerkRolesService.ts
@@ -6,7 +6,7 @@
  */
 
 // Types matching Clerk's API response structure
-type ClerkPermission = {
+export type ClerkPermission = {
   id: string;
   key: string;
   name: string;
@@ -16,7 +16,7 @@ type ClerkPermission = {
   updated_at: number;
 };
 
-type ClerkRole = {
+export type ClerkRole = {
   id: string;
   key: string;
   name: string;
@@ -34,10 +34,19 @@ type ClerkPaginatedResponse<T> = {
 
 const CLERK_API_BASE_URL = 'https://api.clerk.com/v1';
 
+type ClerkApiRequestOptions = {
+  method?: 'GET' | 'POST' | 'PATCH' | 'DELETE';
+  body?: Record<string, unknown>;
+};
+
 /**
- * Makes an authenticated request to the Clerk Backend API
+ * Makes an authenticated request to the Clerk Backend API. Defaults to GET;
+ * pass `{ method, body }` for create/update/delete calls.
  */
-async function clerkApiRequest<T>(endpoint: string): Promise<T> {
+async function clerkApiRequest<T>(
+  endpoint: string,
+  options: ClerkApiRequestOptions = {},
+): Promise<T> {
   const secretKey = process.env.CLERK_SECRET_KEY;
 
   if (!secretKey) {
@@ -45,15 +54,22 @@ async function clerkApiRequest<T>(endpoint: string): Promise<T> {
   }
 
   const response = await fetch(`${CLERK_API_BASE_URL}${endpoint}`, {
+    method: options.method ?? 'GET',
     headers: {
       'Authorization': `Bearer ${secretKey}`,
       'Content-Type': 'application/json',
     },
+    ...(options.body && { body: JSON.stringify(options.body) }),
   });
 
   if (!response.ok) {
     const errorText = await response.text();
     throw new Error(`Clerk API error: ${response.status} - ${errorText}`);
+  }
+
+  // 204 No Content responses (e.g. DELETE) have no body; cast undefined.
+  if (response.status === 204) {
+    return undefined as T;
   }
 
   return response.json() as Promise<T>;
@@ -91,4 +107,80 @@ export async function getOrganizationRole(roleId: string): Promise<ClerkRole> {
  */
 export async function getOrganizationPermission(permissionId: string): Promise<ClerkPermission> {
   return clerkApiRequest<ClerkPermission>(`/organization_permissions/${permissionId}`);
+}
+
+export type CreateOrganizationRoleInput = {
+  name: string;
+  key: string;
+  description: string;
+  /** Permission keys to attach to the new role (e.g. 'org:members:read'). */
+  permissions: string[];
+};
+
+/**
+ * Creates a new custom organization role on the Clerk instance.
+ *
+ * Per Clerk's BAPI (the 2025-11-24 changelog), POSTing to
+ * `/organization_roles` with `{ name, key, description, permissions }`
+ * creates a custom role available to every org on the instance. System
+ * roles (org:admin / org:member etc.) are managed by Clerk and cannot be
+ * created here — Clerk will return 4xx if the key collides.
+ */
+export async function createOrganizationRole(
+  input: CreateOrganizationRoleInput,
+): Promise<ClerkRole> {
+  return clerkApiRequest<ClerkRole>('/organization_roles', {
+    method: 'POST',
+    body: {
+      name: input.name,
+      key: input.key,
+      description: input.description,
+      permissions: input.permissions,
+    },
+  });
+}
+
+export type UpdateOrganizationRoleInput = {
+  name?: string;
+  description?: string;
+  /** When provided, REPLACES the role's permission set (not additive). */
+  permissions?: string[];
+};
+
+/**
+ * Updates a custom organization role. Only fields present in `input` are
+ * sent — Clerk leaves omitted fields untouched. `permissions` is REPLACE
+ * semantics, not merge: send the full desired list, not just additions.
+ *
+ * Clerk's BAPI rejects edits to system roles with 4xx; surface that as-is.
+ */
+export async function updateOrganizationRole(
+  roleId: string,
+  input: UpdateOrganizationRoleInput,
+): Promise<ClerkRole> {
+  const body: Record<string, unknown> = {};
+  if (input.name !== undefined) {
+    body.name = input.name;
+  }
+  if (input.description !== undefined) {
+    body.description = input.description;
+  }
+  if (input.permissions !== undefined) {
+    body.permissions = input.permissions;
+  }
+
+  return clerkApiRequest<ClerkRole>(`/organization_roles/${roleId}`, {
+    method: 'PATCH',
+    body,
+  });
+}
+
+/**
+ * Deletes a custom organization role. Clerk rejects deletion of system
+ * roles or any role currently assigned to a member with 4xx.
+ */
+export async function deleteOrganizationRole(roleId: string): Promise<void> {
+  await clerkApiRequest<void>(`/organization_roles/${roleId}`, {
+    method: 'DELETE',
+  });
 }

--- a/src/types/Audit.test.ts
+++ b/src/types/Audit.test.ts
@@ -24,8 +24,9 @@ describe('Audit Types', () => {
       // + 8 waiver (4 template + 1 signed + 3 membership waiver)
       // + 3 merge field + 1 payment + 1 payment method register + 1 family member link
       // + 1 family member unlink + 1 member convert + 3 saas subscription
-      // + 3 note (create + update + delete) + 3 staff (invite + update + remove) = 84
-      expect(actionCount).toBe(84);
+      // + 3 note (create + update + delete) + 3 staff (invite + update + remove)
+      // + 3 role (create + update + delete) = 87
+      expect(actionCount).toBe(87);
     });
   });
 
@@ -42,8 +43,8 @@ describe('Audit Types', () => {
       // event, eventSession, coupon, classEnrollment, eventRegistration, attendance, transaction, tag, image
       // + catalogItem, catalogVariant, catalogCategory, catalogImage
       // + waiverTemplate, signedWaiver, membershipWaiver, waiverMergeField + familyMember + paymentMethod + organization
-      // + note + staff = 29
-      expect(entityCount).toBe(29);
+      // + note + staff + role = 30
+      expect(entityCount).toBe(30);
     });
   });
 

--- a/src/types/Audit.ts
+++ b/src/types/Audit.ts
@@ -132,6 +132,11 @@ export const AUDIT_ACTION = {
   STAFF_INVITE: 'staff.invite',
   STAFF_UPDATE: 'staff.update',
   STAFF_REMOVE: 'staff.remove',
+
+  // Role operations (Clerk organization roles)
+  ROLE_CREATE: 'role.create',
+  ROLE_UPDATE: 'role.update',
+  ROLE_DELETE: 'role.delete',
 } as const;
 
 export type AuditAction = (typeof AUDIT_ACTION)[keyof typeof AUDIT_ACTION];
@@ -169,6 +174,7 @@ export const AUDIT_ENTITY_TYPE = {
   ORGANIZATION: 'organization',
   NOTE: 'note',
   STAFF: 'staff',
+  ROLE: 'role',
 } as const;
 
 export type AuditEntityType = (typeof AUDIT_ENTITY_TYPE)[keyof typeof AUDIT_ENTITY_TYPE];

--- a/src/validations/RolesValidation.test.ts
+++ b/src/validations/RolesValidation.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CreateRoleValidation,
+  DeleteRoleValidation,
+  UpdateRoleValidation,
+} from './RolesValidation';
+
+const validCreate = {
+  name: 'Front Desk',
+  key: 'org:front_desk',
+  description: 'Day-to-day check-in and member lookup access.',
+  permissions: ['org:members:read', 'org:attendance:write'],
+};
+
+describe('CreateRoleValidation', () => {
+  it('accepts a valid payload', () => {
+    expect(CreateRoleValidation.safeParse(validCreate).success).toBe(true);
+  });
+
+  it('rejects empty name', () => {
+    expect(CreateRoleValidation.safeParse({ ...validCreate, name: '' }).success).toBe(false);
+  });
+
+  it('rejects name longer than 100 characters', () => {
+    expect(CreateRoleValidation.safeParse({
+      ...validCreate,
+      name: 'x'.repeat(101),
+    }).success).toBe(false);
+  });
+
+  it('rejects a role key without the org: prefix', () => {
+    expect(CreateRoleValidation.safeParse({ ...validCreate, key: 'front_desk' }).success).toBe(false);
+  });
+
+  it('rejects a role key with uppercase characters', () => {
+    expect(CreateRoleValidation.safeParse({ ...validCreate, key: 'org:Front_Desk' }).success).toBe(false);
+  });
+
+  it('rejects a role key with spaces or hyphens', () => {
+    expect(CreateRoleValidation.safeParse({ ...validCreate, key: 'org:front desk' }).success).toBe(false);
+    expect(CreateRoleValidation.safeParse({ ...validCreate, key: 'org:front-desk' }).success).toBe(false);
+  });
+
+  it('accepts an empty permissions array (operator can add later)', () => {
+    expect(CreateRoleValidation.safeParse({ ...validCreate, permissions: [] }).success).toBe(true);
+  });
+
+  it('rejects permissions array containing empty strings', () => {
+    expect(CreateRoleValidation.safeParse({
+      ...validCreate,
+      permissions: [''],
+    }).success).toBe(false);
+  });
+
+  it('rejects description longer than 500 characters', () => {
+    expect(CreateRoleValidation.safeParse({
+      ...validCreate,
+      description: 'x'.repeat(501),
+    }).success).toBe(false);
+  });
+});
+
+describe('UpdateRoleValidation', () => {
+  it('requires id', () => {
+    expect(UpdateRoleValidation.safeParse({ name: 'New Name' }).success).toBe(false);
+    expect(UpdateRoleValidation.safeParse({ id: 'role_1', name: 'New Name' }).success).toBe(true);
+  });
+
+  it('accepts id alone (no-op update)', () => {
+    expect(UpdateRoleValidation.safeParse({ id: 'role_1' }).success).toBe(true);
+  });
+
+  it('accepts a partial update with just permissions', () => {
+    expect(UpdateRoleValidation.safeParse({
+      id: 'role_1',
+      permissions: ['org:members:read'],
+    }).success).toBe(true);
+  });
+
+  it('rejects empty id', () => {
+    expect(UpdateRoleValidation.safeParse({ id: '', name: 'x' }).success).toBe(false);
+  });
+});
+
+describe('DeleteRoleValidation', () => {
+  it('rejects empty id', () => {
+    expect(DeleteRoleValidation.safeParse({ id: '' }).success).toBe(false);
+  });
+
+  it('accepts a non-empty id', () => {
+    expect(DeleteRoleValidation.safeParse({ id: 'role_1' }).success).toBe(true);
+  });
+});

--- a/src/validations/RolesValidation.ts
+++ b/src/validations/RolesValidation.ts
@@ -1,0 +1,37 @@
+import * as z from 'zod';
+
+const NAME_MAX = 100;
+const DESCRIPTION_MAX = 500;
+
+// Clerk role keys are slugs prefixed with `org:`. The AddEditRoleModal's
+// generateRoleKey() helper produces this exact shape.
+const RoleKey = z
+  .string()
+  .min(1)
+  .regex(/^org:[a-z0-9_]+$/, 'Role key must be in the form "org:lowercase_slug"');
+
+// Permission keys come from Clerk and look like 'org:members:read'. We
+// don't need to validate the full shape — only that they're non-empty
+// strings — because the upstream API will reject anything malformed.
+const PermissionKey = z.string().min(1);
+
+export const CreateRoleValidation = z.object({
+  name: z.string().min(1).max(NAME_MAX),
+  key: RoleKey,
+  description: z.string().max(DESCRIPTION_MAX),
+  permissions: z.array(PermissionKey),
+});
+
+export const UpdateRoleValidation = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1).max(NAME_MAX).optional(),
+  description: z.string().max(DESCRIPTION_MAX).optional(),
+  permissions: z.array(PermissionKey).optional(),
+});
+
+export const DeleteRoleValidation = z.object({
+  id: z.string().min(1),
+});
+
+export type CreateRoleInput = z.infer<typeof CreateRoleValidation>;
+export type UpdateRoleInput = z.infer<typeof UpdateRoleValidation>;


### PR DESCRIPTION
## Summary

- Implements `roles.create` / `roles.update` / `roles.remove` ORPC endpoints
  backed by Clerk's Backend API (`/organization_roles` POST/PATCH/DELETE),
  replaces the stub `console.info` handlers in `RolesPageClient`, and adds a
  `DeleteRoleAlertDialog` confirmation flow.
- Extends `ClerkRolesService.clerkApiRequest` to support POST/PATCH/DELETE
  with JSON bodies (existing GET callers unchanged).
- Adds `ROLE_CREATE` / `ROLE_UPDATE` / `ROLE_DELETE` audit actions + `ROLE`
  entity type. Each handler emits success/failure audits; 4xx from Clerk
  (duplicate keys, system-role edits, role-still-in-use) is mapped to 409
  Conflict so the UI can surface the message.
- Sends Clerk permission **IDs** (not keys) in the create/update body —
  Clerk's BAPI returns 404 `resource_not_found` ("Organization permission
  not found") when permission keys are sent.

## Closed issues

- Closes #154
- Closes #153 (deferred / out of scope — no operator UX call yet for
  archive-vs-hard-delete on plans with active subscribers)

## Test plan

- [x] `npm run lint && npm run check:types && npm run check:deps && npm run check:i18n`
- [x] `npm run test` — 4339 tests pass
- [x] New tests:
  - `src/routers/Roles.test.ts` — auth guard, audit success/failure, 4xx→409 mapping (9 tests)
  - `src/validations/RolesValidation.test.ts` — name/key/description/permissions edge cases (15 tests)
  - `src/services/ClerkRolesService.test.ts` — create/update/delete fetch contracts incl. 204 (extended, 17 total)
  - `src/features/roles/DeleteRoleAlertDialog.test.tsx` — confirmation dialog (5 tests)
  - `src/features/roles/RolesPageClient.test.tsx` — `client.roles.create/update/remove` + `router.refresh()` + error banner (extended)
- [ ] Manual smoke at `/dashboard/roles`:
  - [ ] Add a custom role with permissions selected → appears in list
  - [ ] Edit a custom role → updated fields reflect after save
  - [ ] Delete a custom role → confirmation dialog → removed from list
  - [ ] Attempt to delete a role assigned to members → 4xx surfaced as inline error
  - [ ] System roles (`org:admin` / `org:member`) remain undeletable in the UI