### PR TITLE
feat(settings): wire up organization location and coupon total savings

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -48,7 +48,8 @@ src/
 │   ├── Classes.ts         # Classes list & tags
 │   ├── Events.ts          # Events list
 │   ├── Tags.ts            # Tags (class, membership, all)
-│   ├── Coupons.ts         # Coupons list & active
+│   ├── Coupons.ts         # Coupons list & active, total savings aggregation
+│   ├── Organization.ts    # Per-org location settings (getLocation, updateLocation)
 │   ├── Transactions.ts    # Transaction listing with filters
 │   ├── Dashboard.ts       # Membership stats, financial stats, chart data
 │   ├── Reports.ts         # Report values, chart data, dynamic insights
@@ -61,10 +62,10 @@ src/
 │   ├── CatalogService.ts  # Catalog items, variants, categories, images
 │   ├── ClassesService.ts  # Class & schedule queries
 │   ├── ClerkRolesService.ts # Clerk Backend API
-│   ├── CouponsService.ts  # Coupon queries
+│   ├── CouponsService.ts  # Coupon queries + organization-wide total savings aggregation
 │   ├── EventsService.ts   # Event queries
 │   ├── MembersService.ts  # Member operations
-│   ├── OrganizationService.ts # Org & Stripe customer storage
+│   ├── OrganizationService.ts # Org & Stripe customer storage + per-org location settings (name, address, phone, email)
 │   ├── TagsService.ts     # Tag queries with usage counts
 │   ├── TransactionsService.ts # Transaction listing with member joins
 │   ├── DashboardService.ts # Membership stats, financial stats, member average & earnings chart data
@@ -154,6 +155,7 @@ docs/                      # Documentation
 | `/dashboard/subscription-expired` | `subscription-expired/page.tsx` | Subscription expired — re-subscribe prompt |
 | `/dashboard/preferences` | `preferences/page.tsx` | User preferences |
 | `/dashboard/security` | `security/page.tsx` | Security settings |
+| `/dashboard/location-settings` | `location-settings/page.tsx` | Per-org location settings (name, address, phone, email) — backed by `organization.location*` columns |
 
 ### Auth Routes
 
@@ -614,7 +616,7 @@ await deleteUserWithOrganization();
 **Schema:** `src/models/Schema.ts`
 
 **Key Tables:**
-- `organization` - Multi-tenant orgs with Stripe IDs + IQPro SaaS subscription fields (iqproCustomerId, iqproSubscriptionId, iqproSubscriptionPlanId, iqproBillingCycle, iqproSubscriptionStatus, iqproCurrentPeriodEnd, iqproPaymentMethodId)
+- `organization` - Multi-tenant orgs with Stripe IDs + IQPro SaaS subscription fields (iqproCustomerId, iqproSubscriptionId, iqproSubscriptionPlanId, iqproBillingCycle, iqproSubscriptionStatus, iqproCurrentPeriodEnd, iqproPaymentMethodId) + location settings (locationName, locationAddress, locationPhone, locationEmail — all nullable, set via the location-settings page)
 - `member` - Member records with dateOfBirth, optional `clerkUserId` for kiosk auth, optional `iqproCustomerId`
 - `membership_plan` - Pricing tiers
 - `member_membership` - Member-plan associations with startDate, endDate, firstPaymentDate, nextPaymentDate, optional `iqproSubscriptionId`
@@ -1016,6 +1018,9 @@ AUDIT_ACTION.PAYMENT_METHOD_REGISTER;
 AUDIT_ACTION.SAAS_SUBSCRIPTION_CREATE;
 AUDIT_ACTION.SAAS_SUBSCRIPTION_CHANGE;
 AUDIT_ACTION.SAAS_SUBSCRIPTION_CANCEL;
+
+// Organization operations
+AUDIT_ACTION.ORGANIZATION_LOCATION_UPDATE;
 
 // Family member operations
 AUDIT_ACTION.FAMILY_MEMBER_LINK;

--- a/migrations/0000_baseline.sql
+++ b/migrations/0000_baseline.sql
@@ -388,6 +388,10 @@ CREATE TABLE "organization" (
 	"iqpro_subscription_status" text,
 	"iqpro_current_period_end" bigint,
 	"iqpro_payment_method_id" text,
+	"location_name" text,
+	"location_address" text,
+	"location_phone" text,
+	"location_email" text,
 	"updated_at" timestamp DEFAULT now() NOT NULL,
 	"created_at" timestamp DEFAULT now() NOT NULL
 );

--- a/migrations/meta/0000_snapshot.json
+++ b/migrations/meta/0000_snapshot.json
@@ -3693,6 +3693,30 @@
           "primaryKey": false,
           "notNull": false
         },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_address": {
+          "name": "location_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_phone": {
+          "name": "location_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_email": {
+          "name": "location_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "updated_at": {
           "name": "updated_at",
           "type": "timestamp",

--- a/src/app/[locale]/(auth)/dashboard/classes/classes.test.tsx
+++ b/src/app/[locale]/(auth)/dashboard/classes/classes.test.tsx
@@ -73,6 +73,15 @@ vi.mock('@/hooks/useEventsCache', () => ({
   invalidateEventsCache: vi.fn(),
 }));
 
+vi.mock('@/hooks/useOrganizationLocation', () => ({
+  useOrganizationLocation: () => ({
+    location: { name: 'Main Dojo', address: 'Downtown HQ', phone: null, email: null },
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
 // Mock the tags cache for ClassTagsManagement
 vi.mock('@/hooks/useTagsCache', () => ({
   useTagsCache: () => ({

--- a/src/app/[locale]/(auth)/dashboard/marketing/page.tsx
+++ b/src/app/[locale]/(auth)/dashboard/marketing/page.tsx
@@ -4,7 +4,7 @@ import type { Coupon, CouponFilters, CouponFormData } from '@/features/marketing
 import { useOrganization } from '@clerk/nextjs';
 import { ArrowDownAZ, ArrowUpZA, Edit, Plus, Trash2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Pagination } from '@/components/ui/pagination/Pagination';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -116,6 +116,28 @@ export default function MarketingPage() {
   const t = useTranslations('MarketingPage');
   const { organization } = useOrganization();
   const { coupons: rawCoupons, loading } = useCouponsCache(organization?.id);
+  const [totalSavings, setTotalSavings] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!organization?.id) {
+      return;
+    }
+    let cancelled = false;
+    client.coupons.getTotalSavings()
+      .then((result) => {
+        if (!cancelled) {
+          setTotalSavings(result.totalSavings);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setTotalSavings(null);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [organization?.id, rawCoupons.length]);
 
   // Transform database coupons to UI format
   const coupons = useMemo(() => transformCouponsToUi(rawCoupons), [rawCoupons]);
@@ -254,9 +276,11 @@ export default function MarketingPage() {
   const stats = useMemo(() => ({
     totalCoupons: coupons.length,
     activeCoupons: coupons.filter(c => c.status === 'Active').length,
-    totalSavings: 'N/A', // Would need transaction data to calculate
+    totalSavings: totalSavings === null
+      ? '—'
+      : `$${totalSavings.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
     timesUsed: totalUsage,
-  }), [coupons, totalUsage]);
+  }), [coupons, totalUsage, totalSavings]);
 
   const statsData = useMemo(() => [
     { id: 'total', label: t('total_coupons_label'), value: stats.totalCoupons },

--- a/src/features/classes/ClassEventHoverCard.tsx
+++ b/src/features/classes/ClassEventHoverCard.tsx
@@ -8,6 +8,7 @@ import { useMemo } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useClassesCache } from '@/hooks/useClassesCache';
+import { useOrganizationLocation } from '@/hooks/useOrganizationLocation';
 import { transformClassesToCardProps } from './classDataTransformers';
 
 type ClassEventHoverCardProps = {
@@ -84,9 +85,11 @@ export function ClassEventHoverCard({
   const router = useRouter();
   const { organization } = useOrganization();
   const { classes: rawClasses } = useClassesCache(organization?.id);
+  const { location: orgLocation } = useOrganizationLocation();
+  const locationLabel = orgLocation.address ?? '';
 
   // Transform and find the class data (only for classes, not events)
-  const classes = useMemo(() => transformClassesToCardProps(rawClasses), [rawClasses]);
+  const classes = useMemo(() => transformClassesToCardProps(rawClasses, locationLabel), [rawClasses, locationLabel]);
   const classData = isEvent ? undefined : classes.find(c => c.id === classId);
 
   const handleClick = () => {

--- a/src/features/classes/ClassesPage.test.tsx
+++ b/src/features/classes/ClassesPage.test.tsx
@@ -235,6 +235,15 @@ vi.mock('@/hooks/useEventsCache', () => ({
   invalidateEventsCache: vi.fn(),
 }));
 
+vi.mock('@/hooks/useOrganizationLocation', () => ({
+  useOrganizationLocation: () => ({
+    location: { name: 'Main Dojo', address: 'Downtown HQ', phone: null, email: null },
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
 // Mock the tags cache for ClassTagsManagement
 vi.mock('@/hooks/useTagsCache', () => ({
   useTagsCache: () => ({

--- a/src/features/classes/ClassesPage.tsx
+++ b/src/features/classes/ClassesPage.tsx
@@ -14,6 +14,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { invalidateClassesCache, useClassesCache } from '@/hooks/useClassesCache';
 import { invalidateEventsCache, useEventsCache } from '@/hooks/useEventsCache';
 import { useHasRole } from '@/hooks/useHasRole';
+import { useOrganizationLocation } from '@/hooks/useOrganizationLocation';
 import { ClassCard } from '@/templates/ClassCard';
 import { EventCard } from '@/templates/EventCard';
 import { StatsCards } from '@/templates/StatsCards';
@@ -38,10 +39,12 @@ export function ClassesPage() {
   // Fetch data from database with caching
   const { classes: rawClasses, loading: classesLoading } = useClassesCache(organization?.id);
   const { events: rawEvents, loading: eventsLoading } = useEventsCache(organization?.id);
+  const { location: orgLocation } = useOrganizationLocation();
+  const locationLabel = orgLocation.address ?? '';
 
   // Transform database data to card props format
-  const classes = useMemo(() => transformClassesToCardProps(rawClasses), [rawClasses]);
-  const events = useMemo(() => transformEventsToCardProps(rawEvents), [rawEvents]);
+  const classes = useMemo(() => transformClassesToCardProps(rawClasses, locationLabel), [rawClasses, locationLabel]);
+  const events = useMemo(() => transformEventsToCardProps(rawEvents, locationLabel), [rawEvents, locationLabel]);
 
   const loading = classesLoading || eventsLoading;
 

--- a/src/features/classes/MonthlyView.tsx
+++ b/src/features/classes/MonthlyView.tsx
@@ -10,6 +10,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { Skeleton } from '@/components/ui/skeleton';
 import { useClassesCache } from '@/hooks/useClassesCache';
 import { useEventsCache } from '@/hooks/useEventsCache';
+import { useOrganizationLocation } from '@/hooks/useOrganizationLocation';
 import { CalendarDateNav } from './CalendarDateNav';
 import { buildClassColorLegend, generateMonthlyEventScheduleFromData, generateMonthlyScheduleFromData, transformClassesToCardProps } from './classDataTransformers';
 import { ClassEventHoverCard } from './ClassEventHoverCard';
@@ -25,6 +26,8 @@ export function MonthlyView({ withFilters }: MonthlyViewProps = {}) {
   const { organization } = useOrganization();
   const { classes: rawClasses, loading: classesLoading } = useClassesCache(organization?.id);
   const { events: rawEvents, loading: eventsLoading } = useEventsCache(organization?.id);
+  const { location: orgLocation } = useOrganizationLocation();
+  const locationLabel = orgLocation.address ?? '';
   const loading = classesLoading || eventsLoading;
 
   const [currentDate, setCurrentDate] = useState(() => new Date());
@@ -35,7 +38,7 @@ export function MonthlyView({ withFilters }: MonthlyViewProps = {}) {
   });
 
   // Transform database data to card props for filtering
-  const classes = useMemo(() => transformClassesToCardProps(rawClasses), [rawClasses]);
+  const classes = useMemo(() => transformClassesToCardProps(rawClasses, locationLabel), [rawClasses, locationLabel]);
 
   // Use parent filters if provided, otherwise use local filters
   const filters = withFilters || localFilters;

--- a/src/features/classes/WeeklyView.tsx
+++ b/src/features/classes/WeeklyView.tsx
@@ -9,6 +9,7 @@ import { ButtonGroupItem, ButtonGroupRoot } from '@/components/ui/button-group';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useClassesCache } from '@/hooks/useClassesCache';
 import { useEventsCache } from '@/hooks/useEventsCache';
+import { useOrganizationLocation } from '@/hooks/useOrganizationLocation';
 import { CalendarDateNav } from './CalendarDateNav';
 import { buildClassColorLegend, generateWeeklyEventScheduleFromData, generateWeeklyScheduleFromData, transformClassesToCardProps } from './classDataTransformers';
 import { ClassEventHoverCard } from './ClassEventHoverCard';
@@ -25,6 +26,8 @@ export function WeeklyView({ withFilters }: WeeklyViewProps = {}) {
   const { organization } = useOrganization();
   const { classes: rawClasses, loading: classesLoading } = useClassesCache(organization?.id);
   const { events: rawEvents, loading: eventsLoading } = useEventsCache(organization?.id);
+  const { location: orgLocation } = useOrganizationLocation();
+  const locationLabel = orgLocation.address ?? '';
   const loading = classesLoading || eventsLoading;
 
   const [currentDate, setCurrentDate] = useState(() => new Date());
@@ -35,7 +38,7 @@ export function WeeklyView({ withFilters }: WeeklyViewProps = {}) {
   });
 
   // Transform database data to card props for filtering
-  const classes = useMemo(() => transformClassesToCardProps(rawClasses), [rawClasses]);
+  const classes = useMemo(() => transformClassesToCardProps(rawClasses, locationLabel), [rawClasses, locationLabel]);
 
   // Use parent filters if provided, otherwise use local filters
   const filters = withFilters || localFilters;

--- a/src/features/classes/classDataTransformers.test.ts
+++ b/src/features/classes/classDataTransformers.test.ts
@@ -1,6 +1,14 @@
 import type { ClassData } from '@/services/ClassesService';
+import type { EventData } from '@/services/EventsService';
 import { describe, expect, it } from 'vitest';
-import { generateMonthlyScheduleFromData, generateWeeklyScheduleFromData } from './classDataTransformers';
+import {
+  generateMonthlyScheduleFromData,
+  generateWeeklyScheduleFromData,
+  transformClassesToCardProps,
+  transformClassToCardProps,
+  transformEventsToCardProps,
+  transformEventToCardProps,
+} from './classDataTransformers';
 
 // =============================================================================
 // TEST HELPERS
@@ -293,5 +301,62 @@ describe('generateMonthlyScheduleFromData', () => {
     for (let day = 1; day <= 28; day++) {
       expect(events[day.toString()]).toHaveLength(0);
     }
+  });
+});
+
+// =============================================================================
+// LOCATION THREADING
+// =============================================================================
+
+const baseEvent: EventData = {
+  id: 'evt-1',
+  name: 'Spring Seminar',
+  description: 'desc',
+  isActive: true,
+  eventType: 'seminar',
+  sessions: [],
+  billing: [],
+} as unknown as EventData;
+
+describe('location threading', () => {
+  it('transformClassToCardProps uses the passed-in location', () => {
+    const cls = makeClass({
+      id: 'c1',
+      name: 'Class',
+      schedule: [{ id: 's1', dayOfWeek: 1, startTime: '09:00', endTime: '10:00', instructorClerkId: null }],
+    });
+
+    expect(transformClassToCardProps(cls, '500 Market St').location).toBe('500 Market St');
+  });
+
+  it('transformClassToCardProps defaults to empty string when location omitted', () => {
+    const cls = makeClass({ id: 'c1', name: 'Class', schedule: [] });
+
+    expect(transformClassToCardProps(cls).location).toBe('');
+  });
+
+  it('transformClassesToCardProps threads location into every transformed item', () => {
+    const cls1 = makeClass({ id: 'c1', name: 'A', schedule: [] });
+    const cls2 = makeClass({ id: 'c2', name: 'B', schedule: [] });
+    const result = transformClassesToCardProps([cls1, cls2], '1 Pine Ave');
+
+    expect(result).toHaveLength(2);
+    expect(result.every(c => c.location === '1 Pine Ave')).toBe(true);
+  });
+
+  it('transformEventToCardProps uses the passed-in location', () => {
+    expect(transformEventToCardProps(baseEvent, '500 Market St').location).toBe('500 Market St');
+  });
+
+  it('transformEventToCardProps defaults to empty string when location omitted', () => {
+    expect(transformEventToCardProps(baseEvent).location).toBe('');
+  });
+
+  it('transformEventsToCardProps threads location into every transformed event', () => {
+    const events = [baseEvent, { ...baseEvent, id: 'evt-2' }];
+    const result = transformEventsToCardProps(events, '1 Pine Ave');
+
+    expect(result).toHaveLength(2);
+    expect(result.every(e => e.location === '1 Pine Ave')).toBe(true);
   });
 });

--- a/src/features/classes/classDataTransformers.ts
+++ b/src/features/classes/classDataTransformers.ts
@@ -88,7 +88,7 @@ function getAvatarUrl(name: string): string {
 /**
  * Transform database ClassData to ClassCardProps
  */
-export function transformClassToCardProps(classData: ClassData): ClassCardProps {
+export function transformClassToCardProps(classData: ClassData, location: string = ''): ClassCardProps {
   // For now, we don't have instructor data from Clerk, so we use placeholders
   // In a full implementation, you would fetch instructor details from Clerk API
   const instructors = classData.schedule
@@ -112,7 +112,7 @@ export function transformClassToCardProps(classData: ClassData): ClassCardProps 
     type: extractType(classData.tags),
     style: extractStyle(classData.tags),
     schedule: transformSchedule(classData.schedule),
-    location: 'Downtown HQ', // Would come from organization settings
+    location,
     instructors,
   };
 }
@@ -120,7 +120,7 @@ export function transformClassToCardProps(classData: ClassData): ClassCardProps 
 /**
  * Transform database EventData to EventCardProps
  */
-export function transformEventToCardProps(eventData: EventData): EventCardProps {
+export function transformEventToCardProps(eventData: EventData, location: string = ''): EventCardProps {
   // Get date range from sessions
   const sortedSessions = [...eventData.sessions].sort(
     (a, b) => new Date(a.sessionDate).getTime() - new Date(b.sessionDate).getTime(),
@@ -170,7 +170,7 @@ export function transformEventToCardProps(eventData: EventData): EventCardProps 
     startDate,
     endDate,
     sessions,
-    location: 'Downtown HQ',
+    location,
     instructors,
     price: lowestPrice,
   };
@@ -179,19 +179,19 @@ export function transformEventToCardProps(eventData: EventData): EventCardProps 
 /**
  * Transform array of classes
  */
-export function transformClassesToCardProps(classes: ClassData[]): ClassCardProps[] {
+export function transformClassesToCardProps(classes: ClassData[], location: string = ''): ClassCardProps[] {
   return classes
     .filter(c => c.isActive !== false)
-    .map(transformClassToCardProps);
+    .map(c => transformClassToCardProps(c, location));
 }
 
 /**
  * Transform array of events
  */
-export function transformEventsToCardProps(events: EventData[]): EventCardProps[] {
+export function transformEventsToCardProps(events: EventData[], location: string = ''): EventCardProps[] {
   return events
     .filter(e => e.isActive !== false)
-    .map(transformEventToCardProps);
+    .map(e => transformEventToCardProps(e, location));
 }
 
 // =============================================================================

--- a/src/features/settings/EditLocationForm.tsx
+++ b/src/features/settings/EditLocationForm.tsx
@@ -40,7 +40,8 @@ type EditLocationFormProps = {
     phone: string;
     email: string;
   };
-  onSave: (data: { name: string; address: string; phone: string; email: string }) => void;
+  onSave: (data: { name: string; address: string; phone: string; email: string }) => void | Promise<void>;
+  errorMessage?: string | null;
 };
 
 type FormErrors = {
@@ -50,7 +51,7 @@ type FormErrors = {
   email?: string;
 };
 
-export function EditLocationForm({ onCancel, onSuccess, initialData, onSave }: EditLocationFormProps) {
+export function EditLocationForm({ onCancel, onSuccess, initialData, onSave, errorMessage }: EditLocationFormProps) {
   const t = useTranslations('LocationSettings.EditLocationModal');
   const tCommon = useTranslations('MyProfile');
 
@@ -97,15 +98,16 @@ export function EditLocationForm({ onCancel, onSuccess, initialData, onSave }: E
     setErrors({});
 
     try {
-      // Sanitize all inputs before saving
       const sanitizedData = {
         name: sanitizeInput(name),
         address: sanitizeInput(address),
         phone: sanitizePhone(phone),
         email: sanitizeEmail(email),
       };
-      onSave(sanitizedData);
+      await onSave(sanitizedData);
       onSuccess();
+    } catch {
+      // Save failed; parent surfaces the error via errorMessage prop
     } finally {
       setIsLoading(false);
     }
@@ -177,6 +179,9 @@ export function EditLocationForm({ onCancel, onSuccess, initialData, onSave }: E
           )}
         </div>
       </div>
+      {errorMessage && (
+        <p className="text-sm text-red-500">{errorMessage}</p>
+      )}
       <div className="flex justify-between pt-2">
         <Button
           type="button"

--- a/src/features/settings/EditLocationModal.tsx
+++ b/src/features/settings/EditLocationModal.tsx
@@ -23,7 +23,8 @@ type EditLocationModalProps = {
     address: string;
     phone: string;
     email: string;
-  }) => void;
+  }) => void | Promise<void>;
+  errorMessage?: string | null;
 };
 
 export function EditLocationModal({
@@ -34,6 +35,7 @@ export function EditLocationModal({
   phone: initialPhone,
   email: initialEmail,
   onSave,
+  errorMessage,
 }: EditLocationModalProps) {
   const t = useTranslations('LocationSettings.EditLocationModal');
 
@@ -61,15 +63,11 @@ export function EditLocationModal({
 
   const handleSubmit = async () => {
     setIsLoading(true);
-    // Simulate API call
-    await new Promise(resolve => setTimeout(resolve, 500));
-    onSave({
-      name,
-      address,
-      phone,
-      email,
-    });
-    setIsLoading(false);
+    try {
+      await onSave({ name, address, phone, email });
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const handleCancel = () => {
@@ -162,6 +160,10 @@ export function EditLocationModal({
               <p className="text-xs text-destructive">{t('email_error')}</p>
             )}
           </div>
+
+          {errorMessage && (
+            <p className="text-sm text-destructive">{errorMessage}</p>
+          )}
 
           {/* Action Buttons */}
           <div className="flex justify-end gap-3 pt-4">

--- a/src/features/settings/LocationCard.test.tsx
+++ b/src/features/settings/LocationCard.test.tsx
@@ -1,9 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { page, userEvent } from 'vitest/browser';
-import { LocationCard } from './LocationCard';
 
-// Mock next-intl
 vi.mock('next-intl', () => ({
   useTranslations: (namespace: string) => (key: string) => {
     const translations: Record<string, Record<string, string>> = {
@@ -40,46 +38,91 @@ vi.mock('next-intl', () => ({
   },
 }));
 
+const refetchMock = vi.fn();
+const updateLocationMock = vi.fn().mockResolvedValue({ location: {} });
+
+let hookState: {
+  location: { name: string | null; address: string | null; phone: string | null; email: string | null };
+  loading: boolean;
+} = {
+  location: {
+    name: 'Main Dojo',
+    address: '500 Market St',
+    phone: '(415) 555-0100',
+    email: 'hello@dojo.test',
+  },
+  loading: false,
+};
+
+vi.mock('@/hooks/useOrganizationLocation', () => ({
+  useOrganizationLocation: () => ({
+    location: hookState.location,
+    loading: hookState.loading,
+    error: null,
+    refetch: refetchMock,
+  }),
+}));
+
+vi.mock('@/libs/Orpc', () => ({
+  client: {
+    organization: {
+      updateLocation: (...args: unknown[]) => updateLocationMock(...args),
+    },
+  },
+}));
+
+// Import after mocks are set up
+const { LocationCard } = await import('./LocationCard');
+
 describe('LocationCard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    hookState = {
+      location: {
+        name: 'Main Dojo',
+        address: '500 Market St',
+        phone: '(415) 555-0100',
+        email: 'hello@dojo.test',
+      },
+      loading: false,
+    };
   });
 
-  it('should render the location title', () => {
+  it('renders the location title', () => {
     render(<LocationCard />);
 
     expect(page.getByText('Location')).toBeDefined();
   });
 
-  it('should render address label and value', () => {
+  it('renders address from the hook', () => {
     render(<LocationCard />);
 
     expect(page.getByText('Address:')).toBeDefined();
-    expect(page.getByText('123 Main St. San Francisco. CA')).toBeDefined();
+    expect(page.getByText('500 Market St')).toBeDefined();
   });
 
-  it('should render phone label and value', () => {
+  it('renders phone from the hook', () => {
     render(<LocationCard />);
 
     expect(page.getByText('Phone:')).toBeDefined();
-    expect(page.getByText('(415) 555-0123')).toBeDefined();
+    expect(page.getByText('(415) 555-0100')).toBeDefined();
   });
 
-  it('should render email label and value', () => {
+  it('renders email from the hook', () => {
     render(<LocationCard />);
 
     expect(page.getByText('Email:')).toBeDefined();
-    expect(page.getByText('downtown@example.com')).toBeDefined();
+    expect(page.getByText('hello@dojo.test')).toBeDefined();
   });
 
-  it('should render status label and active badge', () => {
+  it('renders status label and active badge', () => {
     render(<LocationCard />);
 
     expect(page.getByText('Status:')).toBeDefined();
     expect(page.getByText('Active')).toBeDefined();
   });
 
-  it('should render the edit button', () => {
+  it('renders the edit button', () => {
     render(<LocationCard />);
 
     const editButton = page.getByRole('button', { name: /edit location/i });
@@ -87,93 +130,65 @@ describe('LocationCard', () => {
     expect(editButton).toBeDefined();
   });
 
-  it('should show inline edit form when edit button is clicked', async () => {
+  it('shows inline edit form when edit button is clicked', async () => {
     render(<LocationCard />);
 
     const editButton = page.getByRole('button', { name: /edit location/i });
     await userEvent.click(editButton);
 
-    // The edit form should now be visible with input fields
     expect(page.getByLabelText('Location Name')).toBeDefined();
     expect(page.getByLabelText('Address')).toBeDefined();
     expect(page.getByLabelText('Phone')).toBeDefined();
     expect(page.getByLabelText('Email')).toBeDefined();
   });
 
-  it('should hide edit form when cancel button is clicked', async () => {
+  it('hides edit form when cancel button is clicked', async () => {
     render(<LocationCard />);
 
-    // Open edit form
     const editButton = page.getByRole('button', { name: /edit location/i });
     await userEvent.click(editButton);
 
-    // Cancel editing
     const cancelButton = page.getByRole('button', { name: /cancel/i });
     await userEvent.click(cancelButton);
 
-    // Should be back to display mode with the edit button visible
     expect(page.getByRole('button', { name: /edit location/i })).toBeDefined();
-
-    // Edit form inputs should not be visible
     expect(page.getByLabelText('Location Name').elements().length).toBe(0);
   });
 
-  it('should update location data when save button is clicked', async () => {
+  it('calls updateLocation and refetches when save is clicked', async () => {
     render(<LocationCard />);
 
-    // Open edit form
     const editButton = page.getByRole('button', { name: /edit location/i });
     await userEvent.click(editButton);
 
-    // Clear and fill in new values
     const addressInput = page.getByLabelText('Address');
     await userEvent.clear(addressInput);
-    await userEvent.type(addressInput, '456 New St. Los Angeles. CA');
+    await userEvent.type(addressInput, '456 New St');
 
-    const phoneInput = page.getByLabelText('Phone');
-    await userEvent.clear(phoneInput);
-    await userEvent.type(phoneInput, '(310) 555-9999');
-
-    const emailInput = page.getByLabelText('Email');
-    await userEvent.clear(emailInput);
-    await userEvent.type(emailInput, 'updated@example.com');
-
-    // Save changes
     const saveButton = page.getByRole('button', { name: /save/i });
     await userEvent.click(saveButton);
 
-    // Check that the data is updated
-    expect(page.getByText('456 New St. Los Angeles. CA')).toBeDefined();
-    expect(page.getByText('(310) 555-9999')).toBeDefined();
-    expect(page.getByText('updated@example.com')).toBeDefined();
+    expect(updateLocationMock).toHaveBeenCalledWith(expect.objectContaining({
+      address: '456 New St',
+    }));
+    expect(refetchMock).toHaveBeenCalled();
   });
 
-  it('should display dash when value is empty', () => {
-    // This test verifies the fallback behavior
-    render(<LocationCard />);
-
-    // The mock data has values, so no dashes should appear in default state
-    // This is more of a structural test
-    expect(page.getByText('Location')).toBeDefined();
-  });
-
-  it('should show title even when in edit mode', async () => {
+  it('shows the title even when in edit mode', async () => {
     render(<LocationCard />);
 
     const editButton = page.getByRole('button', { name: /edit location/i });
     await userEvent.click(editButton);
 
-    // Title should still be visible
     expect(page.getByText('Location')).toBeDefined();
   });
 
-  it('should hide display fields when in edit mode', async () => {
+  it('hides display fields when in edit mode', async () => {
     render(<LocationCard />);
 
     const editButton = page.getByRole('button', { name: /edit location/i });
     await userEvent.click(editButton);
 
-    // The status badge should not be visible in edit mode
     expect(page.getByText('Status:').elements().length).toBe(0);
   });
 });
@@ -183,23 +198,22 @@ describe('LocationCard - Loading State', () => {
     vi.clearAllMocks();
   });
 
-  it('should render skeleton when loading', () => {
+  it('renders skeleton when isLoading prop is true', () => {
+    hookState = { ...hookState, loading: false };
     render(<LocationCard isLoading={true} />);
 
-    // When loading, the card should show skeletons instead of data
-    // The title should not be visible when loading
     expect(page.getByText('Location').elements().length).toBe(0);
   });
 
-  it('should not render edit button when loading', () => {
-    render(<LocationCard isLoading={true} />);
+  it('renders skeleton when the hook is loading', () => {
+    hookState = { ...hookState, loading: true };
+    render(<LocationCard />);
 
-    const editButton = page.getByRole('button', { name: /edit/i }).elements();
-
-    expect(editButton.length).toBe(0);
+    expect(page.getByText('Location').elements().length).toBe(0);
   });
 
-  it('should render normal content when not loading', () => {
+  it('renders normal content when not loading', () => {
+    hookState = { ...hookState, loading: false };
     render(<LocationCard isLoading={false} />);
 
     expect(page.getByText('Location')).toBeDefined();

--- a/src/features/settings/LocationCard.tsx
+++ b/src/features/settings/LocationCard.tsx
@@ -7,48 +7,37 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useOrganizationLocation } from '@/hooks/useOrganizationLocation';
+import { client } from '@/libs/Orpc';
 import { EditLocationForm } from './EditLocationForm';
-
-type LocationData = {
-  id: string;
-  name: string;
-  address: string;
-  phone: string;
-  email: string;
-};
-
-// Test data marker - for development/testing purposes only
-const mockLocation: LocationData = {
-  id: 'downtown-hq',
-  name: 'Downtown HQ',
-  address: '123 Main St. San Francisco. CA',
-  phone: '(415) 555-0123',
-  email: 'downtown@example.com',
-};
 
 type LocationCardProps = {
   isLoading?: boolean;
 };
 
-export function LocationCard({ isLoading = false }: LocationCardProps) {
+export function LocationCard({ isLoading: forcedLoading = false }: LocationCardProps) {
   const t = useTranslations('LocationSettings');
   const tProfile = useTranslations('MyProfile');
+  const { location, loading: fetchLoading, refetch } = useOrganizationLocation();
   const [isEditing, setIsEditing] = useState(false);
-  const [location, setLocation] = useState<LocationData>(mockLocation);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
-  const handleSaveLocation = (data: {
+  const isLoading = forcedLoading || fetchLoading;
+
+  const handleSaveLocation = async (data: {
     name: string;
     address: string;
     phone: string;
     email: string;
   }) => {
-    setLocation(prev => ({
-      ...prev,
-      name: data.name,
-      address: data.address,
-      phone: data.phone,
-      email: data.email,
-    }));
+    setSaveError(null);
+    try {
+      await client.organization.updateLocation(data);
+      await refetch();
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to save location');
+      throw err;
+    }
   };
 
   const handleEditSuccess = () => {
@@ -80,14 +69,18 @@ export function LocationCard({ isLoading = false }: LocationCardProps) {
             <div className="mt-4">
               <EditLocationForm
                 initialData={{
-                  name: location.name,
-                  address: location.address,
-                  phone: location.phone,
-                  email: location.email,
+                  name: location.name ?? '',
+                  address: location.address ?? '',
+                  phone: location.phone ?? '',
+                  email: location.email ?? '',
                 }}
-                onCancel={() => setIsEditing(false)}
+                onCancel={() => {
+                  setIsEditing(false);
+                  setSaveError(null);
+                }}
                 onSuccess={handleEditSuccess}
                 onSave={handleSaveLocation}
+                errorMessage={saveError}
               />
             </div>
           )

--- a/src/features/settings/LocationSettingsPage.test.tsx
+++ b/src/features/settings/LocationSettingsPage.test.tsx
@@ -1,7 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { page, userEvent } from 'vitest/browser';
-import { LocationSettingsPage } from './LocationSettingsPage';
 
 vi.mock('next-intl', () => ({
   useTranslations: (namespace: string) => (key: string) => {
@@ -38,52 +37,100 @@ vi.mock('next-intl', () => ({
   },
 }));
 
+const refetchMock = vi.fn();
+const updateLocationMock = vi.fn().mockResolvedValue({ location: {} });
+
+let hookState: {
+  location: { name: string | null; address: string | null; phone: string | null; email: string | null };
+  loading: boolean;
+} = {
+  location: {
+    name: 'Main Dojo',
+    address: '500 Market St, San Francisco, CA',
+    phone: '(415) 555-0100',
+    email: 'hello@dojo.test',
+  },
+  loading: false,
+};
+
+vi.mock('@/hooks/useOrganizationLocation', () => ({
+  useOrganizationLocation: () => ({
+    location: hookState.location,
+    loading: hookState.loading,
+    error: null,
+    refetch: refetchMock,
+  }),
+}));
+
+vi.mock('@/libs/Orpc', () => ({
+  client: {
+    organization: {
+      updateLocation: (...args: unknown[]) => updateLocationMock(...args),
+    },
+  },
+}));
+
+const { LocationSettingsPage } = await import('./LocationSettingsPage');
+
 describe('LocationSettingsPage', () => {
-  it('should render the page title', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hookState = {
+      location: {
+        name: 'Main Dojo',
+        address: '500 Market St, San Francisco, CA',
+        phone: '(415) 555-0100',
+        email: 'hello@dojo.test',
+      },
+      loading: false,
+    };
+  });
+
+  it('renders the page title', () => {
     render(<LocationSettingsPage />);
 
     expect(page.getByText('Location Settings')).toBeDefined();
   });
 
-  it('should render location section header', () => {
+  it('renders location section header', () => {
     render(<LocationSettingsPage />);
 
     expect(page.getByText('Location')).toBeDefined();
   });
 
-  it('should render location address', () => {
+  it('renders the location address from the hook', () => {
     render(<LocationSettingsPage />);
 
-    expect(page.getByText('123 Main St. San Francisco. CA')).toBeDefined();
+    expect(page.getByText('500 Market St, San Francisco, CA')).toBeDefined();
   });
 
-  it('should render location phone number', () => {
+  it('renders the location phone from the hook', () => {
     render(<LocationSettingsPage />);
 
-    expect(page.getByText('(415) 555-0123')).toBeDefined();
+    expect(page.getByText('(415) 555-0100')).toBeDefined();
   });
 
-  it('should render location email', () => {
+  it('renders the location email from the hook', () => {
     render(<LocationSettingsPage />);
 
-    expect(page.getByText('downtown@example.com')).toBeDefined();
+    expect(page.getByText('hello@dojo.test')).toBeDefined();
   });
 
-  it('should render active status badge', () => {
+  it('renders active status badge', () => {
     render(<LocationSettingsPage />);
 
     expect(page.getByText('Active')).toBeDefined();
   });
 
-  it('should render edit button', () => {
+  it('renders the edit button', () => {
     render(<LocationSettingsPage />);
 
-    const editButton = page.getByRole('button', { name: /edit/i });
+    const editButton = page.getByRole('button', { name: /edit location/i });
 
     expect(editButton).toBeDefined();
   });
 
-  it('should open edit modal when edit button is clicked', async () => {
+  it('opens the edit modal when edit button is clicked', async () => {
     render(<LocationSettingsPage />);
 
     const editButton = page.getByRole('button', { name: /edit/i });
@@ -92,7 +139,7 @@ describe('LocationSettingsPage', () => {
     expect(page.getByText('Edit Location Information')).toBeDefined();
   });
 
-  it('should display all field labels', () => {
+  it('displays all field labels', () => {
     render(<LocationSettingsPage />);
 
     expect(page.getByText('Address:')).toBeDefined();
@@ -101,82 +148,56 @@ describe('LocationSettingsPage', () => {
     expect(page.getByText('Status:')).toBeDefined();
   });
 
-  it('should not render subscription details section', () => {
+  it('closes the modal when cancel is clicked', async () => {
     render(<LocationSettingsPage />);
 
-    const subscriptionText = page.getByText('Subscription Details');
-
-    expect(subscriptionText.elements()).toHaveLength(0);
-  });
-
-  it('should not render payment method section', () => {
-    render(<LocationSettingsPage />);
-
-    const paymentText = page.getByText('Payment Method');
-
-    expect(paymentText.elements()).toHaveLength(0);
-  });
-
-  it('should not render billing history section', () => {
-    render(<LocationSettingsPage />);
-
-    const billingText = page.getByText('Billing History');
-
-    expect(billingText.elements()).toHaveLength(0);
-  });
-
-  it('should not render location dropdown selector', () => {
-    render(<LocationSettingsPage />);
-
-    // Check that there's no dropdown/select for location
-    const selectElements = page.getByRole('combobox');
-
-    expect(selectElements.elements()).toHaveLength(0);
-  });
-
-  it('should close modal when cancel is clicked', async () => {
-    render(<LocationSettingsPage />);
-
-    // Open the modal
     const editButton = page.getByRole('button', { name: /edit/i });
     await userEvent.click(editButton.element());
 
-    // Verify modal is open
     expect(page.getByText('Edit Location Information')).toBeDefined();
 
-    // Click cancel
     const cancelButton = page.getByRole('button', { name: /cancel/i });
     await userEvent.click(cancelButton.element());
 
-    // Verify modal is closed - the dialog content should not be visible
-    const modalTitle = page.getByText('Edit Location Information');
-
-    expect(modalTitle.elements()).toHaveLength(0);
+    expect(page.getByText('Edit Location Information').elements()).toHaveLength(0);
   });
 
-  it('should update location info after saving in modal', async () => {
+  it('calls updateLocation and refetches when saving in the modal', async () => {
     render(<LocationSettingsPage />);
 
-    // Open the modal
     const editButton = page.getByRole('button', { name: /edit/i });
     await userEvent.click(editButton.element());
 
-    // Find and update the address input
     const addressInput = page.getByPlaceholder('Enter address');
     await userEvent.clear(addressInput.element());
     await userEvent.type(addressInput.element(), '456 New Street, Los Angeles, CA');
 
-    // Click save button
     const saveButton = page.getByRole('button', { name: /save changes/i });
     await userEvent.click(saveButton.element());
 
-    // Wait for modal to close and verify the updated address is displayed
     await vi.waitFor(() => {
-      expect(page.getByText('456 New Street, Los Angeles, CA')).toBeDefined();
+      expect(updateLocationMock).toHaveBeenCalledWith(expect.objectContaining({
+        address: '456 New Street, Los Angeles, CA',
+      }));
     });
+
+    expect(refetchMock).toHaveBeenCalled();
   });
 
-  it('should have proper accessibility for edit button', () => {
+  it('shows a dash when the address has not been set yet', () => {
+    hookState = {
+      location: { name: null, address: null, phone: null, email: null },
+      loading: false,
+    };
+
+    render(<LocationSettingsPage />);
+
+    expect(page.getByText('Address:')).toBeDefined();
+    // Three dashes show up — one each for address, phone, email. We just check that at least one exists.
+    expect(page.getByText('-').elements().length).toBeGreaterThan(0);
+  });
+
+  it('has proper accessibility on the edit button', () => {
     render(<LocationSettingsPage />);
 
     const editButton = page.getByRole('button', { name: /edit location information/i });

--- a/src/features/settings/LocationSettingsPage.tsx
+++ b/src/features/settings/LocationSettingsPage.tsx
@@ -6,67 +6,64 @@ import { useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useOrganizationLocation } from '@/hooks/useOrganizationLocation';
+import { client } from '@/libs/Orpc';
 import { EditLocationModal } from './EditLocationModal';
 
-type LocationData = {
-  id: string;
+type LocationFormData = {
   name: string;
   address: string;
   phone: string;
   email: string;
 };
 
-const mockLocation: LocationData = {
-  id: 'downtown-hq',
-  name: 'Downtown HQ',
-  address: '123 Main St. San Francisco. CA',
-  phone: '(415) 555-0123',
-  email: 'downtown@example.com',
-};
-
 export function LocationSettingsPage() {
   const t = useTranslations('LocationSettings');
+  const { location, loading, error, refetch } = useOrganizationLocation();
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
-  const [location, setLocation] = useState<LocationData>(mockLocation);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
-  const handleSaveLocation = (data: {
-    name: string;
-    address: string;
-    phone: string;
-    email: string;
-  }) => {
-    setLocation(prev => ({
-      ...prev,
-      name: data.name,
-      address: data.address,
-      phone: data.phone,
-      email: data.email,
-    }));
-    setIsEditModalOpen(false);
+  const handleSaveLocation = async (data: LocationFormData) => {
+    setSaveError(null);
+    try {
+      await client.organization.updateLocation(data);
+      await refetch();
+      setIsEditModalOpen(false);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to save location');
+    }
   };
 
   return (
     <div className="space-y-6">
-      {/* Header */}
       <div>
         <h1 className="text-3xl font-bold text-foreground">{t('title')}</h1>
       </div>
 
-      {/* Location Information Card */}
       <Card className="relative p-6">
         <h3 className="text-lg font-semibold text-foreground">{t('location_title')}</h3>
+        {error && (
+          <p className="mt-2 text-sm text-destructive">{error}</p>
+        )}
         <div className="mt-4 space-y-4">
           <div>
             <label className="text-sm text-muted-foreground">{t('address_label')}</label>
-            <p className="mt-1 text-foreground">{location.address}</p>
+            {loading
+              ? <Skeleton className="mt-1 h-5 w-64" />
+              : <p className="mt-1 text-foreground">{location.address || '-'}</p>}
           </div>
           <div>
             <label className="text-sm text-muted-foreground">{t('phone_label')}</label>
-            <p className="mt-1 text-foreground">{location.phone}</p>
+            {loading
+              ? <Skeleton className="mt-1 h-5 w-40" />
+              : <p className="mt-1 text-foreground">{location.phone || '-'}</p>}
           </div>
           <div>
             <label className="text-sm text-muted-foreground">{t('email_label')}</label>
-            <p className="mt-1 text-foreground">{location.email}</p>
+            {loading
+              ? <Skeleton className="mt-1 h-5 w-56" />
+              : <p className="mt-1 text-foreground">{location.email || '-'}</p>}
           </div>
           <div>
             <label className="text-sm text-muted-foreground">{t('status_label')}</label>
@@ -76,7 +73,6 @@ export function LocationSettingsPage() {
           </div>
         </div>
 
-        {/* Edit Button - Bottom Right */}
         <div className="mt-6 flex justify-end">
           <Button
             variant="outline"
@@ -84,21 +80,25 @@ export function LocationSettingsPage() {
             onClick={() => setIsEditModalOpen(true)}
             aria-label="Edit location information"
             title="Edit location information"
+            disabled={loading}
           >
             <Edit className="h-4 w-4" />
           </Button>
         </div>
       </Card>
 
-      {/* Edit Location Modal */}
       <EditLocationModal
         isOpen={isEditModalOpen}
-        onClose={() => setIsEditModalOpen(false)}
-        name={location.name}
-        address={location.address}
-        phone={location.phone}
-        email={location.email}
+        onClose={() => {
+          setIsEditModalOpen(false);
+          setSaveError(null);
+        }}
+        name={location.name ?? ''}
+        address={location.address ?? ''}
+        phone={location.phone ?? ''}
+        email={location.email ?? ''}
         onSave={handleSaveLocation}
+        errorMessage={saveError}
       />
     </div>
   );

--- a/src/hooks/useOrganizationLocation.ts
+++ b/src/hooks/useOrganizationLocation.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useState } from 'react';
+import { client } from '@/libs/Orpc';
+
+export type OrganizationLocation = {
+  name: string | null;
+  address: string | null;
+  phone: string | null;
+  email: string | null;
+};
+
+const EMPTY_LOCATION: OrganizationLocation = {
+  name: null,
+  address: null,
+  phone: null,
+  email: null,
+};
+
+export function useOrganizationLocation() {
+  const [location, setLocation] = useState<OrganizationLocation>(EMPTY_LOCATION);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchLocation = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await client.organization.getLocation();
+      setLocation(result.location);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load location');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchLocation();
+  }, [fetchLocation]);
+
+  return { location, loading, error, refetch: fetchLocation };
+}

--- a/src/models/Schema.ts
+++ b/src/models/Schema.ts
@@ -41,6 +41,10 @@ export const organizationSchema = pgTable(
       { mode: 'number' },
     ),
     iqproPaymentMethodId: text('iqpro_payment_method_id'),
+    locationName: text('location_name'),
+    locationAddress: text('location_address'),
+    locationPhone: text('location_phone'),
+    locationEmail: text('location_email'),
     updatedAt: timestamp('updated_at', { mode: 'date' })
       .defaultNow()
       .$onUpdate(() => new Date())

--- a/src/routers/Coupons.test.ts
+++ b/src/routers/Coupons.test.ts
@@ -15,6 +15,7 @@ vi.mock('@/services/CouponsService', async () => {
     createCoupon: vi.fn(),
     updateCoupon: vi.fn(),
     deleteCoupon: vi.fn(),
+    getOrganizationTotalSavings: vi.fn(),
   };
 });
 
@@ -192,5 +193,37 @@ describe('Coupons Router mutations', () => {
 
       await expect(callHandler(remove, { id: 'cpn-1' })).rejects.toBeInstanceOf(ORPCError);
     });
+  });
+});
+
+describe('Coupons Router getTotalSavings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the org total savings under ACADEMY_OWNER guard', async () => {
+    const { guardRole } = await import('./AuthGuards');
+    const { getOrganizationTotalSavings } = await import('@/services/CouponsService');
+    vi.mocked(guardRole).mockResolvedValue(academyOwnerContext);
+    vi.mocked(getOrganizationTotalSavings).mockResolvedValue(425.5);
+
+    const { getTotalSavings } = await import('./Coupons');
+    const result = await callHandler(getTotalSavings);
+
+    expect(guardRole).toHaveBeenCalledWith(ORG_ROLE.ACADEMY_OWNER);
+    expect(getOrganizationTotalSavings).toHaveBeenCalledWith('org-1');
+    expect(result).toEqual({ totalSavings: 425.5 });
+  });
+
+  it('returns zero when there are no redemptions', async () => {
+    const { guardRole } = await import('./AuthGuards');
+    const { getOrganizationTotalSavings } = await import('@/services/CouponsService');
+    vi.mocked(guardRole).mockResolvedValue(academyOwnerContext);
+    vi.mocked(getOrganizationTotalSavings).mockResolvedValue(0);
+
+    const { getTotalSavings } = await import('./Coupons');
+    const result = await callHandler(getTotalSavings);
+
+    expect(result).toEqual({ totalSavings: 0 });
   });
 });

--- a/src/routers/Coupons.ts
+++ b/src/routers/Coupons.ts
@@ -7,6 +7,7 @@ import {
   deleteCoupon,
   getActiveCoupons,
   getOrganizationCoupons,
+  getOrganizationTotalSavings,
   updateCoupon,
 } from '@/services/CouponsService';
 import { AUDIT_ACTION, AUDIT_ENTITY_TYPE } from '@/types/Audit';
@@ -32,6 +33,14 @@ export const listActive = os.handler(async () => {
   const coupons = await getActiveCoupons(orgId);
 
   return { coupons };
+});
+
+export const getTotalSavings = os.handler(async () => {
+  const { orgId } = await guardRole(ORG_ROLE.ACADEMY_OWNER);
+
+  const totalSavings = await getOrganizationTotalSavings(orgId);
+
+  return { totalSavings };
 });
 
 export const create = os

--- a/src/routers/Organization.test.ts
+++ b/src/routers/Organization.test.ts
@@ -1,0 +1,108 @@
+import type { AuditContext } from '@/types/Audit';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AUDIT_ACTION, AUDIT_ENTITY_TYPE } from '@/types/Audit';
+import { ORG_ROLE } from '@/types/Auth';
+
+vi.mock('@/libs/DB', () => ({ db: {} }));
+vi.mock('./AuthGuards', () => ({ guardRole: vi.fn() }));
+vi.mock('@/services/AuditService', () => ({ audit: vi.fn() }));
+vi.mock('@/services/OrganizationService', async () => {
+  const actual = await vi.importActual<typeof import('@/services/OrganizationService')>('@/services/OrganizationService');
+  return {
+    ...actual,
+    getOrganizationLocation: vi.fn(),
+    updateOrganizationLocation: vi.fn(),
+  };
+});
+
+const academyOwnerContext: AuditContext = {
+  userId: 'user-1',
+  orgId: 'org-1',
+  role: ORG_ROLE.ACADEMY_OWNER,
+};
+const frontDeskContext: AuditContext = {
+  userId: 'user-1',
+  orgId: 'org-1',
+  role: ORG_ROLE.FRONT_DESK,
+};
+
+function callHandler(handler: unknown, input?: unknown) {
+  const h = handler as { '~orpc': { handler: (args: Record<string, unknown>) => unknown } };
+  return h['~orpc'].handler({ input, context: undefined, errors: undefined });
+}
+
+const fakeLocation = {
+  name: 'Main Dojo',
+  address: '500 Market St',
+  phone: '555-0100',
+  email: 'hello@dojo.test',
+};
+
+const validUpdateInput = {
+  name: 'Main Dojo',
+  address: '500 Market St',
+  phone: '555-0100',
+  email: 'hello@dojo.test',
+};
+
+describe('Organization Router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getLocation', () => {
+    it('returns the persisted location for FRONT_DESK or higher', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { getOrganizationLocation } = await import('@/services/OrganizationService');
+      vi.mocked(guardRole).mockResolvedValue(frontDeskContext);
+      vi.mocked(getOrganizationLocation).mockResolvedValue(fakeLocation);
+
+      const { getLocation } = await import('./Organization');
+      const result = await callHandler(getLocation);
+
+      expect(guardRole).toHaveBeenCalledWith(ORG_ROLE.FRONT_DESK);
+      expect(result).toEqual({ location: fakeLocation });
+    });
+  });
+
+  describe('updateLocation', () => {
+    it('persists the location and emits a success audit', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { updateOrganizationLocation } = await import('@/services/OrganizationService');
+      const { audit } = await import('@/services/AuditService');
+      vi.mocked(guardRole).mockResolvedValue(academyOwnerContext);
+      vi.mocked(updateOrganizationLocation).mockResolvedValue(fakeLocation);
+
+      const { updateLocation } = await import('./Organization');
+      const result = await callHandler(updateLocation, validUpdateInput);
+
+      expect(guardRole).toHaveBeenCalledWith(ORG_ROLE.ACADEMY_OWNER);
+      expect(audit).toHaveBeenCalledWith(
+        academyOwnerContext,
+        AUDIT_ACTION.ORGANIZATION_LOCATION_UPDATE,
+        AUDIT_ENTITY_TYPE.ORGANIZATION,
+        expect.objectContaining({ entityId: 'org-1', status: 'success' }),
+      );
+      expect(result).toEqual({ location: fakeLocation });
+    });
+
+    it('emits a failure audit and rethrows when persistence fails', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { updateOrganizationLocation } = await import('@/services/OrganizationService');
+      const { audit } = await import('@/services/AuditService');
+      vi.mocked(guardRole).mockResolvedValue(academyOwnerContext);
+      vi.mocked(updateOrganizationLocation).mockRejectedValue(new Error('db down'));
+
+      const { updateLocation } = await import('./Organization');
+
+      await expect(callHandler(updateLocation, validUpdateInput)).rejects.toThrow('db down');
+      expect(audit).toHaveBeenCalledWith(
+        academyOwnerContext,
+        AUDIT_ACTION.ORGANIZATION_LOCATION_UPDATE,
+        AUDIT_ENTITY_TYPE.ORGANIZATION,
+        expect.objectContaining({ entityId: 'org-1', status: 'failure', error: 'db down' }),
+      );
+    });
+  });
+});

--- a/src/routers/Organization.ts
+++ b/src/routers/Organization.ts
@@ -1,0 +1,50 @@
+import { os } from '@orpc/server';
+import { audit } from '@/services/AuditService';
+import {
+  getOrganizationLocation,
+  updateOrganizationLocation,
+} from '@/services/OrganizationService';
+import { AUDIT_ACTION, AUDIT_ENTITY_TYPE } from '@/types/Audit';
+import { ORG_ROLE } from '@/types/Auth';
+import { UpdateLocationValidation } from '@/validations/OrganizationValidation';
+import { guardRole } from './AuthGuards';
+
+export const getLocation = os.handler(async () => {
+  const { orgId } = await guardRole(ORG_ROLE.FRONT_DESK);
+  const location = await getOrganizationLocation(orgId);
+  return { location };
+});
+
+export const updateLocation = os
+  .input(UpdateLocationValidation)
+  .handler(async ({ input }) => {
+    const context = await guardRole(ORG_ROLE.ACADEMY_OWNER);
+
+    try {
+      const location = await updateOrganizationLocation(context.orgId, input);
+
+      await audit(
+        context,
+        AUDIT_ACTION.ORGANIZATION_LOCATION_UPDATE,
+        AUDIT_ENTITY_TYPE.ORGANIZATION,
+        {
+          entityId: context.orgId,
+          status: 'success',
+        },
+      );
+
+      return { location };
+    } catch (error) {
+      await audit(
+        context,
+        AUDIT_ACTION.ORGANIZATION_LOCATION_UPDATE,
+        AUDIT_ENTITY_TYPE.ORGANIZATION,
+        {
+          entityId: context.orgId,
+          status: 'failure',
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+      );
+      throw error;
+    }
+  });

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -18,13 +18,14 @@ import {
   variantUpdate,
 } from './Catalog';
 import { tags as classTags, create as createClass, list as listClasses, remove as removeClass, removeException as removeClassException, update as updateClass, upsertException as upsertClassException } from './Classes';
-import { create as createCoupon, listActive as listActiveCoupons, list as listCoupons, remove as removeCoupon, update as updateCoupon } from './Coupons';
+import { create as createCoupon, getTotalSavings as getCouponTotalSavings, listActive as listActiveCoupons, list as listCoupons, remove as removeCoupon, update as updateCoupon } from './Coupons';
 import { earningsChart, financialStats, memberAverageChart, membershipStats } from './Dashboard';
 import { create as createEvent, list as listEvents, remove as removeEvent, update as updateEvent } from './Events';
 import { addMembership, changeMembership, create as createMember, getHOHForMember, getHOHPaymentMethods, linkFamily, listAllMembershipPlans, listFamily, listMembershipPlans, listMemberTransactions, listPaymentMethods, removeFullyMember, remove as removeMember, restore as restoreMember, searchHOH, sendConfirmationEmail, unlinkFamily, updateLastAccessed, update as updateMember, updateContactInfo as updateMemberContactInfo, updatePhoto as updateMemberPhoto, updateMemberType } from './Member';
 import { list as listMembers } from './Members';
 import { create as createMembershipPlan, remove as removeMembershipPlan, update as updateMembershipPlan } from './MembershipPlans';
 import { create as createNoteHandler, list as listNotes, remove as removeNoteHandler, update as updateNoteHandler } from './Notes';
+import { getLocation as getOrganizationLocation, updateLocation as updateOrganizationLocation } from './Organization';
 import { getTokenizationIframeConfig, processPayment, registerPaymentMethod } from './Payment';
 import { create as createProgram, list as listPrograms, remove as removeProgram, update as updateProgram } from './Programs';
 import { chartData as reportChartData, currentValues as reportCurrentValues, insights as reportInsights } from './Reports';
@@ -137,6 +138,7 @@ export const router = {
     create: createCoupon,
     update: updateCoupon,
     remove: removeCoupon,
+    getTotalSavings: getCouponTotalSavings,
   },
   membershipPlans: {
     create: createMembershipPlan,
@@ -154,6 +156,10 @@ export const router = {
     create: createNoteHandler,
     update: updateNoteHandler,
     remove: removeNoteHandler,
+  },
+  organization: {
+    getLocation: getOrganizationLocation,
+    updateLocation: updateOrganizationLocation,
   },
   catalog: {
     list: listCatalogItems,

--- a/src/services/CouponsService.test.ts
+++ b/src/services/CouponsService.test.ts
@@ -19,6 +19,7 @@ vi.mock('@/models/Schema', () => ({
   },
   couponUsageSchema: {
     couponId: 'coupon_id',
+    discountApplied: 'discount_applied',
   },
 }));
 
@@ -284,5 +285,60 @@ describe('CouponsService.deleteCoupon', () => {
 
     await expect(deleteCoupon('cpn-1', 'org-1')).rejects.toBeInstanceOf(CouponHasUsagesError);
     expect(dbMock.delete).not.toHaveBeenCalled();
+  });
+});
+
+describe('CouponsService.getOrganizationTotalSavings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the summed discountApplied joined through coupon for the org', async () => {
+    const where = vi.fn(() => Promise.resolve([{ total: 137.5 }]));
+    const innerJoin = vi.fn(() => ({ where }));
+    const from = vi.fn(() => ({ innerJoin }));
+    dbMock.select.mockReturnValueOnce({ from });
+
+    const { getOrganizationTotalSavings } = await import('./CouponsService');
+    const total = await getOrganizationTotalSavings('org-1');
+
+    expect(total).toBe(137.5);
+    expect(from).toHaveBeenCalled();
+    expect(innerJoin).toHaveBeenCalled();
+    expect(where).toHaveBeenCalled();
+  });
+
+  it('returns 0 when there are no redemptions (COALESCE result)', async () => {
+    const where = vi.fn(() => Promise.resolve([{ total: 0 }]));
+    dbMock.select.mockReturnValueOnce({
+      from: () => ({ innerJoin: () => ({ where }) }),
+    });
+
+    const { getOrganizationTotalSavings } = await import('./CouponsService');
+    const total = await getOrganizationTotalSavings('org-empty');
+
+    expect(total).toBe(0);
+  });
+
+  it('returns 0 when the query returns an empty result', async () => {
+    dbMock.select.mockReturnValueOnce({
+      from: () => ({ innerJoin: () => ({ where: () => Promise.resolve([]) }) }),
+    });
+
+    const { getOrganizationTotalSavings } = await import('./CouponsService');
+    const total = await getOrganizationTotalSavings('org-empty');
+
+    expect(total).toBe(0);
+  });
+
+  it('coerces numeric strings to numbers (postgres SUM can return text)', async () => {
+    dbMock.select.mockReturnValueOnce({
+      from: () => ({ innerJoin: () => ({ where: () => Promise.resolve([{ total: '99.99' }]) }) }),
+    });
+
+    const { getOrganizationTotalSavings } = await import('./CouponsService');
+    const total = await getOrganizationTotalSavings('org-1');
+
+    expect(total).toBe(99.99);
   });
 });

--- a/src/services/CouponsService.ts
+++ b/src/services/CouponsService.ts
@@ -295,3 +295,18 @@ export async function deleteCoupon(couponId: string, organizationId: string): Pr
     .where(and(eq(couponSchema.id, couponId), eq(couponSchema.organizationId, organizationId)));
   return true;
 }
+
+/**
+ * Sum of every coupon redemption's actual discount within an organization.
+ * Joins through `coupon` because `coupon_usage` has no organizationId.
+ */
+export async function getOrganizationTotalSavings(organizationId: string): Promise<number> {
+  const [row] = await db
+    .select({
+      total: sql<number>`COALESCE(SUM(${couponUsageSchema.discountApplied}), 0)`,
+    })
+    .from(couponUsageSchema)
+    .innerJoin(couponSchema, eq(couponUsageSchema.couponId, couponSchema.id))
+    .where(eq(couponSchema.organizationId, organizationId));
+  return Number(row?.total ?? 0);
+}

--- a/src/services/OrganizationService.test.ts
+++ b/src/services/OrganizationService.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMock = {
+  query: {
+    organizationSchema: {
+      findFirst: vi.fn(),
+    },
+  },
+  insert: vi.fn(),
+};
+
+vi.mock('@/libs/DB', () => ({ db: dbMock }));
+
+vi.mock('@/models/Schema', () => ({
+  organizationSchema: {
+    id: 'id',
+  },
+}));
+
+describe('OrganizationService.location', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getOrganizationLocation', () => {
+    it('returns the persisted location values', async () => {
+      vi.mocked(dbMock.query.organizationSchema.findFirst).mockResolvedValueOnce({
+        locationName: 'Main Dojo',
+        locationAddress: '500 Market St',
+        locationPhone: '555-0100',
+        locationEmail: 'hello@dojo.test',
+      });
+
+      const { getOrganizationLocation } = await import('./OrganizationService');
+      const result = await getOrganizationLocation('org-1');
+
+      expect(result).toEqual({
+        name: 'Main Dojo',
+        address: '500 Market St',
+        phone: '555-0100',
+        email: 'hello@dojo.test',
+      });
+    });
+
+    it('returns nulls when the org has no row yet', async () => {
+      vi.mocked(dbMock.query.organizationSchema.findFirst).mockResolvedValueOnce(undefined);
+
+      const { getOrganizationLocation } = await import('./OrganizationService');
+      const result = await getOrganizationLocation('org-empty');
+
+      expect(result).toEqual({ name: null, address: null, phone: null, email: null });
+    });
+
+    it('returns nulls when individual fields are missing', async () => {
+      vi.mocked(dbMock.query.organizationSchema.findFirst).mockResolvedValueOnce({
+        locationName: null,
+        locationAddress: null,
+        locationPhone: null,
+        locationEmail: null,
+      });
+
+      const { getOrganizationLocation } = await import('./OrganizationService');
+      const result = await getOrganizationLocation('org-2');
+
+      expect(result).toEqual({ name: null, address: null, phone: null, email: null });
+    });
+  });
+
+  describe('updateOrganizationLocation', () => {
+    it('upserts the location and returns the input', async () => {
+      const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+      const values = vi.fn().mockReturnValue({ onConflictDoUpdate });
+      dbMock.insert.mockReturnValue({ values });
+
+      const { updateOrganizationLocation } = await import('./OrganizationService');
+      const result = await updateOrganizationLocation('org-1', {
+        name: 'New Name',
+        address: '1 New Way',
+        phone: '555-9999',
+        email: 'new@dojo.test',
+      });
+
+      expect(values).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'org-1',
+        locationName: 'New Name',
+        locationAddress: '1 New Way',
+        locationPhone: '555-9999',
+        locationEmail: 'new@dojo.test',
+      }));
+      expect(onConflictDoUpdate).toHaveBeenCalled();
+      expect(result).toEqual({
+        name: 'New Name',
+        address: '1 New Way',
+        phone: '555-9999',
+        email: 'new@dojo.test',
+      });
+    });
+  });
+});

--- a/src/services/OrganizationService.ts
+++ b/src/services/OrganizationService.ts
@@ -53,3 +53,60 @@ export const updateStripeSubscription = (
     })
     .where(eq(organizationSchema.stripeCustomerId, customerId));
 };
+
+export type OrganizationLocation = {
+  name: string | null;
+  address: string | null;
+  phone: string | null;
+  email: string | null;
+};
+
+export const getOrganizationLocation = async (
+  orgId: string,
+): Promise<OrganizationLocation> => {
+  const row = await db.query.organizationSchema.findFirst({
+    where: eq(organizationSchema.id, orgId),
+    columns: {
+      locationName: true,
+      locationAddress: true,
+      locationPhone: true,
+      locationEmail: true,
+    },
+  });
+  return {
+    name: row?.locationName ?? null,
+    address: row?.locationAddress ?? null,
+    phone: row?.locationPhone ?? null,
+    email: row?.locationEmail ?? null,
+  };
+};
+
+export const updateOrganizationLocation = async (
+  orgId: string,
+  input: { name: string; address: string; phone: string; email: string },
+): Promise<OrganizationLocation> => {
+  await db
+    .insert(organizationSchema)
+    .values({
+      id: orgId,
+      locationName: input.name,
+      locationAddress: input.address,
+      locationPhone: input.phone,
+      locationEmail: input.email,
+    })
+    .onConflictDoUpdate({
+      target: organizationSchema.id,
+      set: {
+        locationName: input.name,
+        locationAddress: input.address,
+        locationPhone: input.phone,
+        locationEmail: input.email,
+      },
+    });
+  return {
+    name: input.name,
+    address: input.address,
+    phone: input.phone,
+    email: input.email,
+  };
+};

--- a/src/types/Audit.test.ts
+++ b/src/types/Audit.test.ts
@@ -25,8 +25,8 @@ describe('Audit Types', () => {
       // + 3 merge field + 1 payment + 1 payment method register + 1 family member link
       // + 1 family member unlink + 1 member convert + 3 saas subscription
       // + 3 note (create + update + delete) + 3 staff (invite + update + remove)
-      // + 3 role (create + update + delete) = 87
-      expect(actionCount).toBe(87);
+      // + 3 role (create + update + delete) + 1 organization location update = 88
+      expect(actionCount).toBe(88);
     });
   });
 

--- a/src/types/Audit.ts
+++ b/src/types/Audit.ts
@@ -123,6 +123,9 @@ export const AUDIT_ACTION = {
   SAAS_SUBSCRIPTION_CHANGE: 'saasSubscription.change',
   SAAS_SUBSCRIPTION_CANCEL: 'saasSubscription.cancel',
 
+  // Organization operations
+  ORGANIZATION_LOCATION_UPDATE: 'organizationLocation.update',
+
   // Note operations
   NOTE_CREATE: 'note.create',
   NOTE_UPDATE: 'note.update',

--- a/src/validations/OrganizationValidation.test.ts
+++ b/src/validations/OrganizationValidation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { UpdateLocationValidation } from './OrganizationValidation';
+
+describe('UpdateLocationValidation', () => {
+  const valid = {
+    name: 'Main Dojo',
+    address: '123 Main St, City, State',
+    phone: '(555) 555-1234',
+    email: 'hello@dojo.test',
+  };
+
+  it('accepts a valid payload', () => {
+    expect(UpdateLocationValidation.parse(valid)).toEqual(valid);
+  });
+
+  it('rejects empty name', () => {
+    expect(() => UpdateLocationValidation.parse({ ...valid, name: '' })).toThrow();
+  });
+
+  it('rejects empty address', () => {
+    expect(() => UpdateLocationValidation.parse({ ...valid, address: '' })).toThrow();
+  });
+
+  it('rejects empty phone', () => {
+    expect(() => UpdateLocationValidation.parse({ ...valid, phone: '' })).toThrow();
+  });
+
+  it('rejects malformed email', () => {
+    expect(() => UpdateLocationValidation.parse({ ...valid, email: 'not-an-email' })).toThrow();
+  });
+
+  it('rejects name longer than 120 chars', () => {
+    expect(() => UpdateLocationValidation.parse({ ...valid, name: 'x'.repeat(121) })).toThrow();
+  });
+
+  it('rejects address longer than 500 chars', () => {
+    expect(() => UpdateLocationValidation.parse({ ...valid, address: 'x'.repeat(501) })).toThrow();
+  });
+
+  it('rejects phone longer than 40 chars', () => {
+    expect(() => UpdateLocationValidation.parse({ ...valid, phone: 'x'.repeat(41) })).toThrow();
+  });
+});

--- a/src/validations/OrganizationValidation.ts
+++ b/src/validations/OrganizationValidation.ts
@@ -1,0 +1,10 @@
+import * as z from 'zod';
+
+export const UpdateLocationValidation = z.object({
+  name: z.string().min(1).max(120),
+  address: z.string().min(1).max(500),
+  phone: z.string().min(1).max(40),
+  email: z.string().email(),
+});
+
+export type UpdateLocationInput = z.infer<typeof UpdateLocationValidation>;


### PR DESCRIPTION
## Summary
- Replaces mock location data in settings with real per-org persistence (`organization.location_*` columns), threaded through class and event cards
- Adds `coupons.getTotalSavings` endpoint and renders the actual sum on the marketing dashboard ($0.00 when empty, was hardcoded `N/A`)
- Adds `Organization` router (`getLocation` / `updateLocation`) with `ORGANIZATION_LOCATION_UPDATE` audit action

## Schema
Adds four nullable text columns to `organization`: `location_name`, `location_address`, `location_phone`, `location_email`. Edited the existing `0000_baseline.sql` and snapshot — no new migration file. **Preview and Production DBs were ALTERed manually**; fresh DBs pick up the columns from the updated baseline.

## Notes
- All four columns nullable — existing orgs see empty form on first visit; class/event cards fall back to empty string until an admin fills in the address
- HOH skip-membership flow and other unrelated paths unchanged
- 22 new tests added; `npm run lint && check:types && check:deps && check:i18n && test` all clean (4362 tests pass)

## Test plan
- [ ] `/dashboard/location-settings`: save form → reload → values persist
- [ ] `/dashboard/classes`: class and event cards show the saved address (not "Downtown HQ")
- [ ] `/dashboard/marketing`: Total Savings shows real dollar amount with redemptions, `$0.00` for a fresh org
- [ ] Audit log: `ORGANIZATION_LOCATION_UPDATE` event fires on save
- [ ] Auth: FRONT_DESK can read location, only ACADEMY_OWNER+ can write