### PR TITLE
feat(payment): enable per-location payment settings

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -156,6 +156,8 @@ docs/                      # Documentation
 | `/dashboard/preferences` | `preferences/page.tsx` | User preferences |
 | `/dashboard/security` | `security/page.tsx` | Security settings |
 | `/dashboard/location-settings` | `location-settings/page.tsx` | Per-org location settings (name, address, phone, email, tax rate) — backed by `organization.location*` columns |
+| `/dashboard/payment-settings` | `payment-settings/page.tsx` | Per-org IQPro merchant credentials (clientId, clientSecret, gatewayId). ADMIN-only |
+| `/dashboard/platform-settings` | `platform-settings/page.tsx` | Platform IQPro credentials for SaaS billing — backed by singleton `platform_config` row. Super-admin only |
 
 ### Auth Routes
 
@@ -369,9 +371,33 @@ npm run stripe:setup-price # Create test prices
 
 **Purpose:** Processes member-level payments (one-time charges and recurring autopay subscriptions) and organization-level SaaS subscriptions. Stripe remains as a legacy fallback for org-level billing only.
 
+**Per-org configuration (production multi-tenancy):**
+
+IQPro credentials are split across two scopes:
+
+| Field | Scope | Storage |
+|-------|-------|---------|
+| `clientId`, `clientSecret`, `gatewayId` | **per-org** (customer payments) | `organization.iqpro_config_*` columns. `clientSecret` is AES-256-GCM encrypted at rest. Set via the per-org Payment Settings page (ADMIN-only). |
+| `clientId`, `clientSecret`, `gatewayId` | **platform** (SaaS billing) | Singleton `platform_config` row (`id = 'singleton'` enforced by CHECK constraint). Encrypted. Set via Platform Settings (super-admin only). |
+| `scope`, `oauthUrl`, `baseUrl`, `webhookSecret` | **platform-wide** | Env vars (`IQPRO_SCOPE`, `IQPRO_OAUTH_URL`, `IQPRO_BASE_URL`, `IQPRO_WEBHOOK_SECRET`). Same for every dojo. |
+
+Customer-facing flows resolve config via `resolveIQProConfig(orgId)`; SaaS-billing flows use `resolvePlatformIQProConfig()`. Both resolvers fall back to the legacy `IQPRO_CLIENT_ID/IQPRO_CLIENT_SECRET/IQPRO_GATEWAY_ID` env vars per field when the DB column is null, so single-tenant deployments keep working unchanged.
+
+The webhook handler at `src/app/[locale]/webhook/iqpro/route.ts` does only DB writes (no callbacks into IQPro), so it doesn't need per-org config — the global `IQPRO_WEBHOOK_SECRET` validates every webhook and routing to the right org happens via subscription/transaction-ID DB lookup.
+
+**Migrating from env vars to DB-backed config:**
+
+1. Set `IQPRO_CONFIG_ENCRYPTION_KEY` (32 raw bytes, hex-encoded) on the deployment.
+2. For each org: ADMIN visits `/dashboard/payment-settings` and enters Client ID / Client Secret / Gateway ID (or run `src/scripts/backfillIQProConfig.ts --orgId=org_xxx` to copy the current env values into one org's DB row).
+3. For the platform's own SaaS-billing account: super admin visits `/dashboard/platform-settings` (or run `src/scripts/backfillPlatformIQProConfig.ts`).
+4. Once every org and the platform have their values in the DB, the `IQPRO_CLIENT_ID` / `IQPRO_CLIENT_SECRET` / `IQPRO_GATEWAY_ID` env vars can be removed (keep `IQPRO_SCOPE` / `IQPRO_OAUTH_URL` / `IQPRO_BASE_URL` / `IQPRO_WEBHOOK_SECRET` — they're platform-wide).
+
+**OAuth token cache:** keyed by `clientId` (since `oauthUrl` and `scope` are global). Two orgs with different `clientId`s get two separate cached tokens — there's no cross-tenant leakage. Cap 100 entries; lazy eviction on access; oldest-by-expiry dropped on overflow.
+
 **Key Files:**
 - `src/libs/IQPro.ts` - REST helpers (`iqproPost`, `iqproGet`, `iqproPut`), OAuth token management, tokenization config endpoint, ACH tokenization (`tokenizeAch`), gateway processor lookup (`getGatewayProcessors`), server-authoritative fee calculation (`calculateTransactionFees`)
-- `src/services/PaymentProviderService.ts` - Provider-agnostic interface + factory; defines `FeeBreakdown`, `TransactionLineItem`, `TransactionBillingAddress` types
+- `src/services/IQProConfigService.ts` - Per-org + platform IQPro config resolver (DB → env fallback). `resolveIQProConfig(orgId)` for customer-facing payments; `resolvePlatformIQProConfig()` for SaaS billing. Decrypts `client_secret` from AES-GCM at-rest storage. 60s in-memory cache per scope; invalidated on update.
+- `src/services/PaymentProviderService.ts` - Provider-agnostic interface + factory; defines `FeeBreakdown`, `TransactionLineItem`, `TransactionBillingAddress` types. Every interface method now takes `config: IQProConfig` as its first arg so the provider hits the right merchant gateway per call.
 - `src/services/IQProPaymentService.ts` - IQPro implementation (REST). `createCustomer` returns `{ customerId, billingAddressId }` (the billing-address ID is fetched via `iqproGet` and forwarded into transaction payloads as `paymentMethod.customer.customerBillingAddressId` so the ACH processor can resolve the cardholder name). Card uses InsertCard schema with token + maskedCard BIN format; ACH uses `tokenizeAch` then InsertAch. `processPayment` builds the canonical `Sale` payload with `remit` (tax + paymentAdjustments), `address[]`, and `lineItems[]`. Sandbox certification errors on ACH (`"not a valid transaction for certification"`) are tolerated as `pendingsettlement → approved` so dev flows work.
 - `src/services/MemberPaymentService.ts` - Payment orchestration (customer → method → calculate fees → charge/subscription → DB). Tax state for fee calculation comes from `params.memberAddress.state`. For autopay: subscription is created **and** an immediate Sale charge runs for the first period (IQPro subscriptions don't auto-charge on creation). If the initial charge fails after subscription creation, the failure is surfaced and `iqproSubscriptionId` is NOT persisted on the membership — the IQPro subscription will exist but the local membership stays unactivated.
 - `src/services/SaasSubscriptionService.ts` - Org SaaS subscriptions via REST. Uses `iqproPost`/`iqproGet`/`iqproPut` for customer create, payment method, subscription create/get/update, and cancel.
@@ -642,7 +668,8 @@ await deleteUserWithOrganization();
 **Schema:** `src/models/Schema.ts`
 
 **Key Tables:**
-- `organization` - Multi-tenant orgs with Stripe IDs + IQPro SaaS subscription fields (iqproCustomerId, iqproSubscriptionId, iqproSubscriptionPlanId, iqproBillingCycle, iqproSubscriptionStatus, iqproCurrentPeriodEnd, iqproPaymentMethodId) + location settings (locationName, locationAddress, locationPhone, locationEmail — nullable, set via the location-settings page; `locationTaxRate` real defaulting to 0, applied to taxable transactions)
+- `organization` - Multi-tenant orgs with Stripe IDs + IQPro SaaS subscription fields (iqproCustomerId, iqproSubscriptionId, iqproSubscriptionPlanId, iqproBillingCycle, iqproSubscriptionStatus, iqproCurrentPeriodEnd, iqproPaymentMethodId) + location settings (locationName, locationAddress, locationPhone, locationEmail — nullable, set via the location-settings page; `locationTaxRate` real defaulting to 0, applied to taxable transactions) + per-org IQPro merchant credentials (iqproConfigClientId, iqproConfigClientSecretEncrypted, iqproConfigGatewayId — set via Payment Settings; `clientSecret` AES-GCM encrypted at rest)
+- `platform_config` - Singleton row (`id = 'singleton'` enforced by CHECK constraint) holding the platform's own IQPro credentials used for SaaS billing (iqproSaasClientId, iqproSaasClientSecretEncrypted, iqproSaasGatewayId). Set via Platform Settings (super admin only).
 - `member` - Member records with dateOfBirth, optional `clerkUserId` for kiosk auth, optional `iqproCustomerId`
 - `membership_plan` - Pricing tiers
 - `member_membership` - Member-plan associations with startDate, endDate, firstPaymentDate, nextPaymentDate, optional `iqproSubscriptionId`
@@ -899,15 +926,25 @@ NEXT_PUBLIC_BETTER_STACK_SOURCE_TOKEN
 NEXT_PUBLIC_BETTER_STACK_INGESTING_HOST
 ```
 
-**Optional (IQPro Member Payments):**
+**Optional (IQPro — platform-wide):**
 ```bash
-IQPRO_CLIENT_ID
-IQPRO_CLIENT_SECRET
+# These five are platform-wide (same IQPro environment for every dojo).
 IQPRO_SCOPE
 IQPRO_OAUTH_URL
 IQPRO_BASE_URL
-IQPRO_GATEWAY_ID
 IQPRO_WEBHOOK_SECRET
+IQPRO_CONFIG_ENCRYPTION_KEY  # 32 raw bytes, hex-encoded (64 chars). Required when any iqpro_config_*_enc column is populated.
+
+# These three are per-org / per-platform. Read at runtime from the
+# organization or platform_config row, with these env vars as a fallback for
+# orgs that haven't filled in Payment Settings yet (or for the platform's own
+# SaaS-billing IQPro account before super admin fills in Platform Settings).
+# Once you've migrated everything into the DB via Payment Settings + Platform
+# Settings, these env vars can be removed.
+IQPRO_CLIENT_ID
+IQPRO_CLIENT_SECRET
+IQPRO_GATEWAY_ID
+
 SERVICE_FEE_PCT=3.75     # Service fee % applied to EVERY transaction. Sent to IQPro as a ServiceFee paymentAdjustment (percentage, not flatAmount).
 # Note: Sales-tax % is per-organization (see Location Settings page → tax_rate).
 # It is stored in `organization.location_tax_rate` (default 0) and applied to TAXABLE
@@ -1051,6 +1088,10 @@ AUDIT_ACTION.SAAS_SUBSCRIPTION_CANCEL;
 
 // Organization operations
 AUDIT_ACTION.ORGANIZATION_LOCATION_UPDATE;
+
+// IQPro merchant configuration
+AUDIT_ACTION.IQPRO_CONFIG_UPDATE; // per-org Payment Settings
+AUDIT_ACTION.PLATFORM_IQPRO_CONFIG_UPDATE; // platform Platform Settings (super admin)
 
 // Family member operations
 AUDIT_ACTION.FAMILY_MEMBER_LINK;

--- a/migrations/0000_baseline.sql
+++ b/migrations/0000_baseline.sql
@@ -392,8 +392,20 @@ CREATE TABLE "organization" (
 	"location_phone" text,
 	"location_email" text,
 	"location_tax_rate" real DEFAULT 0 NOT NULL,
+	"iqpro_config_client_id" text,
+	"iqpro_config_client_secret_enc" text,
+	"iqpro_config_gateway_id" text,
 	"updated_at" timestamp DEFAULT now() NOT NULL,
 	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "platform_config" (
+	"id" text PRIMARY KEY NOT NULL DEFAULT 'singleton',
+	"iqpro_saas_client_id" text,
+	"iqpro_saas_client_secret_enc" text,
+	"iqpro_saas_gateway_id" text,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "platform_config_singleton" CHECK ("id" = 'singleton')
 );
 --> statement-breakpoint
 CREATE TABLE "payment_method" (

--- a/migrations/meta/0000_snapshot.json
+++ b/migrations/meta/0000_snapshot.json
@@ -3718,6 +3718,24 @@
           "notNull": true,
           "default": 0
         },
+        "iqpro_config_client_id": {
+          "name": "iqpro_config_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iqpro_config_client_secret_enc": {
+          "name": "iqpro_config_client_secret_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iqpro_config_gateway_id": {
+          "name": "iqpro_config_gateway_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "updated_at": {
           "name": "updated_at",
           "type": "timestamp",
@@ -3770,6 +3788,56 @@
       "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_config": {
+      "name": "platform_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'singleton'"
+        },
+        "iqpro_saas_client_id": {
+          "name": "iqpro_saas_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iqpro_saas_client_secret_enc": {
+          "name": "iqpro_saas_client_secret_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iqpro_saas_gateway_id": {
+          "name": "iqpro_saas_gateway_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_config_singleton": {
+          "name": "platform_config_singleton",
+          "value": "\"id\" = 'singleton'"
+        }
+      },
       "isRLSEnabled": false
     },
     "public.payment_method": {

--- a/src/app/[locale]/(auth)/dashboard/location-settings/page.tsx
+++ b/src/app/[locale]/(auth)/dashboard/location-settings/page.tsx
@@ -1,9 +1,11 @@
+import { auth } from '@clerk/nextjs/server';
 import { LocationSettingsPage } from '@/features/settings/LocationSettingsPage';
 
 export default async function LocationSettingsRoute(props: {
   params: Promise<{ locale: string }>;
 }) {
   const { locale: _locale } = await props.params;
+  const { orgRole } = await auth();
 
-  return <LocationSettingsPage />;
+  return <LocationSettingsPage userRole={orgRole ?? undefined} />;
 }

--- a/src/app/[locale]/(auth)/dashboard/platform-settings/page.tsx
+++ b/src/app/[locale]/(auth)/dashboard/platform-settings/page.tsx
@@ -1,0 +1,17 @@
+import { auth } from '@clerk/nextjs/server';
+import { redirect } from 'next/navigation';
+import { PlatformSettingsPage } from '@/features/platform-settings/PlatformSettingsPage';
+import { isSuperAdmin } from '@/utils/SuperAdmins';
+
+export default async function PlatformSettingsRoute(props: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale: _locale } = await props.params;
+  const { sessionClaims } = await auth();
+  const username = (sessionClaims as Record<string, unknown> | null)?.username as string | undefined;
+  if (!isSuperAdmin(username)) {
+    redirect('/dashboard');
+  }
+
+  return <PlatformSettingsPage />;
+}

--- a/src/features/payment-settings/PaymentSettingsForm.test.tsx
+++ b/src/features/payment-settings/PaymentSettingsForm.test.tsx
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { page, userEvent } from 'vitest/browser';
+import { PaymentSettingsForm } from './PaymentSettingsForm';
+
+describe('PaymentSettingsForm', () => {
+  const mockOnSave = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the three IQPro credential fields', () => {
+    render(
+      <PaymentSettingsForm
+        title="IQPro Merchant Credentials"
+        description="desc"
+        initial={{ clientId: 'env-cid', gatewayId: 'env-gid', hasSecret: true, source: 'env' }}
+        loading={false}
+        saving={false}
+        errorMessage={null}
+        successMessage={null}
+        onSave={mockOnSave}
+      />,
+    );
+
+    expect(page.getByLabelText(/Client ID/i)).toBeDefined();
+    expect(page.getByLabelText(/Client Secret/i)).toBeDefined();
+    expect(page.getByLabelText(/Gateway ID/i)).toBeDefined();
+  });
+
+  it('shows a "Secret configured" badge when hasSecret is true', () => {
+    render(
+      <PaymentSettingsForm
+        title="t"
+        description="d"
+        initial={{ clientId: 'cid', gatewayId: 'gid', hasSecret: true, source: 'org' }}
+        loading={false}
+        saving={false}
+        errorMessage={null}
+        successMessage={null}
+        onSave={mockOnSave}
+      />,
+    );
+
+    expect(page.getByText(/Secret configured/i)).toBeDefined();
+  });
+
+  it('pre-fills clientId and gatewayId but NOT the secret', () => {
+    render(
+      <PaymentSettingsForm
+        title="t"
+        description="d"
+        initial={{ clientId: 'pre-cid', gatewayId: 'pre-gid', hasSecret: true, source: 'org' }}
+        loading={false}
+        saving={false}
+        errorMessage={null}
+        successMessage={null}
+        onSave={mockOnSave}
+      />,
+    );
+
+    expect(page.getByLabelText(/Client ID/i).element()).toHaveProperty('value', 'pre-cid');
+    expect(page.getByLabelText(/Gateway ID/i).element()).toHaveProperty('value', 'pre-gid');
+    expect(page.getByLabelText(/Client Secret/i).element()).toHaveProperty('value', '');
+  });
+
+  it('submitting without filling clientSecret omits it from the payload (means "keep")', async () => {
+    render(
+      <PaymentSettingsForm
+        title="t"
+        description="d"
+        initial={{ clientId: 'pre-cid', gatewayId: 'pre-gid', hasSecret: true, source: 'org' }}
+        loading={false}
+        saving={false}
+        errorMessage={null}
+        successMessage={null}
+        onSave={mockOnSave}
+      />,
+    );
+
+    await userEvent.click(page.getByRole('button', { name: /^Save$/i }));
+
+    expect(mockOnSave).toHaveBeenCalledWith({
+      clientId: 'pre-cid',
+      gatewayId: 'pre-gid',
+    });
+
+    const args = mockOnSave.mock.calls[0]![0] as Record<string, unknown>;
+
+    expect(args).not.toHaveProperty('clientSecret');
+  });
+
+  it('submitting with a clientSecret includes it in the payload', async () => {
+    render(
+      <PaymentSettingsForm
+        title="t"
+        description="d"
+        initial={{ clientId: 'cid', gatewayId: 'gid', hasSecret: false, source: 'env' }}
+        loading={false}
+        saving={false}
+        errorMessage={null}
+        successMessage={null}
+        onSave={mockOnSave}
+      />,
+    );
+
+    const secretInput = page.getByLabelText(/Client Secret/i);
+    await userEvent.type(secretInput, 'new-secret-shhh');
+    await userEvent.click(page.getByRole('button', { name: /^Save$/i }));
+
+    expect(mockOnSave).toHaveBeenCalledWith({
+      clientId: 'cid',
+      gatewayId: 'gid',
+      clientSecret: 'new-secret-shhh',
+    });
+  });
+
+  it('displays the error message when provided', () => {
+    render(
+      <PaymentSettingsForm
+        title="t"
+        description="d"
+        initial={null}
+        loading={false}
+        saving={false}
+        errorMessage="Encryption key missing"
+        successMessage={null}
+        onSave={mockOnSave}
+      />,
+    );
+
+    expect(page.getByText(/Encryption key missing/i)).toBeDefined();
+  });
+
+  it('disables submit while saving', () => {
+    render(
+      <PaymentSettingsForm
+        title="t"
+        description="d"
+        initial={{ clientId: 'cid', gatewayId: 'gid', hasSecret: true, source: 'org' }}
+        loading={false}
+        saving={true}
+        errorMessage={null}
+        successMessage={null}
+        onSave={mockOnSave}
+      />,
+    );
+
+    expect(page.getByRole('button', { name: /Saving/i }).element()).toHaveProperty('disabled', true);
+  });
+});

--- a/src/features/payment-settings/PaymentSettingsForm.tsx
+++ b/src/features/payment-settings/PaymentSettingsForm.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { useState } from 'react';
+import { Alert } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export type IQProConfigFormData = {
+  clientId: string;
+  clientSecret?: string;
+  gatewayId: string;
+};
+
+export type IQProConfigInitialData = {
+  clientId: string | null;
+  gatewayId: string | null;
+  hasSecret: boolean;
+  source: 'org' | 'env' | 'mixed' | 'platform';
+};
+
+type Props = {
+  title: string;
+  description: string;
+  initial: IQProConfigInitialData | null;
+  loading: boolean;
+  saving: boolean;
+  errorMessage: string | null;
+  successMessage: string | null;
+  onSave: (data: IQProConfigFormData) => Promise<void> | void;
+};
+
+export function PaymentSettingsForm({
+  title,
+  description,
+  initial,
+  loading,
+  saving,
+  errorMessage,
+  successMessage,
+  onSave,
+}: Props) {
+  // State is seeded from `initial` once. Parents that want the form to reflect
+  // a freshly-loaded value (e.g. after refetch) should re-mount via `key`.
+  const [clientId, setClientId] = useState(initial?.clientId ?? '');
+  const [clientSecret, setClientSecret] = useState('');
+  const [gatewayId, setGatewayId] = useState(initial?.gatewayId ?? '');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmedSecret = clientSecret.trim();
+    await onSave({
+      clientId: clientId.trim(),
+      gatewayId: gatewayId.trim(),
+      ...(trimmedSecret && { clientSecret: trimmedSecret }),
+    });
+    setClientSecret('');
+  };
+
+  const submitDisabled = saving || loading || !clientId.trim() || !gatewayId.trim();
+
+  return (
+    <Card className="p-6">
+      <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+      <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+
+      {initial && (
+        <div className="mt-4 flex items-center gap-2 text-sm">
+          <span className="text-muted-foreground">Currently loaded from:</span>
+          <Badge variant={initial.source === 'env' ? 'secondary' : 'default'}>
+            {initial.source}
+          </Badge>
+        </div>
+      )}
+
+      {errorMessage && (
+        <Alert variant="error" className="mt-4">
+          {errorMessage}
+        </Alert>
+      )}
+      {successMessage && (
+        <Alert variant="success" className="mt-4">{successMessage}</Alert>
+      )}
+
+      <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+        <div>
+          <Label htmlFor="iqpro-client-id">Client ID</Label>
+          <Input
+            id="iqpro-client-id"
+            value={clientId}
+            onChange={e => setClientId(e.target.value)}
+            disabled={loading || saving}
+            placeholder="e.g. abc123-..."
+            required
+            maxLength={200}
+          />
+        </div>
+
+        <div>
+          <Label htmlFor="iqpro-client-secret">
+            Client Secret
+            {initial?.hasSecret && (
+              <Badge variant="outline" className="ml-2 text-xs">
+                Secret configured
+              </Badge>
+            )}
+          </Label>
+          <Input
+            id="iqpro-client-secret"
+            type="password"
+            value={clientSecret}
+            onChange={e => setClientSecret(e.target.value)}
+            disabled={loading || saving}
+            placeholder={initial?.hasSecret ? '••••••••  Leave blank to keep current secret' : 'Enter client secret'}
+            maxLength={500}
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            Leave blank to keep the existing secret unchanged.
+          </p>
+        </div>
+
+        <div>
+          <Label htmlFor="iqpro-gateway-id">Gateway ID</Label>
+          <Input
+            id="iqpro-gateway-id"
+            value={gatewayId}
+            onChange={e => setGatewayId(e.target.value)}
+            disabled={loading || saving}
+            placeholder="IQPro merchant gateway identifier"
+            required
+            maxLength={100}
+          />
+        </div>
+
+        <div className="flex justify-end">
+          <Button type="submit" disabled={submitDisabled}>
+            {saving ? 'Saving…' : 'Save'}
+          </Button>
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/src/features/platform-settings/PlatformSettingsPage.tsx
+++ b/src/features/platform-settings/PlatformSettingsPage.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import type { IQProConfigFormData, IQProConfigInitialData } from '@/features/payment-settings/PaymentSettingsForm';
+import { useCallback, useEffect, useState } from 'react';
+import { PaymentSettingsForm } from '@/features/payment-settings/PaymentSettingsForm';
+import { client } from '@/libs/Orpc';
+
+export function PlatformSettingsPage() {
+  const [initial, setInitial] = useState<IQProConfigInitialData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setErrorMessage(null);
+    try {
+      const data = await client.platformSettings.getConfig();
+      setInitial(data as IQProConfigInitialData);
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : 'Failed to load platform settings');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleSave = async (data: IQProConfigFormData) => {
+    setSaving(true);
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    try {
+      await client.platformSettings.updateConfig(data);
+      setSuccessMessage('Platform settings saved.');
+      await load();
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : 'Failed to save platform settings');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-foreground">Platform Settings</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Super-admin only. Configure the IQPro merchant gateway used to bill customer organizations for the dojo-planner SaaS subscription.
+        </p>
+      </div>
+
+      <PaymentSettingsForm
+        key={`${initial?.clientId ?? ''}|${initial?.gatewayId ?? ''}|${initial?.hasSecret ?? false}`}
+        title="Platform IQPro Merchant Credentials"
+        description="These values are stored encrypted at rest in the platform_config table. Falls back to IQPRO_* env vars when no value is set."
+        initial={initial}
+        loading={loading}
+        saving={saving}
+        errorMessage={errorMessage}
+        successMessage={successMessage}
+        onSave={handleSave}
+      />
+    </div>
+  );
+}

--- a/src/features/settings/EditPaymentSettingsModal.tsx
+++ b/src/features/settings/EditPaymentSettingsModal.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+
+export type EditPaymentSettingsModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  clientId: string;
+  gatewayId: string;
+  hasSecret: boolean;
+  onSave: (data: {
+    clientId: string;
+    clientSecret?: string;
+    gatewayId: string;
+  }) => void | Promise<void>;
+  errorMessage?: string | null;
+  title?: string;
+};
+
+export function EditPaymentSettingsModal({
+  isOpen,
+  onClose,
+  clientId: initialClientId,
+  gatewayId: initialGatewayId,
+  hasSecret,
+  onSave,
+  errorMessage,
+  title = 'Edit IQPro Credentials',
+}: EditPaymentSettingsModalProps) {
+  const [clientId, setClientId] = useState(initialClientId);
+  const [clientSecret, setClientSecret] = useState('');
+  const [gatewayId, setGatewayId] = useState(initialGatewayId);
+  const [touched, setTouched] = useState<Record<string, boolean>>({});
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleInputBlur = (field: string) => {
+    setTouched(prev => ({ ...prev, [field]: true }));
+  };
+
+  const isClientIdInvalid = touched.clientId && !clientId.trim();
+  const isGatewayIdInvalid = touched.gatewayId && !gatewayId.trim();
+  // A new secret is required only when nothing has ever been saved.
+  const isSecretInvalid = touched.clientSecret && !hasSecret && !clientSecret.trim();
+
+  const isFormValid = clientId.trim() !== ''
+    && gatewayId.trim() !== ''
+    && (hasSecret || clientSecret.trim() !== '');
+
+  const handleSubmit = async () => {
+    setIsLoading(true);
+    try {
+      const trimmedSecret = clientSecret.trim();
+      await onSave({
+        clientId: clientId.trim(),
+        gatewayId: gatewayId.trim(),
+        ...(trimmedSecret && { clientSecret: trimmedSecret }),
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const reset = () => {
+    setClientId(initialClientId);
+    setGatewayId(initialGatewayId);
+    setClientSecret('');
+    setTouched({});
+  };
+
+  const handleCancel = () => {
+    reset();
+    onClose();
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    if (open) {
+      reset();
+    } else {
+      handleCancel();
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-6 py-4">
+          <div className="space-y-1.5">
+            <label htmlFor="iqpro-client-id" className="text-sm font-medium text-foreground">Client ID</label>
+            <Input
+              id="iqpro-client-id"
+              placeholder="e.g. abc123-..."
+              value={clientId}
+              onChange={e => setClientId(e.target.value)}
+              onBlur={() => handleInputBlur('clientId')}
+              error={isClientIdInvalid}
+              maxLength={200}
+            />
+            {isClientIdInvalid && (
+              <p className="text-xs text-destructive">Client ID is required.</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="iqpro-client-secret" className="text-sm font-medium text-foreground">Client Secret</label>
+            <Input
+              id="iqpro-client-secret"
+              type="password"
+              placeholder={hasSecret ? '••••••••  Leave blank to keep current secret' : 'Enter client secret'}
+              value={clientSecret}
+              onChange={e => setClientSecret(e.target.value)}
+              onBlur={() => handleInputBlur('clientSecret')}
+              error={isSecretInvalid}
+              maxLength={500}
+            />
+            <p className="text-xs text-muted-foreground">
+              {hasSecret
+                ? 'Leave blank to keep the existing secret unchanged.'
+                : 'A client secret has not been saved yet.'}
+            </p>
+            {isSecretInvalid && (
+              <p className="text-xs text-destructive">Client Secret is required.</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="iqpro-gateway-id" className="text-sm font-medium text-foreground">Gateway ID</label>
+            <Input
+              id="iqpro-gateway-id"
+              placeholder="IQPro merchant gateway identifier"
+              value={gatewayId}
+              onChange={e => setGatewayId(e.target.value)}
+              onBlur={() => handleInputBlur('gatewayId')}
+              error={isGatewayIdInvalid}
+              maxLength={100}
+            />
+            {isGatewayIdInvalid && (
+              <p className="text-xs text-destructive">Gateway ID is required.</p>
+            )}
+          </div>
+
+          {errorMessage && (
+            <p className="text-sm text-destructive">{errorMessage}</p>
+          )}
+
+          <div className="flex justify-end gap-3 pt-4">
+            <Button variant="outline" onClick={handleCancel} disabled={isLoading}>
+              Cancel
+            </Button>
+            <Button onClick={handleSubmit} disabled={!isFormValid || isLoading}>
+              {isLoading ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/settings/LocationSettingsPage.test.tsx
+++ b/src/features/settings/LocationSettingsPage.test.tsx
@@ -36,6 +36,13 @@ vi.mock('next-intl', () => ({
 
 const refetchMock = vi.fn();
 const updateLocationMock = vi.fn().mockResolvedValue({ location: {} });
+const getPaymentConfigMock = vi.fn().mockResolvedValue({
+  clientId: 'env-client-id',
+  gatewayId: 'env-gateway-id',
+  hasSecret: true,
+  source: 'env',
+});
+const updatePaymentConfigMock = vi.fn().mockResolvedValue({ success: true });
 
 let hookState: {
   location: { address: string | null; phone: string | null; email: string | null; taxRate: number };
@@ -64,6 +71,10 @@ vi.mock('@/libs/Orpc', () => ({
     organization: {
       updateLocation: (...args: unknown[]) => updateLocationMock(...args),
     },
+    paymentSettings: {
+      getConfig: (...args: unknown[]) => getPaymentConfigMock(...args),
+      updateConfig: (...args: unknown[]) => updatePaymentConfigMock(...args),
+    },
   },
 }));
 
@@ -81,6 +92,36 @@ describe('LocationSettingsPage', () => {
       },
       loading: false,
     };
+  });
+
+  describe('IQPro card role gating', () => {
+    it('hides the IQPro card entirely for non-management roles (e.g. front_desk)', async () => {
+      render(<LocationSettingsPage userRole="org:front_desk" />);
+
+      expect(page.getByText('IQPro Payment Gateway').elements()).toHaveLength(0);
+      // Front-desk shouldn't even fetch the config.
+      expect(getPaymentConfigMock).not.toHaveBeenCalled();
+    });
+
+    it('shows the IQPro card for academy_owner but HIDES the edit button', async () => {
+      render(<LocationSettingsPage userRole="org:academy_owner" />);
+
+      expect(page.getByText('IQPro Payment Gateway')).toBeDefined();
+      expect(page.getByRole('button', { name: /edit iqpro/i }).elements()).toHaveLength(0);
+    });
+
+    it('shows the IQPro card AND the edit button for admin', async () => {
+      render(<LocationSettingsPage userRole="org:admin" />);
+
+      expect(page.getByText('IQPro Payment Gateway')).toBeDefined();
+      expect(page.getByRole('button', { name: /edit iqpro/i })).toBeDefined();
+    });
+
+    it('hides the card when no role is provided (defensive default)', () => {
+      render(<LocationSettingsPage />);
+
+      expect(page.getByText('IQPro Payment Gateway').elements()).toHaveLength(0);
+    });
   });
 
   it('renders the page title', () => {
@@ -130,7 +171,7 @@ describe('LocationSettingsPage', () => {
   it('opens the edit modal when edit button is clicked', async () => {
     render(<LocationSettingsPage />);
 
-    const editButton = page.getByRole('button', { name: /edit/i });
+    const editButton = page.getByRole('button', { name: /edit location information/i });
     await userEvent.click(editButton.element());
 
     expect(page.getByText('Edit Location Information')).toBeDefined();
@@ -148,7 +189,7 @@ describe('LocationSettingsPage', () => {
   it('closes the modal when cancel is clicked', async () => {
     render(<LocationSettingsPage />);
 
-    const editButton = page.getByRole('button', { name: /edit/i });
+    const editButton = page.getByRole('button', { name: /edit location information/i });
     await userEvent.click(editButton.element());
 
     expect(page.getByText('Edit Location Information')).toBeDefined();
@@ -162,7 +203,7 @@ describe('LocationSettingsPage', () => {
   it('calls updateLocation and refetches when saving in the modal', async () => {
     render(<LocationSettingsPage />);
 
-    const editButton = page.getByRole('button', { name: /edit/i });
+    const editButton = page.getByRole('button', { name: /edit location information/i });
     await userEvent.click(editButton.element());
 
     const addressInput = page.getByPlaceholder('Enter address');

--- a/src/features/settings/LocationSettingsPage.tsx
+++ b/src/features/settings/LocationSettingsPage.tsx
@@ -2,14 +2,22 @@
 
 import { Edit } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useOrganizationLocation } from '@/hooks/useOrganizationLocation';
 import { client } from '@/libs/Orpc';
+import { ORG_ROLE } from '@/types/Auth';
 import { EditLocationModal } from './EditLocationModal';
+import { EditPaymentSettingsModal } from './EditPaymentSettingsModal';
+
+// Roles that can VIEW the IQPro payment-gateway card. Admin is included
+// because it sits above academy_owner in the role hierarchy.
+const PAYMENT_VIEW_ROLES = new Set<string>([ORG_ROLE.ADMIN, ORG_ROLE.ACADEMY_OWNER]);
+// Roles that can EDIT (open the modal + save). Stricter than view.
+const PAYMENT_EDIT_ROLES = new Set<string>([ORG_ROLE.ADMIN]);
 
 type LocationFormData = {
   address: string;
@@ -18,11 +26,55 @@ type LocationFormData = {
   taxRate: number;
 };
 
-export function LocationSettingsPage() {
+type PaymentConfigState = {
+  clientId: string | null;
+  gatewayId: string | null;
+  hasSecret: boolean;
+  source: 'org' | 'env' | 'mixed' | 'platform';
+};
+
+export type LocationSettingsPageProps = {
+  /**
+   * The current user's Clerk org role (e.g. `org:admin`, `org:academy_owner`).
+   * Drives client-side gating of the IQPro card. Server-side `guardRole` on
+   * the ORPC endpoints is the authoritative check — this only hides the UI.
+   */
+  userRole?: string;
+};
+
+export function LocationSettingsPage({ userRole }: LocationSettingsPageProps = {}) {
   const t = useTranslations('LocationSettings');
   const { location, loading, error, refetch } = useOrganizationLocation();
+  const canViewPayment = !!userRole && PAYMENT_VIEW_ROLES.has(userRole);
+  const canEditPayment = !!userRole && PAYMENT_EDIT_ROLES.has(userRole);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+
+  const [paymentConfig, setPaymentConfig] = useState<PaymentConfigState | null>(null);
+  const [paymentLoading, setPaymentLoading] = useState(true);
+  const [paymentError, setPaymentError] = useState<string | null>(null);
+  const [isPaymentModalOpen, setIsPaymentModalOpen] = useState(false);
+  const [paymentSaveError, setPaymentSaveError] = useState<string | null>(null);
+
+  const loadPaymentConfig = useCallback(async () => {
+    if (!canViewPayment) {
+      return;
+    }
+    setPaymentLoading(true);
+    setPaymentError(null);
+    try {
+      const data = await client.paymentSettings.getConfig();
+      setPaymentConfig(data as PaymentConfigState);
+    } catch (err) {
+      setPaymentError(err instanceof Error ? err.message : 'Failed to load payment settings');
+    } finally {
+      setPaymentLoading(false);
+    }
+  }, [canViewPayment]);
+
+  useEffect(() => {
+    loadPaymentConfig();
+  }, [loadPaymentConfig]);
 
   const handleSaveLocation = async (data: LocationFormData) => {
     setSaveError(null);
@@ -32,6 +84,21 @@ export function LocationSettingsPage() {
       setIsEditModalOpen(false);
     } catch (err) {
       setSaveError(err instanceof Error ? err.message : 'Failed to save location');
+    }
+  };
+
+  const handleSavePaymentConfig = async (data: {
+    clientId: string;
+    clientSecret?: string;
+    gatewayId: string;
+  }) => {
+    setPaymentSaveError(null);
+    try {
+      await client.paymentSettings.updateConfig(data);
+      await loadPaymentConfig();
+      setIsPaymentModalOpen(false);
+    } catch (err) {
+      setPaymentSaveError(err instanceof Error ? err.message : 'Failed to save payment settings');
     }
   };
 
@@ -93,6 +160,66 @@ export function LocationSettingsPage() {
         </div>
       </Card>
 
+      {canViewPayment && (
+        <Card className="relative p-6">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-foreground">IQPro Payment Gateway</h3>
+            {paymentConfig && (
+              <Badge variant={paymentConfig.source === 'env' ? 'secondary' : 'default'}>
+                {paymentConfig.source === 'env' ? 'Using env fallback' : `Source: ${paymentConfig.source}`}
+              </Badge>
+            )}
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Merchant credentials used to process member payments. Stored encrypted at rest.
+          </p>
+          {paymentError && (
+            <p className="mt-2 text-sm text-destructive">{paymentError}</p>
+          )}
+          <div className="mt-4 space-y-4">
+            <div>
+              <span className="text-sm text-muted-foreground">Client ID</span>
+              {paymentLoading
+                ? <Skeleton className="mt-1 h-5 w-64" />
+                : <p className="mt-1 text-foreground">{paymentConfig?.clientId || '-'}</p>}
+            </div>
+            <div>
+              <span className="text-sm text-muted-foreground">Client Secret</span>
+              {paymentLoading
+                ? <Skeleton className="mt-1 h-5 w-40" />
+                : (
+                    <p className="mt-1">
+                      {paymentConfig?.hasSecret
+                        ? <Badge>Configured</Badge>
+                        : <span className="text-muted-foreground">Not set</span>}
+                    </p>
+                  )}
+            </div>
+            <div>
+              <span className="text-sm text-muted-foreground">Gateway ID</span>
+              {paymentLoading
+                ? <Skeleton className="mt-1 h-5 w-56" />
+                : <p className="mt-1 text-foreground">{paymentConfig?.gatewayId || '-'}</p>}
+            </div>
+          </div>
+
+          {canEditPayment && (
+            <div className="mt-6 flex justify-end">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setIsPaymentModalOpen(true)}
+                aria-label="Edit IQPro credentials"
+                title="Edit IQPro credentials"
+                disabled={paymentLoading}
+              >
+                <Edit className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+        </Card>
+      )}
+
       <EditLocationModal
         isOpen={isEditModalOpen}
         onClose={() => {
@@ -106,6 +233,21 @@ export function LocationSettingsPage() {
         onSave={handleSaveLocation}
         errorMessage={saveError}
       />
+
+      {canEditPayment && (
+        <EditPaymentSettingsModal
+          isOpen={isPaymentModalOpen}
+          onClose={() => {
+            setIsPaymentModalOpen(false);
+            setPaymentSaveError(null);
+          }}
+          clientId={paymentConfig?.clientId ?? ''}
+          gatewayId={paymentConfig?.gatewayId ?? ''}
+          hasSecret={paymentConfig?.hasSecret ?? false}
+          onSave={handleSavePaymentConfig}
+          errorMessage={paymentSaveError}
+        />
+      )}
     </div>
   );
 }

--- a/src/libs/Crypto.test.ts
+++ b/src/libs/Crypto.test.ts
@@ -1,0 +1,59 @@
+import { Buffer } from 'node:buffer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const TEST_KEY_HEX = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+vi.mock('./Env', () => ({
+  Env: {
+    IQPRO_CONFIG_ENCRYPTION_KEY: TEST_KEY_HEX,
+  },
+}));
+
+describe('Crypto', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('round-trips a plaintext value', async () => {
+    const { encryptSecret, decryptSecret } = await import('./Crypto');
+    const plaintext = 'my-super-secret-iqpro-client-secret-value';
+    const cipher = encryptSecret(plaintext);
+
+    expect(cipher).not.toBe(plaintext);
+    expect(decryptSecret(cipher)).toBe(plaintext);
+  });
+
+  it('produces a fresh IV per encrypt (same plaintext → different ciphertext)', async () => {
+    const { encryptSecret } = await import('./Crypto');
+    const plaintext = 'identical-input';
+    const a = encryptSecret(plaintext);
+    const b = encryptSecret(plaintext);
+
+    expect(a).not.toBe(b);
+  });
+
+  it('rejects a tampered ciphertext (auth tag mismatch)', async () => {
+    const { encryptSecret, decryptSecret } = await import('./Crypto');
+    const cipher = encryptSecret('hello');
+    const tampered = Buffer.from(cipher, 'base64');
+    // Flip a bit deep inside the ciphertext body (past iv + tag).
+    tampered[tampered.length - 1] = tampered[tampered.length - 1]! ^ 0x01;
+
+    expect(() => decryptSecret(tampered.toString('base64'))).toThrow();
+  });
+
+  it('rejects truncated payloads', async () => {
+    const { decryptSecret } = await import('./Crypto');
+
+    expect(() => decryptSecret('AAAA')).toThrow('too short');
+  });
+
+  it('throws a clear error when the key env var is missing', async () => {
+    vi.doMock('./Env', () => ({
+      Env: { IQPRO_CONFIG_ENCRYPTION_KEY: undefined },
+    }));
+    const { encryptSecret } = await import('./Crypto');
+
+    expect(() => encryptSecret('x')).toThrow('IQPRO_CONFIG_ENCRYPTION_KEY');
+  });
+});

--- a/src/libs/Crypto.ts
+++ b/src/libs/Crypto.ts
@@ -1,0 +1,47 @@
+/**
+ * AES-256-GCM encryption helpers for IQPro `client_secret` values stored in
+ * the database. The key is read from `IQPRO_CONFIG_ENCRYPTION_KEY` (32 raw
+ * bytes, hex-encoded) at call time so test setups that mutate `process.env`
+ * see the new value without restarting the module.
+ *
+ * Format on disk: base64( iv (12 bytes) || authTag (16 bytes) || ciphertext )
+ */
+
+import { Buffer } from 'node:buffer';
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+import { Env } from './Env';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_BYTES = 12;
+const TAG_BYTES = 16;
+
+function loadKey(): Buffer {
+  const hex = Env.IQPRO_CONFIG_ENCRYPTION_KEY;
+  if (!hex) {
+    throw new Error('IQPRO_CONFIG_ENCRYPTION_KEY is not set; cannot encrypt or decrypt IQPro secrets');
+  }
+  return Buffer.from(hex, 'hex');
+}
+
+export function encryptSecret(plaintext: string): string {
+  const key = loadKey();
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, ciphertext]).toString('base64');
+}
+
+export function decryptSecret(ciphertextB64: string): string {
+  const key = loadKey();
+  const buf = Buffer.from(ciphertextB64, 'base64');
+  if (buf.length < IV_BYTES + TAG_BYTES + 1) {
+    throw new Error('encrypted payload is too short');
+  }
+  const iv = buf.subarray(0, IV_BYTES);
+  const tag = buf.subarray(IV_BYTES, IV_BYTES + TAG_BYTES);
+  const ciphertext = buf.subarray(IV_BYTES + TAG_BYTES);
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+}

--- a/src/libs/Env.ts
+++ b/src/libs/Env.ts
@@ -19,6 +19,11 @@ export const Env = createEnv({
     IQPRO_BASE_URL: z.string().url().optional(),
     IQPRO_GATEWAY_ID: z.string().min(1).optional(),
     IQPRO_WEBHOOK_SECRET: z.string().min(1).optional(),
+    // AES-256-GCM key (32 raw bytes, hex-encoded → 64 chars) used to encrypt
+    // per-org and platform IQPro client_secret values stored in the DB.
+    // Required at decrypt time when any encrypted column has a value; optional
+    // otherwise so local dev without IQPro keeps booting.
+    IQPRO_CONFIG_ENCRYPTION_KEY: z.string().regex(/^[0-9a-f]{64}$/i, 'must be 64 hex chars (32 bytes)').optional(),
     // Service fee % applied to every transaction (membership + taxable).
     // Passed to IQPro as a paymentAdjustment of type "ServiceFee" (percentage,
     // not flatAmount — IQPro rejects flatAmount on ServiceFee adjustments).
@@ -53,6 +58,7 @@ export const Env = createEnv({
     IQPRO_BASE_URL: process.env.IQPRO_BASE_URL,
     IQPRO_GATEWAY_ID: process.env.IQPRO_GATEWAY_ID,
     IQPRO_WEBHOOK_SECRET: process.env.IQPRO_WEBHOOK_SECRET,
+    IQPRO_CONFIG_ENCRYPTION_KEY: process.env.IQPRO_CONFIG_ENCRYPTION_KEY,
     SERVICE_FEE_PCT: process.env.SERVICE_FEE_PCT,
     RESEND_API_KEY: process.env.RESEND_API_KEY,
     RESEND_FROM_EMAIL: process.env.RESEND_FROM_EMAIL,

--- a/src/libs/IQPro.test.ts
+++ b/src/libs/IQPro.test.ts
@@ -7,12 +7,6 @@ vi.stubGlobal('fetch', mockFetch);
 // Mock Env
 vi.mock('./Env', () => ({
   Env: {
-    IQPRO_CLIENT_ID: 'test-client-id',
-    IQPRO_CLIENT_SECRET: 'test-client-secret',
-    IQPRO_SCOPE: 'test-scope',
-    IQPRO_OAUTH_URL: 'https://sandbox.oauth.example.com/token',
-    IQPRO_BASE_URL: 'https://sandbox.api.basyspro.com',
-    IQPRO_GATEWAY_ID: 'test-gateway-id',
     SERVICE_FEE_PCT: '3.75',
   },
 }));
@@ -27,6 +21,16 @@ const mockLogger = {
 vi.mock('./Logger', () => ({
   logger: mockLogger,
 }));
+
+const testConfig = {
+  clientId: 'test-client-id',
+  clientSecret: 'test-client-secret',
+  gatewayId: 'test-gateway-id',
+  scope: 'test-scope',
+  oauthUrl: 'https://sandbox.oauth.example.com/token',
+  baseUrl: 'https://sandbox.api.basyspro.com',
+  source: 'env' as const,
+};
 
 function mockOAuthOk() {
   mockFetch.mockResolvedValueOnce(new Response(
@@ -43,7 +47,7 @@ describe('tokenizeAch', () => {
 
   async function getTokenizeAch() {
     const mod = await import('./IQPro');
-    mod.resetOAuthToken();
+    mod.resetOAuthTokenCache();
     return mod.tokenizeAch;
   }
 
@@ -65,7 +69,7 @@ describe('tokenizeAch', () => {
       new Response(JSON.stringify({ achToken: 'ach-tok-abc123' }), { status: 200 }),
     );
 
-    const result = await tokenizeAch({
+    const result = await tokenizeAch(testConfig, {
       accountNumber: '123456789',
       routingNumber: '021000021',
       achAccountType: 'Checking',
@@ -102,7 +106,7 @@ describe('tokenizeAch', () => {
       new Response(JSON.stringify({ data: { achToken: 'ach-tok-nested' } }), { status: 200 }),
     );
 
-    const result = await tokenizeAch({
+    const result = await tokenizeAch(testConfig, {
       accountNumber: '987654321',
       routingNumber: '021000021',
     });
@@ -117,7 +121,7 @@ describe('tokenizeAch', () => {
       new Response(JSON.stringify({ statusCode: 'OK', data: { achId: 'ach-id-vault', maskedAccount: '12*****89' } }), { status: 200 }),
     );
 
-    const result = await tokenizeAch({
+    const result = await tokenizeAch(testConfig, {
       accountNumber: '123456789',
       routingNumber: '021000021',
     });
@@ -132,7 +136,7 @@ describe('tokenizeAch', () => {
       new Response(JSON.stringify({ token: 'ach-tok-fallback' }), { status: 200 }),
     );
 
-    const result = await tokenizeAch({
+    const result = await tokenizeAch(testConfig, {
       accountNumber: '987654321',
       routingNumber: '021000021',
     });
@@ -147,7 +151,7 @@ describe('tokenizeAch', () => {
       new Response(JSON.stringify({ achToken: 'ach-tok-defaults' }), { status: 200 }),
     );
 
-    await tokenizeAch({
+    await tokenizeAch(testConfig, {
       accountNumber: '123456789',
       routingNumber: '021000021',
     });
@@ -165,7 +169,7 @@ describe('tokenizeAch', () => {
       new Response(JSON.stringify({ achToken: 'ach-tok-savings' }), { status: 200 }),
     );
 
-    await tokenizeAch({
+    await tokenizeAch(testConfig, {
       accountNumber: '123456789',
       routingNumber: '021000021',
       achAccountType: 'Savings',
@@ -183,7 +187,7 @@ describe('tokenizeAch', () => {
       new Response('Bad Request', { status: 400 }),
     );
 
-    await expect(tokenizeAch({
+    await expect(tokenizeAch(testConfig, {
       accountNumber: '123456789',
       routingNumber: '021000021',
     })).rejects.toThrow('ACH tokenization failed: 400');
@@ -196,47 +200,10 @@ describe('tokenizeAch', () => {
       new Response(JSON.stringify({ someOtherField: 'value' }), { status: 200 }),
     );
 
-    await expect(tokenizeAch({
+    await expect(tokenizeAch(testConfig, {
       accountNumber: '123456789',
       routingNumber: '021000021',
     })).rejects.toThrow('ACH tokenization response missing achToken');
-  });
-
-  it('should throw when IQPro is not configured', async () => {
-    // Override the Env mock to remove required values
-    vi.doMock('./Env', () => ({
-      Env: {
-        IQPRO_CLIENT_ID: undefined,
-        IQPRO_CLIENT_SECRET: undefined,
-        IQPRO_SCOPE: undefined,
-        IQPRO_OAUTH_URL: undefined,
-        IQPRO_BASE_URL: undefined,
-        IQPRO_GATEWAY_ID: undefined,
-      },
-    }));
-
-    // Re-import to pick up new mock
-    vi.resetModules();
-    const { tokenizeAch } = await import('./IQPro');
-
-    await expect(tokenizeAch({
-      accountNumber: '123456789',
-      routingNumber: '021000021',
-    })).rejects.toThrow('IQPro is not configured');
-
-    // Restore original mock for other tests
-    vi.doMock('./Env', () => ({
-      Env: {
-        IQPRO_CLIENT_ID: 'test-client-id',
-        IQPRO_CLIENT_SECRET: 'test-client-secret',
-        IQPRO_SCOPE: 'test-scope',
-        IQPRO_OAUTH_URL: 'https://sandbox.oauth.example.com/token',
-        IQPRO_BASE_URL: 'https://sandbox.api.basyspro.com',
-        IQPRO_GATEWAY_ID: 'test-gateway-id',
-        TAX_STATE_PCT: '3.75',
-        SERVICE_FEE_PCT: '3.75',
-      },
-    }));
   });
 });
 
@@ -248,7 +215,7 @@ describe('iqproPost', () => {
 
   it('logs both request body and response body in full', async () => {
     const mod = await import('./IQPro');
-    mod.resetOAuthToken();
+    mod.resetOAuthTokenCache();
 
     mockOAuthOk();
     mockFetch.mockResolvedValueOnce(new Response(
@@ -257,7 +224,7 @@ describe('iqproPost', () => {
     ));
 
     const requestBody = { name: 'Acme', referenceId: 'mem_1' };
-    const result = await mod.iqproPost('/api/gateway/test-gateway-id/customer', requestBody);
+    const result = await mod.iqproPost(testConfig, '/api/gateway/test-gateway-id/customer', requestBody);
 
     expect(result).toEqual({ data: { customerId: 'cust_42' } });
 
@@ -281,7 +248,7 @@ describe('iqproPost', () => {
 
   it('logs the full error body on failure and throws with status', async () => {
     const mod = await import('./IQPro');
-    mod.resetOAuthToken();
+    mod.resetOAuthTokenCache();
 
     mockOAuthOk();
     mockFetch.mockResolvedValueOnce(new Response(
@@ -290,7 +257,7 @@ describe('iqproPost', () => {
     ));
 
     await expect(
-      mod.iqproPost('/api/gateway/test-gateway-id/customer', { x: 1 }),
+      mod.iqproPost(testConfig, '/api/gateway/test-gateway-id/customer', { x: 1 }),
     ).rejects.toThrow('IQPro API /api/gateway/test-gateway-id/customer failed: 400 Validation failed: missing field');
 
     expect(mockLogger.error).toHaveBeenCalledWith('[IQPro] POST failed', {
@@ -309,7 +276,7 @@ describe('iqproGet', () => {
 
   it('returns parsed JSON and logs request + response', async () => {
     const mod = await import('./IQPro');
-    mod.resetOAuthToken();
+    mod.resetOAuthTokenCache();
 
     mockOAuthOk();
     mockFetch.mockResolvedValueOnce(new Response(
@@ -318,6 +285,7 @@ describe('iqproGet', () => {
     ));
 
     const result = await mod.iqproGet<{ data: { addresses: Array<{ customerAddressId: string }> } }>(
+      testConfig,
       '/api/gateway/test-gateway-id/customer/cust_42',
     );
 
@@ -343,7 +311,7 @@ describe('iqproPut', () => {
 
   it('PUTs the body and returns parsed JSON', async () => {
     const mod = await import('./IQPro');
-    mod.resetOAuthToken();
+    mod.resetOAuthTokenCache();
 
     mockOAuthOk();
     mockFetch.mockResolvedValueOnce(new Response(
@@ -351,7 +319,7 @@ describe('iqproPut', () => {
       { status: 200 },
     ));
 
-    const result = await mod.iqproPut('/api/gateway/test-gateway-id/subscription/sub_1', { name: 'X' });
+    const result = await mod.iqproPut(testConfig, '/api/gateway/test-gateway-id/subscription/sub_1', { name: 'X' });
 
     expect(result).toEqual({ data: { id: 'sub_1' } });
 
@@ -370,7 +338,7 @@ describe('computeFeeBreakdown', () => {
 
   it('non-taxable (membership) returns 0 tax + IQPro service fee', async () => {
     const mod = await import('./IQPro');
-    mod.resetOAuthToken();
+    mod.resetOAuthTokenCache();
 
     mockOAuthOk();
     // /calculatefees response — IQPro returns the flat service-fee amount
@@ -379,7 +347,7 @@ describe('computeFeeBreakdown', () => {
       { status: 200 },
     ));
 
-    const result = await mod.computeFeeBreakdown(100, /* isTaxable */ false, /* taxStatePct */ 3.75, {
+    const result = await mod.computeFeeBreakdown(testConfig, 100, /* isTaxable */ false, /* taxStatePct */ 3.75, {
       processorId: 'proc_1',
       token: 'tok_xyz',
     });
@@ -409,7 +377,7 @@ describe('computeFeeBreakdown', () => {
 
   it('taxable (event/store) computes tax locally + IQPro service fee', async () => {
     const mod = await import('./IQPro');
-    mod.resetOAuthToken();
+    mod.resetOAuthTokenCache();
 
     mockOAuthOk();
     mockFetch.mockResolvedValueOnce(new Response(
@@ -417,7 +385,7 @@ describe('computeFeeBreakdown', () => {
       { status: 200 },
     ));
 
-    const result = await mod.computeFeeBreakdown(100, /* isTaxable */ true, /* taxStatePct */ 3.75, {
+    const result = await mod.computeFeeBreakdown(testConfig, 100, /* isTaxable */ true, /* taxStatePct */ 3.75, {
       processorId: 'proc_1',
       creditCardBin: '424242',
     });
@@ -431,7 +399,7 @@ describe('computeFeeBreakdown', () => {
 
   it('taxable with 0 tax rate yields no tax (default for new orgs)', async () => {
     const mod = await import('./IQPro');
-    mod.resetOAuthToken();
+    mod.resetOAuthTokenCache();
 
     mockOAuthOk();
     mockFetch.mockResolvedValueOnce(new Response(
@@ -439,7 +407,7 @@ describe('computeFeeBreakdown', () => {
       { status: 200 },
     ));
 
-    const result = await mod.computeFeeBreakdown(100, /* isTaxable */ true, /* taxStatePct */ 0, {
+    const result = await mod.computeFeeBreakdown(testConfig, 100, /* isTaxable */ true, /* taxStatePct */ 0, {
       processorId: 'proc_1',
       token: 'tok_xyz',
     });
@@ -451,7 +419,7 @@ describe('computeFeeBreakdown', () => {
 
   it('taxable with custom tax rate (e.g. 5.25%) computes correctly', async () => {
     const mod = await import('./IQPro');
-    mod.resetOAuthToken();
+    mod.resetOAuthTokenCache();
 
     mockOAuthOk();
     mockFetch.mockResolvedValueOnce(new Response(
@@ -459,7 +427,7 @@ describe('computeFeeBreakdown', () => {
       { status: 200 },
     ));
 
-    const result = await mod.computeFeeBreakdown(100, /* isTaxable */ true, /* taxStatePct */ 5.25, {
+    const result = await mod.computeFeeBreakdown(testConfig, 100, /* isTaxable */ true, /* taxStatePct */ 5.25, {
       processorId: 'proc_1',
       token: 'tok_xyz',
     });
@@ -471,7 +439,7 @@ describe('computeFeeBreakdown', () => {
 
   it('falls back to creditCardBin when token is not provided', async () => {
     const mod = await import('./IQPro');
-    mod.resetOAuthToken();
+    mod.resetOAuthTokenCache();
 
     mockOAuthOk();
     mockFetch.mockResolvedValueOnce(new Response(
@@ -479,7 +447,7 @@ describe('computeFeeBreakdown', () => {
       { status: 200 },
     ));
 
-    await mod.computeFeeBreakdown(50, false, 0, {
+    await mod.computeFeeBreakdown(testConfig, 50, false, 0, {
       processorId: 'proc_1',
       creditCardBin: '424242',
     });
@@ -574,7 +542,7 @@ describe('getCustomerPaymentMethod', () => {
 
   it('extracts BIN + last4 from a saved card', async () => {
     const mod = await import('./IQPro');
-    mod.resetOAuthToken();
+    mod.resetOAuthTokenCache();
 
     mockOAuthOk();
     mockFetch.mockResolvedValueOnce(new Response(
@@ -592,14 +560,14 @@ describe('getCustomerPaymentMethod', () => {
       { status: 200 },
     ));
 
-    const info = await mod.getCustomerPaymentMethod('cust_1', 'pm_2');
+    const info = await mod.getCustomerPaymentMethod(testConfig, 'cust_1', 'pm_2');
 
     expect(info).toEqual({ type: 'card', firstSix: '555555', last4: '5555' });
   });
 
   it('extracts achToken from a saved ACH PM', async () => {
     const mod = await import('./IQPro');
-    mod.resetOAuthToken();
+    mod.resetOAuthTokenCache();
 
     mockOAuthOk();
     mockFetch.mockResolvedValueOnce(new Response(
@@ -616,7 +584,7 @@ describe('getCustomerPaymentMethod', () => {
       { status: 200 },
     ));
 
-    const info = await mod.getCustomerPaymentMethod('cust_1', 'pm_ach');
+    const info = await mod.getCustomerPaymentMethod(testConfig, 'cust_1', 'pm_ach');
 
     expect(info?.type).toBe('ach');
     expect(info?.achToken).toBe('ach-tok-xyz');
@@ -625,7 +593,7 @@ describe('getCustomerPaymentMethod', () => {
 
   it('returns null when paymentMethodId is not found', async () => {
     const mod = await import('./IQPro');
-    mod.resetOAuthToken();
+    mod.resetOAuthTokenCache();
 
     mockOAuthOk();
     mockFetch.mockResolvedValueOnce(new Response(
@@ -633,7 +601,7 @@ describe('getCustomerPaymentMethod', () => {
       { status: 200 },
     ));
 
-    const info = await mod.getCustomerPaymentMethod('cust_1', 'pm_missing');
+    const info = await mod.getCustomerPaymentMethod(testConfig, 'cust_1', 'pm_missing');
 
     expect(info).toBeNull();
   });
@@ -647,8 +615,8 @@ describe('getGatewayProcessors', () => {
 
   it('extracts default card and ACH processor IDs', async () => {
     const mod = await import('./IQPro');
-    mod.resetOAuthToken();
-    mod.resetGatewayProcessors();
+    mod.resetOAuthTokenCache();
+    mod.resetGatewayProcessorsCache();
 
     mockOAuthOk();
     mockFetch.mockResolvedValueOnce(new Response(
@@ -664,43 +632,8 @@ describe('getGatewayProcessors', () => {
       { status: 200 },
     ));
 
-    const result = await mod.getGatewayProcessors();
+    const result = await mod.getGatewayProcessors(testConfig);
 
     expect(result).toEqual({ cardProcessorId: 'card_proc', achProcessorId: 'ach_proc' });
-  });
-
-  it('returns nulls when IQPro is not configured', async () => {
-    vi.doMock('./Env', () => ({
-      Env: {
-        IQPRO_CLIENT_ID: undefined,
-        IQPRO_CLIENT_SECRET: undefined,
-        IQPRO_SCOPE: undefined,
-        IQPRO_OAUTH_URL: undefined,
-        IQPRO_BASE_URL: undefined,
-        IQPRO_GATEWAY_ID: undefined,
-      },
-    }));
-    vi.resetModules();
-
-    const { getGatewayProcessors, resetGatewayProcessors } = await import('./IQPro');
-
-    resetGatewayProcessors();
-    const result = await getGatewayProcessors();
-
-    expect(result).toEqual({ cardProcessorId: null, achProcessorId: null });
-
-    // Restore
-    vi.doMock('./Env', () => ({
-      Env: {
-        IQPRO_CLIENT_ID: 'test-client-id',
-        IQPRO_CLIENT_SECRET: 'test-client-secret',
-        IQPRO_SCOPE: 'test-scope',
-        IQPRO_OAUTH_URL: 'https://sandbox.oauth.example.com/token',
-        IQPRO_BASE_URL: 'https://sandbox.api.basyspro.com',
-        IQPRO_GATEWAY_ID: 'test-gateway-id',
-        TAX_STATE_PCT: '3.75',
-        SERVICE_FEE_PCT: '3.75',
-      },
-    }));
   });
 });

--- a/src/libs/IQPro.ts
+++ b/src/libs/IQPro.ts
@@ -4,10 +4,18 @@
  * All calls go directly through `fetch` with an OAuth bearer token — no SDK
  * dependency. Every request and response is logged in full so vague IQPro
  * 4xx errors can be diagnosed from Better Stack without re-running the call.
+ *
+ * Configuration is passed in as an `IQProConfig` object (one per organization
+ * for customer payments, one platform-wide config for SaaS billing). The
+ * resolver lives in `IQProConfigService` — keeping the lib free of DB imports
+ * makes it trivial to mock and avoids circular dependencies.
  */
 
+import type { IQProConfig } from '@/services/IQProConfigService';
 import { Env } from './Env';
 import { logger } from './Logger';
+
+export type { IQProConfig };
 
 // ===== Tokenization config types =====
 
@@ -20,38 +28,32 @@ export type TokenizationIframeConfig = {
   iframeScriptUrl: string;
 };
 
-/**
- * Check if IQPro payment processing is configured.
- * Returns false if any required env var is missing.
- */
-export function isIQProConfigured(): boolean {
-  return !!(
-    Env.IQPRO_CLIENT_ID
-    && Env.IQPRO_CLIENT_SECRET
-    && Env.IQPRO_SCOPE
-    && Env.IQPRO_OAUTH_URL
-    && Env.IQPRO_BASE_URL
-    && Env.IQPRO_GATEWAY_ID
-  );
-}
+// ===== OAuth token cache =====
+//
+// Keyed by clientId — the same credentials produce the same token regardless
+// of which org requested it, so deduplication is safe. (oauthUrl and scope are
+// platform-wide env vars and don't vary.) Lazy eviction on access; hard cap of
+// 100 entries with the soonest-to-expire entry dropped on overflow.
 
-// ===== OAuth token (cached per process) =====
+type CachedToken = { token: string; expiresAt: number };
+const oauthTokenCache = new Map<string, CachedToken>();
+const TOKEN_CACHE_MAX = 100;
 
-let cachedOAuthToken: { token: string; expiresAt: number } | null = null;
-
-async function getOAuthToken(): Promise<string> {
-  if (cachedOAuthToken && Date.now() < cachedOAuthToken.expiresAt) {
-    return cachedOAuthToken.token;
+async function getOAuthToken(config: IQProConfig): Promise<string> {
+  const key = config.clientId;
+  const cached = oauthTokenCache.get(key);
+  if (cached && Date.now() < cached.expiresAt) {
+    return cached.token;
   }
 
-  const res = await fetch(Env.IQPRO_OAUTH_URL!, {
+  const res = await fetch(config.oauthUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({
       grant_type: 'client_credentials',
-      client_id: Env.IQPRO_CLIENT_ID!,
-      client_secret: Env.IQPRO_CLIENT_SECRET!,
-      scope: Env.IQPRO_SCOPE!,
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+      scope: config.scope,
     }),
   });
 
@@ -61,35 +63,44 @@ async function getOAuthToken(): Promise<string> {
 
   const data = await res.json();
   const expiresIn = (data.expires_in ?? 3600) as number;
-
-  cachedOAuthToken = {
+  const entry: CachedToken = {
     token: data.access_token as string,
-    // Expire 60s early to avoid edge-case clock issues
     expiresAt: Date.now() + (expiresIn - 60) * 1000,
   };
 
-  return cachedOAuthToken.token;
+  if (oauthTokenCache.size >= TOKEN_CACHE_MAX) {
+    let oldestKey: string | undefined;
+    let oldestExpiry = Infinity;
+    for (const [k, v] of oauthTokenCache) {
+      if (v.expiresAt < oldestExpiry) {
+        oldestExpiry = v.expiresAt;
+        oldestKey = k;
+      }
+    }
+    if (oldestKey !== undefined) {
+      oauthTokenCache.delete(oldestKey);
+    }
+  }
+  oauthTokenCache.set(key, entry);
+
+  return entry.token;
 }
 
 // ===== REST helpers =====
 
-/**
- * Authenticated POST to the IQPro gateway API.
- * Logs the full request body and full response body (or error body).
- */
 export async function iqproPost<T = Record<string, unknown>>(
+  config: IQProConfig,
   path: string,
   body: unknown,
 ): Promise<T> {
-  const token = await getOAuthToken();
-  const baseUrl = Env.IQPRO_BASE_URL!;
+  const token = await getOAuthToken(config);
 
   logger.info('[IQPro] POST request', {
     path,
     body: JSON.stringify(body, null, 2),
   });
 
-  const res = await fetch(`${baseUrl}${path}`, {
+  const res = await fetch(`${config.baseUrl}${path}`, {
     method: 'POST',
     headers: {
       'Authorization': `Bearer ${token}`,
@@ -118,23 +129,19 @@ export async function iqproPost<T = Record<string, unknown>>(
   return text ? (JSON.parse(text) as T) : ({} as T);
 }
 
-/**
- * Authenticated PUT to the IQPro gateway API.
- * Logs the full request body and full response body (or error body).
- */
 export async function iqproPut<T = Record<string, unknown>>(
+  config: IQProConfig,
   path: string,
   body: unknown,
 ): Promise<T> {
-  const token = await getOAuthToken();
-  const baseUrl = Env.IQPRO_BASE_URL!;
+  const token = await getOAuthToken(config);
 
   logger.info('[IQPro] PUT request', {
     path,
     body: JSON.stringify(body, null, 2),
   });
 
-  const res = await fetch(`${baseUrl}${path}`, {
+  const res = await fetch(`${config.baseUrl}${path}`, {
     method: 'PUT',
     headers: {
       'Authorization': `Bearer ${token}`,
@@ -163,19 +170,15 @@ export async function iqproPut<T = Record<string, unknown>>(
   return text ? (JSON.parse(text) as T) : ({} as T);
 }
 
-/**
- * Authenticated GET to the IQPro gateway API.
- * Logs the path and full response body (or error body).
- */
 export async function iqproGet<T = Record<string, unknown>>(
+  config: IQProConfig,
   path: string,
 ): Promise<T> {
-  const token = await getOAuthToken();
-  const baseUrl = Env.IQPRO_BASE_URL!;
+  const token = await getOAuthToken(config);
 
   logger.info('[IQPro] GET request', { path });
 
-  const res = await fetch(`${baseUrl}${path}`, {
+  const res = await fetch(`${config.baseUrl}${path}`, {
     headers: { Authorization: `Bearer ${token}` },
   });
 
@@ -201,20 +204,12 @@ export async function iqproGet<T = Record<string, unknown>>(
 
 // ===== Tokenization config =====
 
-/**
- * Fetch the tokenization iframe configuration from the IQPro API.
- * Returns null if IQPro is not configured.
- */
-export async function getTokenizationConfig(clientOrigin: string): Promise<TokenizationIframeConfig | null> {
-  if (!isIQProConfigured()) {
-    return null;
-  }
-
-  const token = await getOAuthToken();
-  const baseUrl = Env.IQPRO_BASE_URL!;
-  const gatewayId = Env.IQPRO_GATEWAY_ID!;
-
-  const url = `${baseUrl}/api/v1/gateway/${gatewayId}/tokenization/configuration`;
+export async function getTokenizationConfig(
+  config: IQProConfig,
+  clientOrigin: string,
+): Promise<TokenizationIframeConfig> {
+  const token = await getOAuthToken(config);
+  const url = `${config.baseUrl}/api/v1/gateway/${config.gatewayId}/tokenization/configuration`;
 
   const res = await fetch(url, {
     headers: {
@@ -234,8 +229,6 @@ export async function getTokenizationConfig(clientOrigin: string): Promise<Token
 
   const json = await res.json();
 
-  // The iqProV2 config may live under iframeConfiguration or mobileConfiguration
-  // depending on gateway setup. Both contain the same TokenEx fields.
   const iframeConfig
     = json?.data?.iframeConfiguration?.iqProV2
       ?? json?.data?.mobileConfiguration?.iqProV2;
@@ -247,8 +240,7 @@ export async function getTokenizationConfig(clientOrigin: string): Promise<Token
     throw new Error('Tokenization config missing iframe configuration');
   }
 
-  // Derive iframe script URL from base URL (sandbox vs production)
-  const isSandbox = baseUrl.includes('sandbox');
+  const isSandbox = config.baseUrl.includes('sandbox');
   const iframeScriptUrl = isSandbox
     ? 'https://sandbox.api.basyspro.com/Iframe/iframe/iframe-v3.js'
     : 'https://api.basyspro.com/Iframe/iframe/iframe-v3.js';
@@ -278,18 +270,12 @@ export type TokenizeAchResult = {
   achToken: string;
 };
 
-/**
- * Tokenize an ACH account number via the IQPro Vault API.
- * Returns an achToken that can be used in place of the raw account number.
- */
-export async function tokenizeAch(params: TokenizeAchParams): Promise<TokenizeAchResult> {
-  if (!isIQProConfigured()) {
-    throw new Error('IQPro is not configured');
-  }
-
-  const token = await getOAuthToken();
-  // The vault API lives at the domain root, not under the /iqsaas/v1 path prefix
-  const vaultBaseUrl = new URL(Env.IQPRO_BASE_URL!).origin;
+export async function tokenizeAch(
+  config: IQProConfig,
+  params: TokenizeAchParams,
+): Promise<TokenizeAchResult> {
+  const token = await getOAuthToken(config);
+  const vaultBaseUrl = new URL(config.baseUrl).origin;
   const requestBody = {
     accountNumber: params.accountNumber,
     routingNumber: params.routingNumber,
@@ -328,7 +314,6 @@ export async function tokenizeAch(params: TokenizeAchParams): Promise<TokenizeAc
   });
 
   const json = text ? JSON.parse(text) : {};
-  // The vault API returns { data: { achId, maskedAccount } }
   const achToken = (json?.data?.achId ?? json?.achToken ?? json?.data?.achToken ?? json?.token) as string | undefined;
 
   if (!achToken) {
@@ -349,28 +334,19 @@ export type GatewayProcessors = {
   achProcessorId: string | null;
 };
 
-let cachedProcessors: GatewayProcessors | null = null;
+const processorsCache = new Map<string, GatewayProcessors>();
 
-/**
- * Fetch the default card and ACH processor IDs for the configured gateway.
- * Results are cached for the lifetime of the process.
- */
-export async function getGatewayProcessors(): Promise<GatewayProcessors> {
-  if (cachedProcessors) {
-    return cachedProcessors;
+export async function getGatewayProcessors(config: IQProConfig): Promise<GatewayProcessors> {
+  const cached = processorsCache.get(config.gatewayId);
+  if (cached) {
+    return cached;
   }
 
-  if (!isIQProConfigured()) {
-    return { cardProcessorId: null, achProcessorId: null };
-  }
+  const token = await getOAuthToken(config);
 
-  const token = await getOAuthToken();
-  const baseUrl = Env.IQPRO_BASE_URL!;
-  const gatewayId = Env.IQPRO_GATEWAY_ID!;
+  logger.info('[IQPro] Gateway config request', { gatewayId: config.gatewayId });
 
-  logger.info('[IQPro] Gateway config request', { gatewayId });
-
-  const res = await fetch(`${baseUrl}/api/gateway/${gatewayId}`, {
+  const res = await fetch(`${config.baseUrl}/api/gateway/${config.gatewayId}`, {
     headers: { Authorization: `Bearer ${token}` },
   });
 
@@ -399,23 +375,18 @@ export async function getGatewayProcessors(): Promise<GatewayProcessors> {
   const defaultCard = processors.find(p => p.isDefaultCard);
   const defaultAch = processors.find(p => p.isDefaultAch);
 
-  cachedProcessors = {
+  const result: GatewayProcessors = {
     cardProcessorId: defaultCard?.processorId ?? null,
     achProcessorId: defaultAch?.processorId ?? null,
   };
+  processorsCache.set(config.gatewayId, result);
 
-  logger.info('[IQPro] Gateway processors loaded', cachedProcessors);
-  return cachedProcessors;
+  logger.info('[IQPro] Gateway processors loaded', result);
+  return result;
 }
 
 // ===== Service fee config =====
 
-/**
- * Service fee percentage applied to EVERY transaction. Passed to IQPro as a
- * paymentAdjustment of type "ServiceFee" (percentage, not flatAmount — IQPro
- * rejects flatAmount on ServiceFee adjustments). The flat amount is computed
- * by IQPro's /calculatefees endpoint per Basys team guidance.
- */
 function getServiceFeePct(): number {
   const fromEnv = Env.SERVICE_FEE_PCT?.trim();
   if (!fromEnv) {
@@ -435,12 +406,12 @@ function roundCents(n: number): number {
 }
 
 export type ComputedFeeBreakdown = {
-  baseAmount: number; // subtotal - discount (amount fees are calculated on)
-  taxAmount: number; // taxable transactions only; 0 for memberships
-  taxPct: number; // the rate that was applied (0 if non-taxable)
-  serviceFeeAmount: number; // from IQPro /calculatefees (not computed locally)
-  serviceFeePct: number; // the rate that was requested
-  amount: number; // final total charged = base + tax + serviceFee
+  baseAmount: number;
+  taxAmount: number;
+  taxPct: number;
+  serviceFeeAmount: number;
+  serviceFeePct: number;
+  amount: number;
 };
 
 type CalculateServiceFeeParams = {
@@ -450,14 +421,10 @@ type CalculateServiceFeeParams = {
   creditCardBin?: string;
 };
 
-/**
- * Call IQPro's POST /transaction/calculatefees to get the service fee amount
- * for a given base. We send a single paymentAdjustment of type "ServiceFee"
- * with the configured percentage; IQPro returns the computed flat amount in
- * `serviceFeesAmount`.
- */
-async function fetchServiceFeeAmount(params: CalculateServiceFeeParams): Promise<number> {
-  const gatewayId = Env.IQPRO_GATEWAY_ID!;
+async function fetchServiceFeeAmount(
+  config: IQProConfig,
+  params: CalculateServiceFeeParams,
+): Promise<number> {
   const body: Record<string, unknown> = {
     baseAmount: params.baseAmount,
     addTaxToTotal: true,
@@ -468,7 +435,6 @@ async function fetchServiceFeeAmount(params: CalculateServiceFeeParams): Promise
       { type: 'ServiceFee', percentage: getServiceFeePct(), flatAmount: null },
     ],
   };
-  // IQPro accepts exactly one of token or creditCardBin.
   if (params.token) {
     body.token = params.token;
   } else if (params.creditCardBin) {
@@ -476,21 +442,16 @@ async function fetchServiceFeeAmount(params: CalculateServiceFeeParams): Promise
   }
 
   const res = await iqproPost<{ data?: { serviceFeesAmount?: number } }>(
-    `/api/gateway/${gatewayId}/transaction/calculatefees`,
+    config,
+    `/api/gateway/${config.gatewayId}/transaction/calculatefees`,
     body,
   );
   const data = (res.data ?? res) as { serviceFeesAmount?: number };
   return roundCents(data.serviceFeesAmount ?? 0);
 }
 
-/**
- * Compute the full fee breakdown for a transaction.
- * - Tax is computed locally (taxable only; 0 for memberships). The caller
- *   supplies the org-specific tax rate via `taxStatePct`.
- * - Service fee amount is computed by IQPro via /calculatefees, using the
- *   configured ServiceFee percentage. A processor ID + token-or-BIN are required.
- */
 export async function computeFeeBreakdown(
+  config: IQProConfig,
   baseAmount: number,
   isTaxable: boolean,
   taxStatePct: number,
@@ -500,7 +461,7 @@ export async function computeFeeBreakdown(
   const taxPct = isTaxable ? taxStatePct : 0;
   const serviceFeePct = getServiceFeePct();
   const taxAmount = roundCents(base * (taxPct / 100));
-  const serviceFeeAmount = await fetchServiceFeeAmount({ ...serviceFeeLookup, baseAmount: base });
+  const serviceFeeAmount = await fetchServiceFeeAmount(config, { ...serviceFeeLookup, baseAmount: base });
   const amount = roundCents(base + taxAmount + serviceFeeAmount);
   return {
     baseAmount: base,
@@ -512,18 +473,6 @@ export async function computeFeeBreakdown(
   };
 }
 
-/**
- * Build the paymentAdjustments entry for the service fee.
- *
- * IQPro requires ServiceFee adjustments to be expressed as a percentage only —
- * passing a flatAmount with type: "ServiceFee" fails validation with
- * "ServiceFee must be expressed as a percentage". The gateway computes the
- * flat amount itself from the percentage.
- *
- * We still call /calculatefees upstream to preview the exact flat amount
- * (and surface it in our UI/receipts), but on the /transaction call we only
- * send the percentage.
- */
 export function buildServiceFeeAdjustment(breakdown: ComputedFeeBreakdown): {
   type: string;
   percentage: number;
@@ -536,16 +485,6 @@ export function buildServiceFeeAdjustment(breakdown: ComputedFeeBreakdown): {
   };
 }
 
-/**
- * Build the paymentAdjustments entry for sales tax. Used for TAXABLE
- * transactions only. Per Basys team guidance, tax is expressed solely via this
- * paymentAdjustment (not via remit.taxAmount) so it shows up distinctly in
- * reporting.
- *
- * IQPro requires Tax adjustments to be expressed as a flat amount only —
- * passing a percentage with type: "Tax" fails validation with
- * "Tax must be expressed as a flat amount".
- */
 export function buildTaxAdjustment(breakdown: ComputedFeeBreakdown): {
   type: string;
   percentage: null;
@@ -560,12 +499,6 @@ export function buildTaxAdjustment(breakdown: ComputedFeeBreakdown): {
 
 // ===== Transaction response parsing =====
 
-/**
- * Parse an IQPro transaction response into an approval status. IQPro returns
- * `status: "Captured" | "Settled" | "Authorized" | "Declined" | "Failed" |
- * "PendingSettlement"` etc. Anything not in the approved set is treated as
- * declined for safety — we never want to treat an ambiguous status as approved.
- */
 export function mapTransactionStatus(txData: Record<string, unknown>): 'approved' | 'declined' {
   const raw = ((txData.status ?? '') as string).toLowerCase();
   if (raw === 'captured' || raw === 'settled' || raw === 'authorized' || raw === 'pendingsettlement') {
@@ -574,11 +507,6 @@ export function mapTransactionStatus(txData: Record<string, unknown>): 'approved
   return 'declined';
 }
 
-/**
- * Throws if the transaction was not approved. The thrown Error's message
- * includes IQPro's processorResponseText when available so decline reasons
- * bubble up cleanly to the client.
- */
 export function assertTransactionApproved(txData: Record<string, unknown>): void {
   if (mapTransactionStatus(txData) === 'approved') {
     return;
@@ -601,22 +529,14 @@ export type SavedPaymentMethodInfo = {
   achToken?: string;
 };
 
-/**
- * Fetch a single saved payment method's details (BIN + last4 for card, achToken
- * for ACH) by querying the customer record. Used for vaulted-charge fee
- * calculation, since IQPro's /calculatefees endpoint requires a token or BIN
- * to derive the surcharge / service fee.
- */
 export async function getCustomerPaymentMethod(
+  config: IQProConfig,
   customerId: string,
   paymentMethodId: string,
 ): Promise<SavedPaymentMethodInfo | null> {
-  if (!isIQProConfigured()) {
-    return null;
-  }
-  const gatewayId = Env.IQPRO_GATEWAY_ID!;
   const res = await iqproGet<{ data?: Record<string, unknown> }>(
-    `/api/gateway/${gatewayId}/customer/${customerId}`,
+    config,
+    `/api/gateway/${config.gatewayId}/customer/${customerId}`,
   );
   const data = (res.data ?? res) as Record<string, unknown>;
   const paymentMethods = (data.paymentMethods ?? []) as Array<Record<string, unknown>>;
@@ -644,12 +564,12 @@ export async function getCustomerPaymentMethod(
   return null;
 }
 
-// Exported for testing – reset cached OAuth token
-export function resetOAuthToken(): void {
-  cachedOAuthToken = null;
+// ===== Test helpers =====
+
+export function resetOAuthTokenCache(): void {
+  oauthTokenCache.clear();
 }
 
-// Exported for testing – reset cached gateway processors
-export function resetGatewayProcessors(): void {
-  cachedProcessors = null;
+export function resetGatewayProcessorsCache(): void {
+  processorsCache.clear();
 }

--- a/src/models/Schema.ts
+++ b/src/models/Schema.ts
@@ -45,6 +45,10 @@ export const organizationSchema = pgTable(
     locationPhone: text('location_phone'),
     locationEmail: text('location_email'),
     locationTaxRate: real('location_tax_rate').default(0).notNull(),
+    // Per-org IQPro merchant credentials (override of IQPRO_* env vars)
+    iqproConfigClientId: text('iqpro_config_client_id'),
+    iqproConfigClientSecretEncrypted: text('iqpro_config_client_secret_enc'),
+    iqproConfigGatewayId: text('iqpro_config_gateway_id'),
     updatedAt: timestamp('updated_at', { mode: 'date' })
       .defaultNow()
       .$onUpdate(() => new Date())
@@ -56,6 +60,20 @@ export const organizationSchema = pgTable(
     uniqueIndex('iqpro_customer_id_idx').on(table.iqproCustomerId),
   ],
 );
+
+// Singleton row holding platform-level IQPro credentials used for
+// dojo-planner's own SaaS billing (charging customer orgs for the product).
+// The CHECK constraint id = 'singleton' enforces a single row.
+export const platformConfigSchema = pgTable('platform_config', {
+  id: text('id').primaryKey().default('singleton'),
+  iqproSaasClientId: text('iqpro_saas_client_id'),
+  iqproSaasClientSecretEncrypted: text('iqpro_saas_client_secret_enc'),
+  iqproSaasGatewayId: text('iqpro_saas_gateway_id'),
+  updatedAt: timestamp('updated_at', { mode: 'date' })
+    .defaultNow()
+    .$onUpdate(() => new Date())
+    .notNull(),
+});
 
 // Training programs (e.g., Adult BJJ, Kids, Competition)
 export const programSchema = pgTable(

--- a/src/routers/Payment.test.ts
+++ b/src/routers/Payment.test.ts
@@ -24,6 +24,19 @@ vi.mock('@/services/MemberPaymentService', () => ({
 vi.mock('@/libs/IQPro', () => ({
   getTokenizationConfig: vi.fn(),
 }));
+vi.mock('@/services/IQProConfigService', () => ({
+  resolveIQProConfig: vi.fn(),
+}));
+
+const testConfig = {
+  clientId: 'test-client-id',
+  clientSecret: 'test-client-secret',
+  gatewayId: 'test-gateway-001',
+  scope: 'test-scope',
+  oauthUrl: 'https://sandbox.oauth.example.com/token',
+  baseUrl: 'https://sandbox.api.basyspro.com',
+  source: 'env' as const,
+};
 
 const mockContext: AuditContext = {
   userId: 'test-user-123',
@@ -49,8 +62,10 @@ function callHandler(handler: unknown, input?: unknown) {
 }
 
 describe('Payment Router', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    const { resolveIQProConfig } = await import('@/services/IQProConfigService');
+    vi.mocked(resolveIQProConfig).mockResolvedValue(testConfig);
   });
 
   describe('processPayment', () => {
@@ -72,7 +87,7 @@ describe('Payment Router', () => {
       const result = await callHandler(processPayment, baseInput);
 
       expect(guardRole).toHaveBeenCalledWith(ORG_ROLE.FRONT_DESK);
-      expect(processMemberPayment).toHaveBeenCalledWith({
+      expect(processMemberPayment).toHaveBeenCalledWith(testConfig, {
         organizationId: 'test-org-456',
         ...baseInput,
       });
@@ -273,22 +288,23 @@ describe('Payment Router', () => {
       const result = await callHandler(getTokenizationIframeConfig, input);
 
       expect(guardRole).toHaveBeenCalledWith(ORG_ROLE.FRONT_DESK);
-      expect(getTokenizationConfig).toHaveBeenCalledWith('http://localhost:3000');
+      expect(getTokenizationConfig).toHaveBeenCalledWith(testConfig, 'http://localhost:3000');
       expect(result).toEqual(mockConfig);
     });
 
-    it('should return null when IQPro is not configured', async () => {
+    it('should throw 503 when IQPro is not configured for the org', async () => {
       const { guardRole } = await import('./AuthGuards');
-      const { getTokenizationConfig } = await import('@/libs/IQPro');
+      const { resolveIQProConfig } = await import('@/services/IQProConfigService');
 
       vi.mocked(guardRole).mockResolvedValue(mockContext);
-      vi.mocked(getTokenizationConfig).mockResolvedValue(null);
+      vi.mocked(resolveIQProConfig).mockResolvedValue(null);
 
       const { getTokenizationIframeConfig } = await import('./Payment');
       const input = { origin: 'http://localhost:3000' };
-      const result = await callHandler(getTokenizationIframeConfig, input);
 
-      expect(result).toBeNull();
+      await expect(callHandler(getTokenizationIframeConfig, input)).rejects.toThrow(
+        /Payment processing is not configured/,
+      );
     });
 
     it('should throw ORPCError when getTokenizationConfig fails', async () => {
@@ -347,7 +363,7 @@ describe('Payment Router', () => {
       const result = await callHandler(registerPaymentMethod, registerInput);
 
       expect(guardRole).toHaveBeenCalledWith(ORG_ROLE.FRONT_DESK);
-      expect(registerService).toHaveBeenCalledWith({
+      expect(registerService).toHaveBeenCalledWith(testConfig, {
         organizationId: 'test-org-456',
         ...registerInput,
       });

--- a/src/routers/Payment.ts
+++ b/src/routers/Payment.ts
@@ -4,6 +4,7 @@ import * as z from 'zod';
 import { getTokenizationConfig } from '@/libs/IQPro';
 import { logger } from '@/libs/Logger';
 import { audit } from '@/services/AuditService';
+import { resolveIQProConfig } from '@/services/IQProConfigService';
 import { processMemberPayment, registerPaymentMethod as registerPaymentMethodService } from '@/services/MemberPaymentService';
 import { AUDIT_ACTION, AUDIT_ENTITY_TYPE } from '@/types/Audit';
 import { ORG_ROLE } from '@/types/Auth';
@@ -11,14 +12,22 @@ import { ProcessPaymentValidation, RegisterPaymentMethodValidation } from '@/val
 
 import { guardRole } from './AuthGuards';
 
+async function requirePerOrgConfig(orgId: string) {
+  const config = await resolveIQProConfig(orgId);
+  if (!config) {
+    throw new ORPCError('Payment processing is not configured for this organization. Set IQPro credentials in Payment Settings.', { status: 503 });
+  }
+  return config;
+}
+
 export const getTokenizationIframeConfig = os
   .input(z.object({ origin: z.string().url() }))
   .handler(async ({ input }) => {
-    await guardRole(ORG_ROLE.FRONT_DESK);
+    const context = await guardRole(ORG_ROLE.FRONT_DESK);
+    const config = await requirePerOrgConfig(context.orgId);
 
     try {
-      const config = await getTokenizationConfig(input.origin);
-      return config;
+      return await getTokenizationConfig(config, input.origin);
     } catch (error) {
       logger.error('[Payment] Failed to get tokenization config', { error });
       throw new ORPCError('Failed to load payment configuration.', { status: 500 });
@@ -29,6 +38,7 @@ export const processPayment = os
   .input(ProcessPaymentValidation)
   .handler(async ({ input }) => {
     const context = await guardRole(ORG_ROLE.FRONT_DESK);
+    const config = await requirePerOrgConfig(context.orgId);
 
     try {
       logger.info('[Payment] Processing member payment', {
@@ -39,7 +49,7 @@ export const processPayment = os
         isTaxable: input.isTaxable,
       });
 
-      const result = await processMemberPayment({
+      const result = await processMemberPayment(config, {
         organizationId: context.orgId,
         ...input,
       });
@@ -82,6 +92,7 @@ export const registerPaymentMethod = os
   .input(RegisterPaymentMethodValidation)
   .handler(async ({ input }) => {
     const context = await guardRole(ORG_ROLE.FRONT_DESK);
+    const config = await requirePerOrgConfig(context.orgId);
 
     try {
       logger.info('[Payment] Registering payment method (no charge)', {
@@ -89,7 +100,7 @@ export const registerPaymentMethod = os
         paymentMethod: input.paymentMethod,
       });
 
-      const result = await registerPaymentMethodService({
+      const result = await registerPaymentMethodService(config, {
         organizationId: context.orgId,
         ...input,
       });

--- a/src/routers/PaymentSettings.test.ts
+++ b/src/routers/PaymentSettings.test.ts
@@ -1,0 +1,118 @@
+import type { AuditContext } from '@/types/Audit';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AUDIT_ACTION, AUDIT_ENTITY_TYPE } from '@/types/Audit';
+import { ORG_ROLE } from '@/types/Auth';
+
+vi.mock('@/libs/DB', () => ({ db: {} }));
+vi.mock('./AuthGuards', () => ({ guardRole: vi.fn() }));
+vi.mock('@/services/AuditService', () => ({ audit: vi.fn() }));
+vi.mock('@/services/IQProConfigService', () => ({
+  getIQProConfigForAdmin: vi.fn(),
+  updateIQProConfig: vi.fn(),
+}));
+
+const adminContext: AuditContext = { userId: 'u1', orgId: 'org-1', role: ORG_ROLE.ADMIN };
+
+function callHandler(handler: unknown, input?: unknown) {
+  const h = handler as { '~orpc': { handler: (args: Record<string, unknown>) => unknown } };
+  return h['~orpc'].handler({ input, context: undefined, errors: undefined });
+}
+
+describe('PaymentSettings Router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getConfig', () => {
+    it('admits ACADEMY_OWNER (and higher) and never returns the secret value', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { getIQProConfigForAdmin } = await import('@/services/IQProConfigService');
+      vi.mocked(guardRole).mockResolvedValue(adminContext);
+      vi.mocked(getIQProConfigForAdmin).mockResolvedValue({
+        clientId: 'cid',
+        gatewayId: 'gid',
+        hasSecret: true,
+        source: 'org',
+      });
+
+      const { getConfig } = await import('./PaymentSettings');
+      const result = await callHandler(getConfig);
+
+      expect(guardRole).toHaveBeenCalledWith(ORG_ROLE.ACADEMY_OWNER);
+      expect(result).toMatchObject({ clientId: 'cid', gatewayId: 'gid', hasSecret: true });
+      expect(JSON.stringify(result)).not.toContain('secret-value');
+    });
+  });
+
+  describe('updateConfig', () => {
+    it('persists the config and emits a success audit with secret-redacted change diff', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { updateIQProConfig } = await import('@/services/IQProConfigService');
+      const { audit } = await import('@/services/AuditService');
+      vi.mocked(guardRole).mockResolvedValue(adminContext);
+      vi.mocked(updateIQProConfig).mockResolvedValue({
+        clientIdChanged: true,
+        clientSecretChanged: true,
+        gatewayIdChanged: false,
+      });
+
+      const { updateConfig } = await import('./PaymentSettings');
+      const result = await callHandler(updateConfig, {
+        clientId: 'new-cid',
+        clientSecret: 'super-secret-value',
+        gatewayId: 'gid',
+      });
+
+      expect(result).toEqual({ success: true });
+
+      const auditCall = vi.mocked(audit).mock.calls[0]!;
+
+      expect(auditCall[1]).toBe(AUDIT_ACTION.IQPRO_CONFIG_UPDATE);
+      expect(auditCall[2]).toBe(AUDIT_ENTITY_TYPE.ORGANIZATION);
+      // The secret value must never appear in audit metadata.
+      expect(JSON.stringify(auditCall[3])).not.toContain('super-secret-value');
+      expect(auditCall[3]).toMatchObject({ status: 'success' });
+    });
+
+    it('treats blank clientSecret as "no change"', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { updateIQProConfig } = await import('@/services/IQProConfigService');
+      vi.mocked(guardRole).mockResolvedValue(adminContext);
+      vi.mocked(updateIQProConfig).mockResolvedValue({
+        clientIdChanged: false,
+        clientSecretChanged: false,
+        gatewayIdChanged: false,
+      });
+
+      const { updateConfig } = await import('./PaymentSettings');
+      await callHandler(updateConfig, {
+        clientId: 'cid',
+        gatewayId: 'gid',
+      });
+
+      expect(updateIQProConfig).toHaveBeenCalledWith('org-1', expect.objectContaining({
+        clientId: 'cid',
+        gatewayId: 'gid',
+      }));
+    });
+
+    it('emits failure audit and rethrows on service error', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { updateIQProConfig } = await import('@/services/IQProConfigService');
+      const { audit } = await import('@/services/AuditService');
+      vi.mocked(guardRole).mockResolvedValue(adminContext);
+      vi.mocked(updateIQProConfig).mockRejectedValue(new Error('encryption key missing'));
+
+      const { updateConfig } = await import('./PaymentSettings');
+
+      await expect(callHandler(updateConfig, { clientId: 'c', gatewayId: 'g' })).rejects.toThrow('encryption key missing');
+
+      expect(audit).toHaveBeenCalledWith(
+        adminContext,
+        AUDIT_ACTION.IQPRO_CONFIG_UPDATE,
+        AUDIT_ENTITY_TYPE.ORGANIZATION,
+        expect.objectContaining({ status: 'failure', error: 'encryption key missing' }),
+      );
+    });
+  });
+});

--- a/src/routers/PaymentSettings.ts
+++ b/src/routers/PaymentSettings.ts
@@ -1,0 +1,57 @@
+import { os } from '@orpc/server';
+import { audit } from '@/services/AuditService';
+import {
+  getIQProConfigForAdmin,
+  updateIQProConfig,
+} from '@/services/IQProConfigService';
+import { AUDIT_ACTION, AUDIT_ENTITY_TYPE } from '@/types/Audit';
+import { ORG_ROLE } from '@/types/Auth';
+import { UpdateIQProConfigValidation } from '@/validations/PaymentSettingsValidation';
+import { guardRole } from './AuthGuards';
+
+export const getConfig = os.handler(async () => {
+  // ACADEMY_OWNER (which admits both academy_owner and admin) can VIEW the
+  // current config; only ADMIN can mutate (see updateConfig below). The
+  // returned projection never includes the secret value.
+  const { orgId } = await guardRole(ORG_ROLE.ACADEMY_OWNER);
+  return getIQProConfigForAdmin(orgId);
+});
+
+export const updateConfig = os
+  .input(UpdateIQProConfigValidation)
+  .handler(async ({ input }) => {
+    const context = await guardRole(ORG_ROLE.ADMIN);
+
+    try {
+      const diff = await updateIQProConfig(context.orgId, input);
+
+      await audit(
+        context,
+        AUDIT_ACTION.IQPRO_CONFIG_UPDATE,
+        AUDIT_ENTITY_TYPE.ORGANIZATION,
+        {
+          entityId: context.orgId,
+          status: 'success',
+          changes: {
+            clientId: { before: undefined, after: diff.clientIdChanged ? '(changed)' : '(unchanged)' },
+            clientSecret: { before: undefined, after: diff.clientSecretChanged ? '(changed)' : '(unchanged)' },
+            gatewayId: { before: undefined, after: diff.gatewayIdChanged ? '(changed)' : '(unchanged)' },
+          },
+        },
+      );
+
+      return { success: true };
+    } catch (error) {
+      await audit(
+        context,
+        AUDIT_ACTION.IQPRO_CONFIG_UPDATE,
+        AUDIT_ENTITY_TYPE.ORGANIZATION,
+        {
+          entityId: context.orgId,
+          status: 'failure',
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+      );
+      throw error;
+    }
+  });

--- a/src/routers/PlatformSettings.test.ts
+++ b/src/routers/PlatformSettings.test.ts
@@ -1,0 +1,106 @@
+import type { AuditContext } from '@/types/Audit';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AUDIT_ACTION, AUDIT_ENTITY_TYPE } from '@/types/Audit';
+import { ORG_ROLE } from '@/types/Auth';
+
+vi.mock('@/libs/DB', () => ({ db: {} }));
+vi.mock('./AuthGuards', () => ({ guardRole: vi.fn() }));
+vi.mock('@/services/AuditService', () => ({ audit: vi.fn() }));
+vi.mock('@/services/IQProConfigService', () => ({
+  getPlatformConfigForAdmin: vi.fn(),
+  updatePlatformConfig: vi.fn(),
+}));
+vi.mock('@clerk/nextjs/server', () => ({ auth: vi.fn() }));
+
+const adminContext: AuditContext = { userId: 'u1', orgId: 'org-1', role: ORG_ROLE.ADMIN };
+
+function callHandler(handler: unknown, input?: unknown) {
+  const h = handler as { '~orpc': { handler: (args: Record<string, unknown>) => unknown } };
+  return h['~orpc'].handler({ input, context: undefined, errors: undefined });
+}
+
+describe('PlatformSettings Router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getPlatformConfig', () => {
+    it('rejects non-super-admin admins', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { auth } = await import('@clerk/nextjs/server');
+      vi.mocked(guardRole).mockResolvedValue(adminContext);
+      vi.mocked(auth).mockResolvedValue({ sessionClaims: { username: 'random-admin' } } as never);
+
+      const { getPlatformConfig } = await import('./PlatformSettings');
+
+      await expect(callHandler(getPlatformConfig)).rejects.toThrow(/super admin/i);
+    });
+
+    it('returns the projection for super-admin users', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { auth } = await import('@clerk/nextjs/server');
+      const { getPlatformConfigForAdmin } = await import('@/services/IQProConfigService');
+      vi.mocked(guardRole).mockResolvedValue(adminContext);
+      vi.mocked(auth).mockResolvedValue({ sessionClaims: { username: 'aguilanegra' } } as never);
+      vi.mocked(getPlatformConfigForAdmin).mockResolvedValue({
+        clientId: 'pcid',
+        gatewayId: 'pgid',
+        hasSecret: false,
+        source: 'env',
+      });
+
+      const { getPlatformConfig } = await import('./PlatformSettings');
+      const result = await callHandler(getPlatformConfig);
+
+      expect(result).toEqual({ clientId: 'pcid', gatewayId: 'pgid', hasSecret: false, source: 'env' });
+    });
+  });
+
+  describe('updatePlatformConfigHandler', () => {
+    it('persists and emits a success audit (with secret redacted)', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { auth } = await import('@clerk/nextjs/server');
+      const { updatePlatformConfig } = await import('@/services/IQProConfigService');
+      const { audit } = await import('@/services/AuditService');
+      vi.mocked(guardRole).mockResolvedValue(adminContext);
+      vi.mocked(auth).mockResolvedValue({ sessionClaims: { username: 'aguilanegra' } } as never);
+      vi.mocked(updatePlatformConfig).mockResolvedValue({
+        clientIdChanged: false,
+        clientSecretChanged: true,
+        gatewayIdChanged: false,
+      });
+
+      const { updatePlatformConfigHandler } = await import('./PlatformSettings');
+      const result = await callHandler(updatePlatformConfigHandler, {
+        clientId: 'cid',
+        clientSecret: 'super-secret-value',
+        gatewayId: 'gid',
+      });
+
+      expect(result).toEqual({ success: true });
+
+      const auditCall = vi.mocked(audit).mock.calls[0]!;
+
+      expect(auditCall[1]).toBe(AUDIT_ACTION.PLATFORM_IQPRO_CONFIG_UPDATE);
+      expect(auditCall[2]).toBe(AUDIT_ENTITY_TYPE.ORGANIZATION);
+      expect(JSON.stringify(auditCall[3])).not.toContain('super-secret-value');
+    });
+
+    it('rejects when a non-super-admin admin tries to update', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { auth } = await import('@clerk/nextjs/server');
+      const { updatePlatformConfig } = await import('@/services/IQProConfigService');
+      vi.mocked(guardRole).mockResolvedValue(adminContext);
+      vi.mocked(auth).mockResolvedValue({ sessionClaims: { username: 'org-admin' } } as never);
+
+      const { updatePlatformConfigHandler } = await import('./PlatformSettings');
+
+      await expect(callHandler(updatePlatformConfigHandler, {
+        clientId: 'cid',
+        clientSecret: 'x',
+        gatewayId: 'gid',
+      })).rejects.toThrow(/super admin/i);
+      expect(updatePlatformConfig).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/routers/PlatformSettings.ts
+++ b/src/routers/PlatformSettings.ts
@@ -1,0 +1,67 @@
+import { auth } from '@clerk/nextjs/server';
+import { ORPCError, os } from '@orpc/server';
+import { audit } from '@/services/AuditService';
+import {
+  getPlatformConfigForAdmin,
+  updatePlatformConfig,
+} from '@/services/IQProConfigService';
+import { AUDIT_ACTION, AUDIT_ENTITY_TYPE } from '@/types/Audit';
+import { ORG_ROLE } from '@/types/Auth';
+import { isSuperAdmin } from '@/utils/SuperAdmins';
+import { UpdateIQProConfigValidation } from '@/validations/PaymentSettingsValidation';
+import { guardRole } from './AuthGuards';
+
+async function requireSuperAdmin(): Promise<{ userId: string; orgId: string; username: string }> {
+  const context = await guardRole(ORG_ROLE.ADMIN);
+  const { sessionClaims } = await auth();
+  const username = (sessionClaims as Record<string, unknown> | null)?.username as string | undefined;
+  if (!isSuperAdmin(username)) {
+    throw new ORPCError('Platform settings can only be modified by super admins.', { status: 403 });
+  }
+  return { userId: context.userId, orgId: context.orgId, username: username! };
+}
+
+export const getPlatformConfig = os.handler(async () => {
+  await requireSuperAdmin();
+  return getPlatformConfigForAdmin();
+});
+
+export const updatePlatformConfigHandler = os
+  .input(UpdateIQProConfigValidation)
+  .handler(async ({ input }) => {
+    const su = await requireSuperAdmin();
+    const context = { userId: su.userId, orgId: su.orgId, role: ORG_ROLE.ADMIN } as const;
+
+    try {
+      const diff = await updatePlatformConfig(input);
+
+      await audit(
+        context,
+        AUDIT_ACTION.PLATFORM_IQPRO_CONFIG_UPDATE,
+        AUDIT_ENTITY_TYPE.ORGANIZATION,
+        {
+          entityId: 'platform',
+          status: 'success',
+          changes: {
+            clientId: { before: undefined, after: diff.clientIdChanged ? '(changed)' : '(unchanged)' },
+            clientSecret: { before: undefined, after: diff.clientSecretChanged ? '(changed)' : '(unchanged)' },
+            gatewayId: { before: undefined, after: diff.gatewayIdChanged ? '(changed)' : '(unchanged)' },
+          },
+        },
+      );
+
+      return { success: true };
+    } catch (error) {
+      await audit(
+        context,
+        AUDIT_ACTION.PLATFORM_IQPRO_CONFIG_UPDATE,
+        AUDIT_ENTITY_TYPE.ORGANIZATION,
+        {
+          entityId: 'platform',
+          status: 'failure',
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+      );
+      throw error;
+    }
+  });

--- a/src/routers/SaasSubscription.ts
+++ b/src/routers/SaasSubscription.ts
@@ -5,6 +5,7 @@ import * as z from 'zod';
 import { getTokenizationConfig } from '@/libs/IQPro';
 import { logger } from '@/libs/Logger';
 import { audit } from '@/services/AuditService';
+import { resolvePlatformIQProConfig } from '@/services/IQProConfigService';
 import {
   cancelSubscription,
   changePlan,
@@ -22,6 +23,14 @@ import {
 
 import { guardRole } from './AuthGuards';
 
+async function requirePlatformConfig() {
+  const config = await resolvePlatformIQProConfig();
+  if (!config) {
+    throw new ORPCError('SaaS billing is not configured. Set platform IQPro credentials in Platform Settings.', { status: 503 });
+  }
+  return config;
+}
+
 export const getCurrentPlan = os.handler(async () => {
   const context = await guardRole(ORG_ROLE.ACADEMY_OWNER);
   const { sessionClaims } = await auth();
@@ -34,9 +43,10 @@ export const subscribeToPlan = os
   .input(SubscribeValidation)
   .handler(async ({ input }) => {
     const context = await guardRole(ORG_ROLE.ADMIN);
+    const config = await requirePlatformConfig();
 
     try {
-      const result = await subscribe({
+      const result = await subscribe(config, {
         orgId: context.orgId,
         orgName: input.orgName,
         adminEmail: input.adminEmail,
@@ -80,9 +90,10 @@ export const changeSaasPlan = os
   .input(ChangePlanValidation)
   .handler(async ({ input }) => {
     const context = await guardRole(ORG_ROLE.ADMIN);
+    const config = await requirePlatformConfig();
 
     try {
-      const result = await changePlan(context.orgId, input.newPlanId, input.newBillingCycle);
+      const result = await changePlan(config, context.orgId, input.newPlanId, input.newBillingCycle);
 
       await audit(context, AUDIT_ACTION.SAAS_SUBSCRIPTION_CHANGE, AUDIT_ENTITY_TYPE.ORGANIZATION, {
         entityId: context.orgId,
@@ -111,9 +122,12 @@ export const cancelSaasSubscription = os
   .input(CancelSubscriptionValidation)
   .handler(async ({ input }) => {
     const context = await guardRole(ORG_ROLE.ADMIN);
+    // Resolve platform config best-effort — cancellation should still update
+    // local state even when IQPro is unreachable (or never configured).
+    const config = await resolvePlatformIQProConfig();
 
     try {
-      const result = await cancelSubscription(context.orgId, input.endOfPeriod);
+      const result = await cancelSubscription(config, context.orgId, input.endOfPeriod);
 
       await audit(context, AUDIT_ACTION.SAAS_SUBSCRIPTION_CANCEL, AUDIT_ENTITY_TYPE.ORGANIZATION, {
         entityId: context.orgId,
@@ -140,16 +154,18 @@ export const cancelSaasSubscription = os
 
 export const getSaasBillingHistory = os.handler(async () => {
   const context = await guardRole(ORG_ROLE.ACADEMY_OWNER);
-  return getBillingHistory(context.orgId);
+  const config = await resolvePlatformIQProConfig();
+  return getBillingHistory(config, context.orgId);
 });
 
 export const getSaasTokenizationConfig = os
   .input(z.object({ origin: z.string().url() }))
   .handler(async ({ input }) => {
     await guardRole(ORG_ROLE.ADMIN);
+    const config = await requirePlatformConfig();
 
     try {
-      return await getTokenizationConfig(input.origin);
+      return await getTokenizationConfig(config, input.origin);
     } catch (error) {
       logger.error('[SaaSSubscription] Failed to get tokenization config', { error });
       throw new ORPCError('Failed to load payment configuration.', { status: 500 });

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -27,6 +27,8 @@ import { create as createMembershipPlan, remove as removeMembershipPlan, update 
 import { create as createNoteHandler, list as listNotes, remove as removeNoteHandler, update as updateNoteHandler } from './Notes';
 import { getLocation as getOrganizationLocation, updateLocation as updateOrganizationLocation } from './Organization';
 import { getTokenizationIframeConfig, processPayment, registerPaymentMethod } from './Payment';
+import { getConfig as getPaymentSettingsConfig, updateConfig as updatePaymentSettingsConfig } from './PaymentSettings';
+import { getPlatformConfig as getPlatformSettingsConfig, updatePlatformConfigHandler as updatePlatformSettingsConfig } from './PlatformSettings';
 import { create as createProgram, list as listPrograms, remove as removeProgram, update as updateProgram } from './Programs';
 import { chartData as reportChartData, currentValues as reportCurrentValues, insights as reportInsights } from './Reports';
 import { create as createRole, remove as removeRole, update as updateRole } from './Roles';
@@ -120,6 +122,14 @@ export const router = {
     process: processPayment,
     registerPaymentMethod,
     getTokenizationConfig: getTokenizationIframeConfig,
+  },
+  paymentSettings: {
+    getConfig: getPaymentSettingsConfig,
+    updateConfig: updatePaymentSettingsConfig,
+  },
+  platformSettings: {
+    getConfig: getPlatformSettingsConfig,
+    updateConfig: updatePlatformSettingsConfig,
   },
   dashboard: {
     membershipStats,

--- a/src/scripts/backfillIQProConfig.ts
+++ b/src/scripts/backfillIQProConfig.ts
@@ -1,0 +1,68 @@
+/**
+ * One-shot script to backfill a specific organization's IQPro configuration
+ * columns from the legacy IQPRO_* environment variables.
+ *
+ * Run this when migrating an org from env-var-based IQPro config to the new
+ * per-org Payment Settings storage. The org's existing values in DB are
+ * OVERWRITTEN with what's in env. Run once, then optionally remove the env
+ * vars from the deployment.
+ *
+ * Usage:
+ *   DATABASE_URL=postgresql://... IQPRO_CLIENT_ID=... IQPRO_CLIENT_SECRET=... \
+ *   IQPRO_GATEWAY_ID=... IQPRO_CONFIG_ENCRYPTION_KEY=... \
+ *   npx tsx src/scripts/backfillIQProConfig.ts --orgId=org_xxx
+ */
+
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+import { encryptSecret } from '@/libs/Crypto';
+import { Env } from '@/libs/Env';
+import { organizationSchema } from '@/models/Schema';
+
+async function main() {
+  const orgIdArg = process.argv.find(a => a.startsWith('--orgId='));
+  const orgId = orgIdArg?.split('=')[1];
+  if (!orgId) {
+    console.error('Usage: tsx src/scripts/backfillIQProConfig.ts --orgId=org_xxx');
+    process.exit(1);
+  }
+
+  if (!Env.IQPRO_CLIENT_ID || !Env.IQPRO_CLIENT_SECRET || !Env.IQPRO_GATEWAY_ID) {
+    console.error('IQPRO_CLIENT_ID, IQPRO_CLIENT_SECRET, and IQPRO_GATEWAY_ID env vars must all be set.');
+    process.exit(1);
+  }
+  if (!Env.IQPRO_CONFIG_ENCRYPTION_KEY) {
+    console.error('IQPRO_CONFIG_ENCRYPTION_KEY must be set so the client secret can be encrypted at rest.');
+    process.exit(1);
+  }
+
+  const pool = new Pool({ connectionString: Env.DATABASE_URL });
+  const db = drizzle(pool);
+
+  const encrypted = encryptSecret(Env.IQPRO_CLIENT_SECRET);
+
+  // Upsert: keep the row if it exists, only updating the IQPro config columns.
+  const { eq } = await import('drizzle-orm');
+  const existing = await db.select().from(organizationSchema).where(eq(organizationSchema.id, orgId)).limit(1);
+  if (existing.length === 0) {
+    console.error(`Organization ${orgId} does not exist in the database. Aborting.`);
+    process.exit(1);
+  }
+
+  await db
+    .update(organizationSchema)
+    .set({
+      iqproConfigClientId: Env.IQPRO_CLIENT_ID,
+      iqproConfigClientSecretEncrypted: encrypted,
+      iqproConfigGatewayId: Env.IQPRO_GATEWAY_ID,
+    })
+    .where(eq(organizationSchema.id, orgId));
+
+  console.info(`Backfilled IQPro config for organization ${orgId}.`);
+  await pool.end();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/scripts/backfillPlatformIQProConfig.ts
+++ b/src/scripts/backfillPlatformIQProConfig.ts
@@ -1,0 +1,61 @@
+/**
+ * One-shot script to backfill the singleton platform_config row with the
+ * IQPro credentials used for SaaS billing — copies the values from the
+ * legacy IQPRO_* environment variables into the encrypted DB row.
+ *
+ * Run this when migrating dojo-planner's own SaaS-billing IQPro credentials
+ * from env vars to the new Platform Settings UI. Idempotent: re-running
+ * upserts the singleton row.
+ *
+ * Usage:
+ *   DATABASE_URL=postgresql://... IQPRO_CLIENT_ID=... IQPRO_CLIENT_SECRET=... \
+ *   IQPRO_GATEWAY_ID=... IQPRO_CONFIG_ENCRYPTION_KEY=... \
+ *   npx tsx src/scripts/backfillPlatformIQProConfig.ts
+ */
+
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+import { encryptSecret } from '@/libs/Crypto';
+import { Env } from '@/libs/Env';
+import { platformConfigSchema } from '@/models/Schema';
+
+async function main() {
+  if (!Env.IQPRO_CLIENT_ID || !Env.IQPRO_CLIENT_SECRET || !Env.IQPRO_GATEWAY_ID) {
+    console.error('IQPRO_CLIENT_ID, IQPRO_CLIENT_SECRET, and IQPRO_GATEWAY_ID env vars must all be set.');
+    process.exit(1);
+  }
+  if (!Env.IQPRO_CONFIG_ENCRYPTION_KEY) {
+    console.error('IQPRO_CONFIG_ENCRYPTION_KEY must be set so the client secret can be encrypted at rest.');
+    process.exit(1);
+  }
+
+  const pool = new Pool({ connectionString: Env.DATABASE_URL });
+  const db = drizzle(pool);
+
+  const encrypted = encryptSecret(Env.IQPRO_CLIENT_SECRET);
+
+  await db
+    .insert(platformConfigSchema)
+    .values({
+      id: 'singleton',
+      iqproSaasClientId: Env.IQPRO_CLIENT_ID,
+      iqproSaasClientSecretEncrypted: encrypted,
+      iqproSaasGatewayId: Env.IQPRO_GATEWAY_ID,
+    })
+    .onConflictDoUpdate({
+      target: platformConfigSchema.id,
+      set: {
+        iqproSaasClientId: Env.IQPRO_CLIENT_ID,
+        iqproSaasClientSecretEncrypted: encrypted,
+        iqproSaasGatewayId: Env.IQPRO_GATEWAY_ID,
+      },
+    });
+
+  console.info('Backfilled platform_config singleton with IQPro SaaS credentials.');
+  await pool.end();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/services/IQProConfigService.test.ts
+++ b/src/services/IQProConfigService.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const TEST_KEY_HEX = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+vi.mock('@/libs/Env', () => ({
+  Env: {
+    IQPRO_CONFIG_ENCRYPTION_KEY: TEST_KEY_HEX,
+    IQPRO_CLIENT_ID: 'env-client-id',
+    IQPRO_CLIENT_SECRET: 'env-client-secret',
+    IQPRO_GATEWAY_ID: 'env-gateway-id',
+    IQPRO_SCOPE: 'env-scope',
+    IQPRO_OAUTH_URL: 'https://oauth.example/token',
+    IQPRO_BASE_URL: 'https://api.example',
+  },
+}));
+
+vi.mock('@/libs/Logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((_col, val) => ({ _type: 'eq', value: val })),
+}));
+
+const orgFindFirst = vi.fn();
+const platformFindFirst = vi.fn();
+const insertOnConflict = vi.fn().mockResolvedValue(undefined);
+const insertValues = vi.fn().mockReturnValue({ onConflictDoUpdate: insertOnConflict });
+const insertFn = vi.fn().mockReturnValue({ values: insertValues });
+
+vi.mock('@/libs/DB', () => ({
+  db: {
+    query: {
+      organizationSchema: { findFirst: (...args: unknown[]) => orgFindFirst(...args) },
+      platformConfigSchema: { findFirst: (...args: unknown[]) => platformFindFirst(...args) },
+    },
+    insert: (...args: unknown[]) => insertFn(...args),
+  },
+}));
+
+describe('IQProConfigService', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { resetIQProConfigCache } = await import('./IQProConfigService');
+    resetIQProConfigCache();
+  });
+
+  describe('resolveIQProConfig (per-org)', () => {
+    it('returns env-only config when DB row has no IQPro fields set', async () => {
+      orgFindFirst.mockResolvedValueOnce({});
+      const { resolveIQProConfig } = await import('./IQProConfigService');
+      const config = await resolveIQProConfig('org_x');
+
+      expect(config).not.toBeNull();
+      expect(config?.clientId).toBe('env-client-id');
+      expect(config?.clientSecret).toBe('env-client-secret');
+      expect(config?.gatewayId).toBe('env-gateway-id');
+      expect(config?.scope).toBe('env-scope');
+      expect(config?.source).toBe('env');
+    });
+
+    it('prefers DB values over env on a per-field basis', async () => {
+      const { encryptSecret } = await import('@/libs/Crypto');
+      orgFindFirst.mockResolvedValueOnce({
+        iqproConfigClientId: 'org-client',
+        iqproConfigClientSecretEncrypted: encryptSecret('org-secret'),
+        iqproConfigGatewayId: 'org-gateway',
+      });
+      const { resolveIQProConfig } = await import('./IQProConfigService');
+      const config = await resolveIQProConfig('org_x');
+
+      expect(config?.clientId).toBe('org-client');
+      expect(config?.clientSecret).toBe('org-secret');
+      expect(config?.gatewayId).toBe('org-gateway');
+      expect(config?.source).toBe('org');
+    });
+
+    it('tags source as "mixed" when only some fields come from DB', async () => {
+      orgFindFirst.mockResolvedValueOnce({
+        iqproConfigClientId: 'org-client',
+      });
+      const { resolveIQProConfig } = await import('./IQProConfigService');
+      const config = await resolveIQProConfig('org_x');
+
+      expect(config?.source).toBe('mixed');
+      expect(config?.clientId).toBe('org-client');
+      expect(config?.clientSecret).toBe('env-client-secret');
+    });
+
+    it('caches the resolved config (second call does not hit the DB)', async () => {
+      orgFindFirst.mockResolvedValueOnce({});
+      const { resolveIQProConfig } = await import('./IQProConfigService');
+      await resolveIQProConfig('org_x');
+      await resolveIQProConfig('org_x');
+
+      expect(orgFindFirst).toHaveBeenCalledTimes(1);
+    });
+
+    it('invalidates the cache after updateIQProConfig', async () => {
+      orgFindFirst.mockResolvedValue({});
+      const { resolveIQProConfig, updateIQProConfig } = await import('./IQProConfigService');
+      await resolveIQProConfig('org_x');
+      await updateIQProConfig('org_x', { clientId: 'new', clientSecret: 'new', gatewayId: 'new' });
+      await resolveIQProConfig('org_x');
+
+      // 1 read for initial resolve, 1 read inside updateIQProConfig for diff, 1 for re-resolve
+      expect(orgFindFirst).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('getIQProConfigForAdmin', () => {
+    it('never returns the secret value, only hasSecret', async () => {
+      const { encryptSecret } = await import('@/libs/Crypto');
+      orgFindFirst.mockResolvedValueOnce({
+        iqproConfigClientId: 'org-client',
+        iqproConfigClientSecretEncrypted: encryptSecret('super-secret'),
+        iqproConfigGatewayId: 'org-gateway',
+      });
+      const { getIQProConfigForAdmin } = await import('./IQProConfigService');
+      const projection = await getIQProConfigForAdmin('org_x');
+
+      expect(JSON.stringify(projection)).not.toContain('super-secret');
+      expect(projection.hasSecret).toBe(true);
+      expect(projection.source).toBe('org');
+    });
+  });
+
+  describe('updateIQProConfig', () => {
+    it('encrypts the secret before persisting', async () => {
+      orgFindFirst.mockResolvedValueOnce({});
+      const { updateIQProConfig } = await import('./IQProConfigService');
+      await updateIQProConfig('org_x', { clientId: 'c', clientSecret: 'shhh', gatewayId: 'g' });
+
+      const payload = insertValues.mock.calls[0]?.[0] as Record<string, unknown>;
+
+      expect(payload.iqproConfigClientSecretEncrypted).toBeTypeOf('string');
+      expect(payload.iqproConfigClientSecretEncrypted).not.toBe('shhh');
+    });
+
+    it('does NOT touch the secret column when clientSecret is blank/omitted', async () => {
+      orgFindFirst.mockResolvedValueOnce({ iqproConfigClientId: 'old' });
+      const { updateIQProConfig } = await import('./IQProConfigService');
+      const diff = await updateIQProConfig('org_x', { clientId: 'new', gatewayId: 'g' });
+
+      const payload = insertValues.mock.calls[0]?.[0] as Record<string, unknown>;
+
+      expect(payload).not.toHaveProperty('iqproConfigClientSecretEncrypted');
+      expect(diff.clientSecretChanged).toBe(false);
+    });
+
+    it('reports clientSecretChanged=true when a new secret is provided', async () => {
+      orgFindFirst.mockResolvedValueOnce({});
+      const { updateIQProConfig } = await import('./IQProConfigService');
+      const diff = await updateIQProConfig('org_x', { clientId: 'c', clientSecret: 'new', gatewayId: 'g' });
+
+      expect(diff.clientSecretChanged).toBe(true);
+    });
+  });
+
+  describe('resolvePlatformIQProConfig', () => {
+    it('returns env-only when platform_config row is missing', async () => {
+      platformFindFirst.mockResolvedValueOnce(undefined);
+      const { resolvePlatformIQProConfig } = await import('./IQProConfigService');
+      const config = await resolvePlatformIQProConfig();
+
+      expect(config?.source).toBe('env');
+      expect(config?.clientId).toBe('env-client-id');
+    });
+
+    it('uses DB values when present and tags source as "platform"', async () => {
+      const { encryptSecret } = await import('@/libs/Crypto');
+      platformFindFirst.mockResolvedValueOnce({
+        iqproSaasClientId: 'saas-client',
+        iqproSaasClientSecretEncrypted: encryptSecret('saas-secret'),
+        iqproSaasGatewayId: 'saas-gateway',
+      });
+      const { resolvePlatformIQProConfig } = await import('./IQProConfigService');
+      const config = await resolvePlatformIQProConfig();
+
+      expect(config?.clientId).toBe('saas-client');
+      expect(config?.clientSecret).toBe('saas-secret');
+      expect(config?.gatewayId).toBe('saas-gateway');
+      expect(config?.source).toBe('platform');
+    });
+
+    it('caches and invalidates on updatePlatformConfig', async () => {
+      platformFindFirst.mockResolvedValue(undefined);
+      const { resolvePlatformIQProConfig, updatePlatformConfig } = await import('./IQProConfigService');
+      await resolvePlatformIQProConfig();
+      await resolvePlatformIQProConfig();
+
+      expect(platformFindFirst).toHaveBeenCalledTimes(1);
+
+      await updatePlatformConfig({ clientId: 'c', clientSecret: 's', gatewayId: 'g' });
+      await resolvePlatformIQProConfig();
+
+      // 1 cached resolve, 1 read inside update for diff, 1 re-resolve after invalidate
+      expect(platformFindFirst).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('config resolution returns null', () => {
+    it('when env and DB both miss a required field', async () => {
+      vi.resetModules();
+      vi.doMock('@/libs/Env', () => ({
+        Env: { IQPRO_CONFIG_ENCRYPTION_KEY: TEST_KEY_HEX }, // no other IQPRO_*
+      }));
+      orgFindFirst.mockResolvedValueOnce({});
+      const { resolveIQProConfig } = await import('./IQProConfigService');
+      const config = await resolveIQProConfig('org_x');
+
+      expect(config).toBeNull();
+    });
+  });
+});

--- a/src/services/IQProConfigService.ts
+++ b/src/services/IQProConfigService.ts
@@ -1,0 +1,356 @@
+/**
+ * Resolves the IQPro configuration to use for a given flow:
+ *
+ *  - **Per-org (customer payments):** `resolveIQProConfig(orgId)` reads
+ *    `clientId`, `clientSecret`, `gatewayId` from the org row, falling back
+ *    to `IQPRO_*` env vars per field. Platform values (`scope`, `oauthUrl`,
+ *    `baseUrl`) are always from env.
+ *
+ *  - **Platform (SaaS billing):** `resolvePlatformIQProConfig()` reads the
+ *    same 3 values from the singleton `platform_config` row, falling back
+ *    to env vars per field.
+ *
+ * Each resolver caches its result for 60s to absorb burst payment traffic.
+ * `updateIQProConfig` / `updatePlatformConfig` invalidate the relevant
+ * cache entry.
+ *
+ * Secrets are encrypted at rest with AES-256-GCM (see `Crypto.ts`).
+ */
+
+import { eq } from 'drizzle-orm';
+import { decryptSecret, encryptSecret } from '@/libs/Crypto';
+import { db } from '@/libs/DB';
+import { Env } from '@/libs/Env';
+import { logger } from '@/libs/Logger';
+import { organizationSchema, platformConfigSchema } from '@/models/Schema';
+
+const PLATFORM_CONFIG_ID = 'singleton';
+const CACHE_TTL_MS = 60_000;
+const PER_ORG_CACHE_MAX = 200;
+
+export type IQProConfig = {
+  clientId: string;
+  clientSecret: string;
+  gatewayId: string;
+  scope: string;
+  oauthUrl: string;
+  baseUrl: string;
+  source: 'org' | 'env' | 'mixed' | 'platform';
+};
+
+export type IQProConfigPublic = {
+  clientId: string | null;
+  gatewayId: string | null;
+  hasSecret: boolean;
+  source: 'org' | 'env' | 'mixed' | 'platform';
+};
+
+export type UpdateIQProConfigInput = {
+  clientId: string;
+  clientSecret?: string;
+  gatewayId: string;
+};
+
+// ---------- caches ----------
+
+type CacheEntry = { config: IQProConfig; expiresAt: number };
+
+const perOrgCache = new Map<string, CacheEntry>();
+let platformCache: CacheEntry | null = null;
+
+function cacheGetOrg(orgId: string): IQProConfig | null {
+  const entry = perOrgCache.get(orgId);
+  if (!entry) {
+    return null;
+  }
+  if (Date.now() > entry.expiresAt) {
+    perOrgCache.delete(orgId);
+    return null;
+  }
+  return entry.config;
+}
+
+function cacheSetOrg(orgId: string, config: IQProConfig): void {
+  if (perOrgCache.size >= PER_ORG_CACHE_MAX) {
+    const firstKey = perOrgCache.keys().next().value;
+    if (firstKey !== undefined) {
+      perOrgCache.delete(firstKey);
+    }
+  }
+  perOrgCache.set(orgId, { config, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+function cacheGetPlatform(): IQProConfig | null {
+  if (!platformCache) {
+    return null;
+  }
+  if (Date.now() > platformCache.expiresAt) {
+    platformCache = null;
+    return null;
+  }
+  return platformCache.config;
+}
+
+function cacheSetPlatform(config: IQProConfig): void {
+  platformCache = { config, expiresAt: Date.now() + CACHE_TTL_MS };
+}
+
+export function resetIQProConfigCache(): void {
+  perOrgCache.clear();
+  platformCache = null;
+}
+
+// ---------- helpers ----------
+
+function buildConfig(
+  source: { clientId: string | null | undefined; clientSecret: string | null | undefined; gatewayId: string | null | undefined },
+  dbHasAnyField: boolean,
+): IQProConfig | null {
+  const clientId = source.clientId ?? Env.IQPRO_CLIENT_ID ?? null;
+  const clientSecret = source.clientSecret ?? Env.IQPRO_CLIENT_SECRET ?? null;
+  const gatewayId = source.gatewayId ?? Env.IQPRO_GATEWAY_ID ?? null;
+  const scope = Env.IQPRO_SCOPE ?? null;
+  const oauthUrl = Env.IQPRO_OAUTH_URL ?? null;
+  const baseUrl = Env.IQPRO_BASE_URL ?? null;
+
+  if (!clientId || !clientSecret || !gatewayId || !scope || !oauthUrl || !baseUrl) {
+    return null;
+  }
+
+  const dbFields = [source.clientId, source.clientSecret, source.gatewayId];
+  const dbCount = dbFields.filter(v => v != null).length;
+  let computedSource: IQProConfig['source'];
+  if (!dbHasAnyField || dbCount === 0) {
+    computedSource = 'env';
+  } else if (dbCount === 3) {
+    computedSource = 'org';
+  } else {
+    computedSource = 'mixed';
+  }
+
+  return { clientId, clientSecret, gatewayId, scope, oauthUrl, baseUrl, source: computedSource };
+}
+
+function decryptOrNull(enc: string | null | undefined): string | null {
+  if (!enc) {
+    return null;
+  }
+  try {
+    return decryptSecret(enc);
+  } catch (err) {
+    logger.error('[IQProConfig] failed to decrypt client secret', { error: err instanceof Error ? err.message : 'unknown' });
+    throw new Error('Failed to decrypt stored IQPro client secret');
+  }
+}
+
+// ---------- per-org (customer flow) ----------
+
+export async function resolveIQProConfig(orgId: string): Promise<IQProConfig | null> {
+  const cached = cacheGetOrg(orgId);
+  if (cached) {
+    return cached;
+  }
+
+  const row = await db.query.organizationSchema.findFirst({
+    where: eq(organizationSchema.id, orgId),
+    columns: {
+      iqproConfigClientId: true,
+      iqproConfigClientSecretEncrypted: true,
+      iqproConfigGatewayId: true,
+    },
+  });
+
+  const dbClientId = row?.iqproConfigClientId ?? null;
+  const dbSecret = decryptOrNull(row?.iqproConfigClientSecretEncrypted);
+  const dbGatewayId = row?.iqproConfigGatewayId ?? null;
+  const dbHasAnyField = Boolean(dbClientId || dbSecret || dbGatewayId);
+
+  const config = buildConfig({ clientId: dbClientId, clientSecret: dbSecret, gatewayId: dbGatewayId }, dbHasAnyField);
+  if (config) {
+    cacheSetOrg(orgId, config);
+  }
+  return config;
+}
+
+export async function isIQProConfiguredForOrg(orgId: string): Promise<boolean> {
+  return (await resolveIQProConfig(orgId)) !== null;
+}
+
+export async function getIQProConfigForAdmin(orgId: string): Promise<IQProConfigPublic> {
+  const row = await db.query.organizationSchema.findFirst({
+    where: eq(organizationSchema.id, orgId),
+    columns: {
+      iqproConfigClientId: true,
+      iqproConfigClientSecretEncrypted: true,
+      iqproConfigGatewayId: true,
+    },
+  });
+
+  const dbHasAnyField = Boolean(
+    row?.iqproConfigClientId || row?.iqproConfigClientSecretEncrypted || row?.iqproConfigGatewayId,
+  );
+  const dbCount = [row?.iqproConfigClientId, row?.iqproConfigClientSecretEncrypted, row?.iqproConfigGatewayId].filter(Boolean).length;
+
+  let source: IQProConfigPublic['source'];
+  if (!dbHasAnyField) {
+    source = 'env';
+  } else if (dbCount === 3) {
+    source = 'org';
+  } else {
+    source = 'mixed';
+  }
+
+  return {
+    clientId: row?.iqproConfigClientId ?? Env.IQPRO_CLIENT_ID ?? null,
+    gatewayId: row?.iqproConfigGatewayId ?? Env.IQPRO_GATEWAY_ID ?? null,
+    hasSecret: Boolean(row?.iqproConfigClientSecretEncrypted) || Boolean(Env.IQPRO_CLIENT_SECRET),
+    source,
+  };
+}
+
+export type IQProConfigUpdateDiff = {
+  clientIdChanged: boolean;
+  clientSecretChanged: boolean;
+  gatewayIdChanged: boolean;
+};
+
+export async function updateIQProConfig(
+  orgId: string,
+  input: UpdateIQProConfigInput,
+): Promise<IQProConfigUpdateDiff> {
+  const existing = await db.query.organizationSchema.findFirst({
+    where: eq(organizationSchema.id, orgId),
+    columns: {
+      iqproConfigClientId: true,
+      iqproConfigClientSecretEncrypted: true,
+      iqproConfigGatewayId: true,
+    },
+  });
+
+  const diff: IQProConfigUpdateDiff = {
+    clientIdChanged: existing?.iqproConfigClientId !== input.clientId,
+    clientSecretChanged: input.clientSecret != null && input.clientSecret !== '',
+    gatewayIdChanged: existing?.iqproConfigGatewayId !== input.gatewayId,
+  };
+
+  const set: Partial<typeof organizationSchema.$inferInsert> = {
+    iqproConfigClientId: input.clientId,
+    iqproConfigGatewayId: input.gatewayId,
+  };
+  if (diff.clientSecretChanged && input.clientSecret) {
+    set.iqproConfigClientSecretEncrypted = encryptSecret(input.clientSecret);
+  }
+
+  await db
+    .insert(organizationSchema)
+    .values({ id: orgId, ...set })
+    .onConflictDoUpdate({
+      target: organizationSchema.id,
+      set,
+    });
+
+  perOrgCache.delete(orgId);
+  return diff;
+}
+
+// ---------- platform (SaaS billing) ----------
+
+export async function resolvePlatformIQProConfig(): Promise<IQProConfig | null> {
+  const cached = cacheGetPlatform();
+  if (cached) {
+    return cached;
+  }
+
+  const row = await db.query.platformConfigSchema.findFirst({
+    where: eq(platformConfigSchema.id, PLATFORM_CONFIG_ID),
+    columns: {
+      iqproSaasClientId: true,
+      iqproSaasClientSecretEncrypted: true,
+      iqproSaasGatewayId: true,
+    },
+  });
+
+  const dbClientId = row?.iqproSaasClientId ?? null;
+  const dbSecret = decryptOrNull(row?.iqproSaasClientSecretEncrypted);
+  const dbGatewayId = row?.iqproSaasGatewayId ?? null;
+  const dbHasAnyField = Boolean(dbClientId || dbSecret || dbGatewayId);
+
+  const config = buildConfig({ clientId: dbClientId, clientSecret: dbSecret, gatewayId: dbGatewayId }, dbHasAnyField);
+  if (!config) {
+    return null;
+  }
+  // Re-tag the source for platform flow: 'org' becomes 'platform'.
+  const tagged: IQProConfig = { ...config, source: config.source === 'org' ? 'platform' : config.source };
+  cacheSetPlatform(tagged);
+  return tagged;
+}
+
+export async function getPlatformConfigForAdmin(): Promise<IQProConfigPublic> {
+  const row = await db.query.platformConfigSchema.findFirst({
+    where: eq(platformConfigSchema.id, PLATFORM_CONFIG_ID),
+    columns: {
+      iqproSaasClientId: true,
+      iqproSaasClientSecretEncrypted: true,
+      iqproSaasGatewayId: true,
+    },
+  });
+
+  const dbHasAnyField = Boolean(
+    row?.iqproSaasClientId || row?.iqproSaasClientSecretEncrypted || row?.iqproSaasGatewayId,
+  );
+  const dbCount = [row?.iqproSaasClientId, row?.iqproSaasClientSecretEncrypted, row?.iqproSaasGatewayId].filter(Boolean).length;
+
+  let source: IQProConfigPublic['source'];
+  if (!dbHasAnyField) {
+    source = 'env';
+  } else if (dbCount === 3) {
+    source = 'platform';
+  } else {
+    source = 'mixed';
+  }
+
+  return {
+    clientId: row?.iqproSaasClientId ?? Env.IQPRO_CLIENT_ID ?? null,
+    gatewayId: row?.iqproSaasGatewayId ?? Env.IQPRO_GATEWAY_ID ?? null,
+    hasSecret: Boolean(row?.iqproSaasClientSecretEncrypted) || Boolean(Env.IQPRO_CLIENT_SECRET),
+    source,
+  };
+}
+
+export async function updatePlatformConfig(
+  input: UpdateIQProConfigInput,
+): Promise<IQProConfigUpdateDiff> {
+  const existing = await db.query.platformConfigSchema.findFirst({
+    where: eq(platformConfigSchema.id, PLATFORM_CONFIG_ID),
+    columns: {
+      iqproSaasClientId: true,
+      iqproSaasClientSecretEncrypted: true,
+      iqproSaasGatewayId: true,
+    },
+  });
+
+  const diff: IQProConfigUpdateDiff = {
+    clientIdChanged: existing?.iqproSaasClientId !== input.clientId,
+    clientSecretChanged: input.clientSecret != null && input.clientSecret !== '',
+    gatewayIdChanged: existing?.iqproSaasGatewayId !== input.gatewayId,
+  };
+
+  const set: Partial<typeof platformConfigSchema.$inferInsert> = {
+    iqproSaasClientId: input.clientId,
+    iqproSaasGatewayId: input.gatewayId,
+  };
+  if (diff.clientSecretChanged && input.clientSecret) {
+    set.iqproSaasClientSecretEncrypted = encryptSecret(input.clientSecret);
+  }
+
+  await db
+    .insert(platformConfigSchema)
+    .values({ id: PLATFORM_CONFIG_ID, ...set })
+    .onConflictDoUpdate({
+      target: platformConfigSchema.id,
+      set,
+    });
+
+  platformCache = null;
+  return diff;
+}

--- a/src/services/IQProPaymentService.test.ts
+++ b/src/services/IQProPaymentService.test.ts
@@ -23,6 +23,16 @@ vi.mock('@/libs/Logger', () => ({
   logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
 }));
 
+const testConfig = {
+  clientId: 'test-client-id',
+  clientSecret: 'test-client-secret',
+  gatewayId: 'test-gateway-001',
+  scope: 'test-scope',
+  oauthUrl: 'https://sandbox.oauth.example.com/token',
+  baseUrl: 'https://sandbox.api.basyspro.com',
+  source: 'env' as const,
+};
+
 describe('IQProPaymentProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -51,7 +61,7 @@ describe('IQProPaymentProvider', () => {
         },
       });
 
-      const result = await provider.createCustomer({
+      const result = await provider.createCustomer(testConfig, {
         organizationId: 'org_x',
         memberId: 'mem_42',
         email: 'jane@example.com',
@@ -71,6 +81,7 @@ describe('IQProPaymentProvider', () => {
       expect(result).toEqual({ customerId: 'cust_123', billingAddressId: 'addr_billing_1' });
 
       expect(iqproPost).toHaveBeenCalledWith(
+        testConfig,
         '/api/gateway/test-gateway-001/customer',
         expect.objectContaining({
           name: 'Jane Doe',
@@ -93,7 +104,7 @@ describe('IQProPaymentProvider', () => {
         }),
       );
 
-      expect(iqproGet).toHaveBeenCalledWith('/api/gateway/test-gateway-001/customer/cust_123');
+      expect(iqproGet).toHaveBeenCalledWith(testConfig, '/api/gateway/test-gateway-001/customer/cust_123');
     });
 
     it('skips the GET when no address is supplied', async () => {
@@ -101,7 +112,7 @@ describe('IQProPaymentProvider', () => {
 
       iqproPost.mockResolvedValueOnce({ data: { customerId: 'cust_noaddr' } });
 
-      const result = await provider.createCustomer({
+      const result = await provider.createCustomer(testConfig, {
         organizationId: 'org_x',
         memberId: 'mem_99',
         email: 'noaddr@example.com',
@@ -120,7 +131,7 @@ describe('IQProPaymentProvider', () => {
 
       iqproPost.mockResolvedValueOnce({ data: { customerPaymentMethodId: 'pm_card_1', last4: '4242' } });
 
-      const result = await provider.createPaymentMethod({
+      const result = await provider.createPaymentMethod(testConfig, {
         customerId: 'cust_123',
         paymentMethod: 'card',
         cardToken: 'tex-tok-abc',
@@ -133,6 +144,7 @@ describe('IQProPaymentProvider', () => {
       expect(result.last4).toBe('4242');
 
       expect(iqproPost).toHaveBeenCalledWith(
+        testConfig,
         '/api/gateway/test-gateway-001/customer/cust_123/payment',
         {
           card: {
@@ -151,7 +163,7 @@ describe('IQProPaymentProvider', () => {
       tokenizeAch.mockResolvedValueOnce({ achToken: 'ach-tok-xyz' });
       iqproPost.mockResolvedValueOnce({ data: { customerPaymentMethodId: 'pm_ach_1' } });
 
-      const result = await provider.createPaymentMethod({
+      const result = await provider.createPaymentMethod(testConfig, {
         customerId: 'cust_123',
         paymentMethod: 'ach',
         achRoutingNumber: '021000021',
@@ -162,7 +174,7 @@ describe('IQProPaymentProvider', () => {
       expect(result.paymentMethodId).toBe('pm_ach_1');
       expect(result.achToken).toBe('ach-tok-xyz');
 
-      expect(tokenizeAch).toHaveBeenCalledWith({
+      expect(tokenizeAch).toHaveBeenCalledWith(testConfig, {
         accountNumber: '987654321',
         routingNumber: '021000021',
         secCode: 'PPD',
@@ -170,6 +182,7 @@ describe('IQProPaymentProvider', () => {
       });
 
       expect(iqproPost).toHaveBeenCalledWith(
+        testConfig,
         '/api/gateway/test-gateway-001/customer/cust_123/payment',
         {
           ach: {
@@ -223,7 +236,7 @@ describe('IQProPaymentProvider', () => {
         data: { transaction: { transactionId: 'tx_42', status: 'Captured' } },
       });
 
-      const result = await provider.processPayment({
+      const result = await provider.processPayment(testConfig, {
         customerId: 'cust_123',
         paymentMethodId: 'pm_card_1',
         amount: 103.75,
@@ -236,7 +249,7 @@ describe('IQProPaymentProvider', () => {
 
       expect(result.success).toBe(true);
 
-      const p = iqproPost.mock.calls[0]![1] as Record<string, any>;
+      const p = iqproPost.mock.calls[0]![2] as Record<string, any>;
 
       // Non-taxable remit: taxAmount: 0, isTaxExempt: true
       expect(p.remit).toEqual({
@@ -276,7 +289,7 @@ describe('IQProPaymentProvider', () => {
         data: { transaction: { transactionId: 'tx_ach', status: 'Captured' } },
       });
 
-      await provider.processPayment({
+      await provider.processPayment(testConfig, {
         customerId: 'cust_123',
         paymentMethodId: 'pm_ach_1',
         amount: 103.75,
@@ -292,7 +305,7 @@ describe('IQProPaymentProvider', () => {
         billingAddress: baseBilling,
       });
 
-      const p = iqproPost.mock.calls[0]![1] as Record<string, any>;
+      const p = iqproPost.mock.calls[0]![2] as Record<string, any>;
 
       // ACH new-charge: inline ach, NOT customer-ref (matches kiosk)
       expect(p.paymentMethod).toEqual({
@@ -315,7 +328,7 @@ describe('IQProPaymentProvider', () => {
         data: { transaction: { transactionId: 'tx_event', status: 'Captured' } },
       });
 
-      await provider.processPayment({
+      await provider.processPayment(testConfig, {
         customerId: 'cust_123',
         paymentMethodId: 'pm_card_1',
         amount: 107.5,
@@ -326,7 +339,7 @@ describe('IQProPaymentProvider', () => {
         billingAddress: baseBilling,
       });
 
-      const p = iqproPost.mock.calls[0]![1] as Record<string, any>;
+      const p = iqproPost.mock.calls[0]![2] as Record<string, any>;
 
       // Taxable remit: taxAmount: null + isTaxExempt: false
       expect(p.remit.taxAmount).toBeNull();
@@ -346,7 +359,7 @@ describe('IQProPaymentProvider', () => {
         data: { transaction: { transactionId: 'tx_vault', status: 'Captured' } },
       });
 
-      await provider.processPayment({
+      await provider.processPayment(testConfig, {
         customerId: 'cust_existing',
         paymentMethodId: 'pm_saved',
         amount: 103.75,
@@ -358,7 +371,7 @@ describe('IQProPaymentProvider', () => {
         billingAddress: baseBilling,
       });
 
-      const p = iqproPost.mock.calls[0]![1] as Record<string, any>;
+      const p = iqproPost.mock.calls[0]![2] as Record<string, any>;
 
       // Vaulted: no customerBillingAddressId in customer ref
       expect(p.paymentMethod).toEqual({
@@ -377,7 +390,7 @@ describe('IQProPaymentProvider', () => {
         data: { transaction: { transactionId: 'tx_vault_ach', status: 'Captured' } },
       });
 
-      await provider.processPayment({
+      await provider.processPayment(testConfig, {
         customerId: 'cust_existing',
         paymentMethodId: 'pm_ach_saved',
         amount: 103.75,
@@ -394,7 +407,7 @@ describe('IQProPaymentProvider', () => {
         },
       });
 
-      const p = iqproPost.mock.calls[0]![1] as Record<string, any>;
+      const p = iqproPost.mock.calls[0]![2] as Record<string, any>;
 
       expect(p.paymentMethod).toEqual({
         customer: {
@@ -417,7 +430,7 @@ describe('IQProPaymentProvider', () => {
         },
       });
 
-      const result = await provider.processPayment({
+      const result = await provider.processPayment(testConfig, {
         customerId: 'cust_123',
         paymentMethodId: 'pm_ach_1',
         amount: 100,
@@ -448,7 +461,7 @@ describe('IQProPaymentProvider', () => {
         },
       });
 
-      const result = await provider.processPayment({
+      const result = await provider.processPayment(testConfig, {
         customerId: 'cust_123',
         paymentMethodId: 'pm_card_1',
         amount: 100,
@@ -465,7 +478,7 @@ describe('IQProPaymentProvider', () => {
       const { provider, iqproPost } = await loadProvider();
       iqproPost.mockRejectedValueOnce(new Error('boom'));
 
-      const result = await provider.processPayment({
+      const result = await provider.processPayment(testConfig, {
         customerId: 'cust_123',
         paymentMethodId: 'pm_card_1',
         amount: 100,
@@ -485,7 +498,7 @@ describe('IQProPaymentProvider', () => {
 
       iqproPost.mockResolvedValueOnce({ data: { subscriptionId: 'sub_1' } });
 
-      const result = await provider.createSubscription({
+      const result = await provider.createSubscription(testConfig, {
         customerId: 'cust_123',
         paymentMethodId: 'pm_card_1',
         amount: 99,
@@ -509,7 +522,7 @@ describe('IQProPaymentProvider', () => {
       expect(result.success).toBe(true);
       expect(result.subscriptionId).toBe('sub_1');
 
-      const [path, payload] = iqproPost.mock.calls[0]!;
+      const [, path, payload] = iqproPost.mock.calls[0]!;
 
       expect(path).toBe('/api/gateway/test-gateway-001/subscription');
 
@@ -533,7 +546,7 @@ describe('IQProPaymentProvider', () => {
 
       iqproPost.mockResolvedValueOnce({ data: { subscriptionId: 'sub_annual' } });
 
-      await provider.createSubscription({
+      await provider.createSubscription(testConfig, {
         customerId: 'cust_123',
         paymentMethodId: 'pm_card_1',
         amount: 999,
@@ -545,7 +558,7 @@ describe('IQProPaymentProvider', () => {
         email: 'jane@example.com',
       });
 
-      const p = iqproPost.mock.calls[0]![1] as Record<string, any>;
+      const p = iqproPost.mock.calls[0]![2] as Record<string, any>;
 
       expect(p.recurrence.billingPeriodId).toBe(6);
       expect(p.recurrence.schedule).toEqual({ minutes: [0], hours: [0], daysOfMonth: [15], monthsOfYear: [4] });

--- a/src/services/IQProPaymentService.ts
+++ b/src/services/IQProPaymentService.ts
@@ -25,7 +25,7 @@ import type {
   SubscriptionResult,
 } from './PaymentProviderService';
 
-import { Env } from '@/libs/Env';
+import type { IQProConfig } from '@/libs/IQPro';
 import { getGatewayProcessors, iqproGet, iqproPost, tokenizeAch } from '@/libs/IQPro';
 import { logger } from '@/libs/Logger';
 
@@ -49,12 +49,13 @@ function normalizeCountry(country?: string): string {
 }
 
 export class IQProPaymentProvider implements IPaymentProvider {
-  async createCustomer(params: CreateCustomerParams): Promise<CreateCustomerResult> {
-    const gatewayId = Env.IQPRO_GATEWAY_ID!;
+  async createCustomer(config: IQProConfig, params: CreateCustomerParams): Promise<CreateCustomerResult> {
+    const gatewayId = config.gatewayId;
 
     logger.info('[IQPro] Creating customer', { memberId: params.memberId });
 
     const customerRes = await iqproPost<{ data?: Record<string, unknown> }>(
+      config,
       `/api/gateway/${gatewayId}/customer`,
       {
         name: `${params.firstName} ${params.lastName}`,
@@ -87,6 +88,7 @@ export class IQProPaymentProvider implements IPaymentProvider {
     let billingAddressId: string | undefined;
     if (params.address) {
       const detailRes = await iqproGet<{ data?: Record<string, unknown> }>(
+        config,
         `/api/gateway/${gatewayId}/customer/${customerId}`,
       );
       const detailData = (detailRes.data ?? detailRes) as Record<string, unknown>;
@@ -99,8 +101,8 @@ export class IQProPaymentProvider implements IPaymentProvider {
     return { customerId, billingAddressId };
   }
 
-  async createPaymentMethod(params: CreatePaymentMethodParams): Promise<CreatePaymentMethodResult> {
-    const gatewayId = Env.IQPRO_GATEWAY_ID!;
+  async createPaymentMethod(config: IQProConfig, params: CreatePaymentMethodParams): Promise<CreatePaymentMethodResult> {
+    const gatewayId = config.gatewayId;
 
     logger.info('[IQPro] Creating payment method', {
       customerId: params.customerId,
@@ -125,6 +127,7 @@ export class IQProPaymentProvider implements IPaymentProvider {
       const maskedCard = `${params.cardFirstSix}******${params.cardLastFour}`;
 
       const pmRes = await iqproPost<{ data?: Record<string, unknown> }>(
+        config,
         `/api/gateway/${gatewayId}/customer/${params.customerId}/payment`,
         {
           card: {
@@ -159,7 +162,7 @@ export class IQProPaymentProvider implements IPaymentProvider {
     // ACH — tokenize account number via Vault API, then create payment method.
     const accountType = params.achAccountType ?? 'Checking';
 
-    const tokenResult = await tokenizeAch({
+    const tokenResult = await tokenizeAch(config, {
       accountNumber: params.achAccountNumber!,
       routingNumber: params.achRoutingNumber!,
       secCode: 'PPD',
@@ -167,6 +170,7 @@ export class IQProPaymentProvider implements IPaymentProvider {
     });
 
     const pmRes = await iqproPost<{ data?: Record<string, unknown> }>(
+      config,
       `/api/gateway/${gatewayId}/customer/${params.customerId}/payment`,
       {
         ach: {
@@ -205,8 +209,8 @@ export class IQProPaymentProvider implements IPaymentProvider {
     };
   }
 
-  async processPayment(params: ProcessPaymentParams): Promise<PaymentResult> {
-    const gatewayId = Env.IQPRO_GATEWAY_ID!;
+  async processPayment(config: IQProConfig, params: ProcessPaymentParams): Promise<PaymentResult> {
+    const gatewayId = config.gatewayId;
     const isAch = !!params.ach;
     const vaulted = !!params.vaulted;
     const isTaxable = !!params.isTaxable;
@@ -348,6 +352,7 @@ export class IQProPaymentProvider implements IPaymentProvider {
       };
 
       const txRes = await iqproPost<{ data?: Record<string, unknown> }>(
+        config,
         `/api/gateway/${gatewayId}/transaction`,
         txPayload,
       );
@@ -360,7 +365,7 @@ export class IQProPaymentProvider implements IPaymentProvider {
       // Sandbox tolerance: Basys's sandbox ACH processor rejects the standard
       // test routing/account numbers with a certification-error message.
       // Treat that as a successful pendingsettlement so ACH dev flows work.
-      const isSandbox = Env.IQPRO_BASE_URL?.includes('sandbox') ?? false;
+      const isSandbox = config.baseUrl.includes('sandbox');
       const isCertError = responseText?.includes('not a valid transaction for certification') ?? false;
 
       const transactionId = (txData.transactionId ?? txData.id ?? '') as string;
@@ -401,9 +406,9 @@ export class IQProPaymentProvider implements IPaymentProvider {
     }
   }
 
-  async createSubscription(params: CreateSubscriptionParams): Promise<SubscriptionResult> {
-    const gatewayId = Env.IQPRO_GATEWAY_ID!;
-    const processors = await getGatewayProcessors();
+  async createSubscription(config: IQProConfig, params: CreateSubscriptionParams): Promise<SubscriptionResult> {
+    const gatewayId = config.gatewayId;
+    const processors = await getGatewayProcessors(config);
 
     logger.info('[IQPro] Creating subscription', {
       customerId: params.customerId,
@@ -499,6 +504,7 @@ export class IQProPaymentProvider implements IPaymentProvider {
       };
 
       const res = await iqproPost<{ data?: Record<string, unknown> }>(
+        config,
         `/api/gateway/${gatewayId}/subscription`,
         subscriptionPayload,
       );

--- a/src/services/MemberPaymentService.coupon.test.ts
+++ b/src/services/MemberPaymentService.coupon.test.ts
@@ -48,7 +48,6 @@ vi.mock('@/models/Schema', () => ({
 }));
 
 vi.mock('@/libs/IQPro', () => ({
-  isIQProConfigured: vi.fn().mockReturnValue(true),
   computeFeeBreakdown: vi.fn(),
   getCustomerPaymentMethod: vi.fn(),
   getGatewayProcessors: vi.fn().mockResolvedValue({
@@ -56,6 +55,16 @@ vi.mock('@/libs/IQPro', () => ({
     achProcessorId: 'ach_proc_001',
   }),
 }));
+
+const testConfig = {
+  clientId: 'test-client-id',
+  clientSecret: 'test-client-secret',
+  gatewayId: 'test-gateway-001',
+  scope: 'test-scope',
+  oauthUrl: 'https://sandbox.oauth.example.com/token',
+  baseUrl: 'https://sandbox.api.basyspro.com',
+  source: 'env' as const,
+};
 
 vi.mock('./EmailService', () => ({
   sendPaymentReceiptEmail: vi.fn().mockResolvedValue(true),
@@ -76,7 +85,6 @@ vi.mock('./PaymentProviderService', async () => {
   const actual = await vi.importActual<typeof import('./PaymentProviderService')>('./PaymentProviderService');
   return {
     ...actual,
-    isPaymentEnabled: vi.fn().mockReturnValue(true),
     getPaymentProvider: vi.fn().mockResolvedValue(mockProvider),
   };
 });
@@ -127,7 +135,7 @@ describe('processMemberPayment — per-user coupon limit', () => {
       });
 
     const { processMemberPayment } = await import('./MemberPaymentService');
-    const result = await processMemberPayment(baseParams);
+    const result = await processMemberPayment(testConfig, baseParams);
 
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/already used this coupon/i);
@@ -159,7 +167,7 @@ describe('processMemberPayment — per-user coupon limit', () => {
     mockProvider.createCustomer.mockRejectedValueOnce(new Error('stop here'));
 
     const { processMemberPayment } = await import('./MemberPaymentService');
-    const result = await processMemberPayment(baseParams);
+    const result = await processMemberPayment(testConfig, baseParams);
 
     // The limit check passed — we got past it and into the IQPro path which
     // we forced to fail. The error message should NOT be the limit message.

--- a/src/services/MemberPaymentService.test.ts
+++ b/src/services/MemberPaymentService.test.ts
@@ -48,7 +48,6 @@ vi.mock('@/models/Schema', () => ({
 }));
 
 vi.mock('@/libs/IQPro', () => ({
-  isIQProConfigured: vi.fn().mockReturnValue(true),
   computeFeeBreakdown: vi.fn(),
   getCustomerPaymentMethod: vi.fn(),
   getGatewayProcessors: vi.fn().mockResolvedValue({
@@ -56,6 +55,16 @@ vi.mock('@/libs/IQPro', () => ({
     achProcessorId: 'ach_proc_001',
   }),
 }));
+
+const testConfig = {
+  clientId: 'test-client-id',
+  clientSecret: 'test-client-secret',
+  gatewayId: 'test-gateway-001',
+  scope: 'test-scope',
+  oauthUrl: 'https://sandbox.oauth.example.com/token',
+  baseUrl: 'https://sandbox.api.basyspro.com',
+  source: 'env' as const,
+};
 
 vi.mock('./OrganizationService', () => ({
   getOrganizationTaxRate: vi.fn().mockResolvedValue(3.75),
@@ -76,7 +85,6 @@ vi.mock('./PaymentProviderService', async () => {
   const actual = await vi.importActual<typeof import('./PaymentProviderService')>('./PaymentProviderService');
   return {
     ...actual,
-    isPaymentEnabled: vi.fn().mockReturnValue(true),
     getPaymentProvider: vi.fn().mockResolvedValue(mockProvider),
   };
 });
@@ -219,13 +227,14 @@ describe('processMemberPayment', () => {
     vi.mocked(computeFeeBreakdown).mockResolvedValueOnce(baseFees);
 
     const { processMemberPayment } = await import('./MemberPaymentService');
-    const result = await processMemberPayment(baseParams);
+    const result = await processMemberPayment(testConfig, baseParams);
 
     expect(result.success).toBe(true);
     expect(result.status).toBe('approved');
 
     // Memberships are non-taxable by default; taxStatePct passed as 0
     expect(computeFeeBreakdown).toHaveBeenCalledWith(
+      testConfig,
       100,
       false,
       0,
@@ -233,6 +242,7 @@ describe('processMemberPayment', () => {
     );
 
     expect(mockProvider.processPayment).toHaveBeenCalledWith(
+      testConfig,
       expect.objectContaining({
         customerId: 'cust_123',
         paymentMethodId: 'pm_card_1',
@@ -256,7 +266,7 @@ describe('processMemberPayment', () => {
     vi.mocked(computeFeeBreakdown).mockResolvedValueOnce(baseFees);
 
     const { processMemberPayment } = await import('./MemberPaymentService');
-    const result = await processMemberPayment({
+    const result = await processMemberPayment(testConfig, {
       ...baseParams,
       billingType: 'autopay',
       membershipPlanFrequency: 'monthly',
@@ -265,6 +275,7 @@ describe('processMemberPayment', () => {
 
     expect(result.success).toBe(true);
     expect(mockProvider.createSubscription).toHaveBeenCalledWith(
+      testConfig,
       expect.objectContaining({
         customerId: 'cust_123',
         paymentMethodId: 'pm_card_1',
@@ -279,6 +290,7 @@ describe('processMemberPayment', () => {
 
     expect(mockProvider.processPayment).toHaveBeenCalledTimes(1);
     expect(mockProvider.processPayment).toHaveBeenCalledWith(
+      testConfig,
       expect.objectContaining({
         amount: 103.75,
         metadata: expect.objectContaining({ iqproSubscriptionId: 'sub_42' }),
@@ -302,7 +314,7 @@ describe('processMemberPayment', () => {
     });
 
     const { processMemberPayment } = await import('./MemberPaymentService');
-    const result = await processMemberPayment({
+    const result = await processMemberPayment(testConfig, {
       ...baseParams,
       billingType: 'autopay',
       membershipPlanFrequency: 'monthly',
@@ -326,12 +338,12 @@ describe('processMemberPayment', () => {
     vi.mocked(computeFeeBreakdown).mockResolvedValueOnce(baseFees);
 
     const { processMemberPayment } = await import('./MemberPaymentService');
-    await processMemberPayment({ ...baseParams, cardToken: undefined });
+    await processMemberPayment(testConfig, { ...baseParams, cardToken: undefined });
 
     const callArgs = vi.mocked(computeFeeBreakdown).mock.calls[0]!;
 
-    expect(callArgs[3]).toEqual(expect.objectContaining({ creditCardBin: '424242' }));
-    expect(callArgs[3]).not.toHaveProperty('token');
+    expect(callArgs[4]).toEqual(expect.objectContaining({ creditCardBin: '424242' }));
+    expect(callArgs[4]).not.toHaveProperty('token');
   });
 
   it('ACH new payment: passes achToken to fee calc, sends inline ach to provider', async () => {
@@ -349,7 +361,7 @@ describe('processMemberPayment', () => {
     });
 
     const { processMemberPayment } = await import('./MemberPaymentService');
-    await processMemberPayment({
+    await processMemberPayment(testConfig, {
       ...baseParams,
       paymentMethod: 'ach',
       cardToken: undefined,
@@ -361,11 +373,12 @@ describe('processMemberPayment', () => {
 
     const feeArgs = vi.mocked(computeFeeBreakdown).mock.calls[0]!;
 
-    expect(feeArgs[3].processorId).toBe('ach_proc_001');
-    expect(feeArgs[3].token).toBe('ach-tok-xyz');
-    expect(feeArgs[3]).not.toHaveProperty('creditCardBin');
+    expect(feeArgs[4].processorId).toBe('ach_proc_001');
+    expect(feeArgs[4].token).toBe('ach-tok-xyz');
+    expect(feeArgs[4]).not.toHaveProperty('creditCardBin');
 
     expect(mockProvider.processPayment).toHaveBeenCalledWith(
+      testConfig,
       expect.objectContaining({
         ach: {
           achToken: 'ach-tok-xyz',
@@ -382,12 +395,12 @@ describe('processMemberPayment', () => {
     vi.mocked(computeFeeBreakdown).mockResolvedValueOnce({ ...baseFees, baseAmount: 75, amount: 78.75 });
 
     const { processMemberPayment } = await import('./MemberPaymentService');
-    await processMemberPayment({
+    await processMemberPayment(testConfig, {
       ...baseParams,
       appliedCoupon: { id: 'cpn_1', code: 'SAVE25', type: 'Fixed Amount', amount: '25', description: '$25 off' },
     });
 
-    expect(computeFeeBreakdown).toHaveBeenCalledWith(75, false, 0, expect.any(Object));
+    expect(computeFeeBreakdown).toHaveBeenCalledWith(testConfig, 75, false, 0, expect.any(Object));
   });
 
   it('Percentage coupon: discount applied before fee calc', async () => {
@@ -395,12 +408,12 @@ describe('processMemberPayment', () => {
     vi.mocked(computeFeeBreakdown).mockResolvedValueOnce({ ...baseFees, baseAmount: 90, amount: 93.75 });
 
     const { processMemberPayment } = await import('./MemberPaymentService');
-    await processMemberPayment({
+    await processMemberPayment(testConfig, {
       ...baseParams,
       appliedCoupon: { id: 'cpn_2', code: 'TEN_PCT', type: 'Percentage', amount: '10', description: '10% off' },
     });
 
-    expect(computeFeeBreakdown).toHaveBeenCalledWith(90, false, 0, expect.any(Object));
+    expect(computeFeeBreakdown).toHaveBeenCalledWith(testConfig, 90, false, 0, expect.any(Object));
   });
 
   it('throws clear error when no gateway processor is configured', async () => {
@@ -411,7 +424,7 @@ describe('processMemberPayment', () => {
     });
 
     const { processMemberPayment } = await import('./MemberPaymentService');
-    const result = await processMemberPayment(baseParams);
+    const result = await processMemberPayment(testConfig, baseParams);
 
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/No card processor configured/);
@@ -423,10 +436,11 @@ describe('processMemberPayment', () => {
     vi.mocked(computeFeeBreakdown).mockResolvedValueOnce(baseFees);
 
     const { processMemberPayment } = await import('./MemberPaymentService');
-    await processMemberPayment(baseParams);
+    await processMemberPayment(testConfig, baseParams);
 
     expect(mockProvider.createCustomer).not.toHaveBeenCalled();
     expect(mockProvider.processPayment).toHaveBeenCalledWith(
+      testConfig,
       expect.objectContaining({ customerId: 'cust_existing_999' }),
     );
   });
@@ -443,11 +457,12 @@ describe('processMemberPayment', () => {
     });
 
     const { processMemberPayment } = await import('./MemberPaymentService');
-    await processMemberPayment({ ...baseParams, isTaxable: true });
+    await processMemberPayment(testConfig, { ...baseParams, isTaxable: true });
 
     // taxStatePct (3.75 from getOrganizationTaxRate mock) is threaded through as 3rd arg
-    expect(computeFeeBreakdown).toHaveBeenCalledWith(100, true, 3.75, expect.any(Object));
+    expect(computeFeeBreakdown).toHaveBeenCalledWith(testConfig, 100, true, 3.75, expect.any(Object));
     expect(mockProvider.processPayment).toHaveBeenCalledWith(
+      testConfig,
       expect.objectContaining({ isTaxable: true }),
     );
   });
@@ -459,10 +474,10 @@ describe('processMemberPayment', () => {
     vi.mocked(getOrganizationTaxRate).mockResolvedValueOnce(5.25);
 
     const { processMemberPayment } = await import('./MemberPaymentService');
-    await processMemberPayment({ ...baseParams, isTaxable: true });
+    await processMemberPayment(testConfig, { ...baseParams, isTaxable: true });
 
     expect(getOrganizationTaxRate).toHaveBeenCalledWith('org_x');
-    expect(computeFeeBreakdown).toHaveBeenCalledWith(100, true, 5.25, expect.any(Object));
+    expect(computeFeeBreakdown).toHaveBeenCalledWith(testConfig, 100, true, 5.25, expect.any(Object));
   });
 
   it('isTaxable: false — does not call getOrganizationTaxRate', async () => {
@@ -472,10 +487,10 @@ describe('processMemberPayment', () => {
     vi.mocked(getOrganizationTaxRate).mockClear();
 
     const { processMemberPayment } = await import('./MemberPaymentService');
-    await processMemberPayment({ ...baseParams, isTaxable: false });
+    await processMemberPayment(testConfig, { ...baseParams, isTaxable: false });
 
     expect(getOrganizationTaxRate).not.toHaveBeenCalled();
-    expect(computeFeeBreakdown).toHaveBeenCalledWith(100, false, 0, expect.any(Object));
+    expect(computeFeeBreakdown).toHaveBeenCalledWith(testConfig, 100, false, 0, expect.any(Object));
   });
 
   // ── Saved-PM (vaulted) branch ────────────────────────────────────────────
@@ -484,7 +499,7 @@ describe('processMemberPayment', () => {
     resetDbMock({ existingCustomerId: null });
     const { processMemberPayment } = await import('./MemberPaymentService');
 
-    const result = await processMemberPayment({ ...baseParams, paymentMethodSource: 'saved' });
+    const result = await processMemberPayment(testConfig, { ...baseParams, paymentMethodSource: 'saved' });
 
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/no saved customer record/);
@@ -497,7 +512,7 @@ describe('processMemberPayment', () => {
     resetDbMock({ existingCustomerId: 'cust_have', savedPmRow: null });
     const { processMemberPayment } = await import('./MemberPaymentService');
 
-    const result = await processMemberPayment({ ...baseParams, paymentMethodSource: 'saved' });
+    const result = await processMemberPayment(testConfig, { ...baseParams, paymentMethodSource: 'saved' });
 
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/no saved payment method/);
@@ -518,19 +533,21 @@ describe('processMemberPayment', () => {
     vi.mocked(computeFeeBreakdown).mockResolvedValueOnce(baseFees);
 
     const { processMemberPayment } = await import('./MemberPaymentService');
-    const result = await processMemberPayment({ ...baseParams, paymentMethodSource: 'saved' });
+    const result = await processMemberPayment(testConfig, { ...baseParams, paymentMethodSource: 'saved' });
 
     expect(result.success).toBe(true);
     expect(mockProvider.createCustomer).not.toHaveBeenCalled();
     expect(mockProvider.createPaymentMethod).not.toHaveBeenCalled();
-    expect(getCustomerPaymentMethod).toHaveBeenCalledWith('cust_have', 'pm_saved_1');
+    expect(getCustomerPaymentMethod).toHaveBeenCalledWith(testConfig, 'cust_have', 'pm_saved_1');
     expect(computeFeeBreakdown).toHaveBeenCalledWith(
+      testConfig,
       100,
       false,
       0,
       expect.objectContaining({ creditCardBin: '424242' }),
     );
     expect(mockProvider.processPayment).toHaveBeenCalledWith(
+      testConfig,
       expect.objectContaining({
         customerId: 'cust_have',
         paymentMethodId: 'pm_saved_1',
@@ -546,7 +563,7 @@ describe('processMemberPayment', () => {
     vi.mocked(computeFeeBreakdown).mockResolvedValueOnce(baseFees);
 
     const { processMemberPayment } = await import('./MemberPaymentService');
-    await processMemberPayment(baseParams);
+    await processMemberPayment(testConfig, baseParams);
 
     expect(mockSendReceipt).toHaveBeenCalledTimes(1);
     expect(mockSendReceipt).toHaveBeenCalledWith(expect.objectContaining({
@@ -569,7 +586,7 @@ describe('processMemberPayment', () => {
     });
 
     const { processMemberPayment } = await import('./MemberPaymentService');
-    await processMemberPayment(baseParams);
+    await processMemberPayment(testConfig, baseParams);
 
     expect(mockSendReceipt).not.toHaveBeenCalled();
   });
@@ -579,7 +596,7 @@ describe('processMemberPayment', () => {
     vi.mocked(computeFeeBreakdown).mockResolvedValueOnce(baseFees);
 
     const { processMemberPayment } = await import('./MemberPaymentService');
-    await processMemberPayment({
+    await processMemberPayment(testConfig, {
       ...baseParams,
       billingType: 'autopay',
       membershipPlanFrequency: 'monthly',

--- a/src/services/MemberPaymentService.ts
+++ b/src/services/MemberPaymentService.ts
@@ -18,6 +18,7 @@ import type {
 } from './PaymentProviderService';
 
 import type { AppliedCoupon, BillingType, PaymentMethod } from '@/hooks/useAddMemberWizard';
+import type { IQProConfig } from '@/libs/IQPro';
 import { randomUUID } from 'node:crypto';
 
 import { and, desc, eq, sql } from 'drizzle-orm';
@@ -26,14 +27,13 @@ import {
   computeFeeBreakdown,
   getCustomerPaymentMethod,
   getGatewayProcessors,
-  isIQProConfigured,
 } from '@/libs/IQPro';
 import { logger } from '@/libs/Logger';
 import { couponSchema, couponUsageSchema, memberMembershipSchema, memberSchema, paymentMethodSchema, transactionSchema } from '@/models/Schema';
 
 import { sendPaymentReceiptEmail } from './EmailService';
 import { getOrganizationTaxRate } from './OrganizationService';
-import { getPaymentProvider, isPaymentEnabled } from './PaymentProviderService';
+import { getPaymentProvider } from './PaymentProviderService';
 
 // ===== Public types =====
 
@@ -148,12 +148,9 @@ export type RegisterPaymentMethodResult = {
 // ===== Main orchestration function =====
 
 export async function processMemberPayment(
+  config: IQProConfig,
   params: ProcessMemberPaymentParams,
 ): Promise<ProcessMemberPaymentResult> {
-  if (!isPaymentEnabled()) {
-    throw new Error('Payment processing is not configured. Set IQPRO_* environment variables.');
-  }
-
   // Per-user redemption limit — refuse before charging if this member has
   // already redeemed the coupon up to its perUserLimit. We re-fetch the coupon
   // from the DB rather than trusting the client's `appliedCoupon` payload.
@@ -241,7 +238,7 @@ export async function processMemberPayment(
       // Fetch the BIN (for card) or achToken (for ACH) from IQPro so
       // /calculatefees has a valid identifier. The endpoint requires exactly
       // one of token or creditCardBin.
-      const remoteInfo = await getCustomerPaymentMethod(customerId, paymentMethodId);
+      const remoteInfo = await getCustomerPaymentMethod(config, customerId, paymentMethodId);
       if (remoteInfo) {
         if (remoteInfo.type === 'card' && remoteInfo.firstSix) {
           feeBin = remoteInfo.firstSix;
@@ -276,7 +273,7 @@ export async function processMemberPayment(
       let resolvedCustomerId = existing[0]?.iqproCustomerId ?? null;
 
       if (!resolvedCustomerId) {
-        const created = await provider.createCustomer({
+        const created = await provider.createCustomer(config, {
           organizationId: params.organizationId,
           memberId: params.memberId,
           email: params.memberEmail,
@@ -300,7 +297,7 @@ export async function processMemberPayment(
       }
       customerId = resolvedCustomerId;
 
-      const pmResult = await provider.createPaymentMethod({
+      const pmResult = await provider.createPaymentMethod(config, {
         customerId,
         paymentMethod: params.paymentMethod,
         cardholderName: params.cardholderName,
@@ -342,7 +339,7 @@ export async function processMemberPayment(
     }
 
     // ── Step 2: Calculate authoritative fees (kiosk shape) ──────────
-    const processors = await getGatewayProcessors();
+    const processors = await getGatewayProcessors(config);
     const processorId = effectivePaymentMethod === 'card'
       ? processors.cardProcessorId
       : processors.achProcessorId;
@@ -356,6 +353,7 @@ export async function processMemberPayment(
     const taxStatePct = isTaxable ? await getOrganizationTaxRate(params.organizationId) : 0;
 
     const feeBreakdown: FeeBreakdown = await computeFeeBreakdown(
+      config,
       baseAmount,
       isTaxable,
       taxStatePct,
@@ -395,6 +393,7 @@ export async function processMemberPayment(
 
     if (isAutopay) {
       return await handleAutopay({
+        config,
         provider,
         params,
         customerId,
@@ -412,6 +411,7 @@ export async function processMemberPayment(
     }
 
     return await handleOneTimePayment({
+      config,
       provider,
       params,
       customerId,
@@ -438,12 +438,9 @@ export async function processMemberPayment(
 // ===== Register payment method only (no charge) =====
 
 export async function registerPaymentMethod(
+  config: IQProConfig,
   params: RegisterPaymentMethodParams,
 ): Promise<RegisterPaymentMethodResult> {
-  if (!isPaymentEnabled()) {
-    throw new Error('Payment processing is not configured. Set IQPRO_* environment variables.');
-  }
-
   const provider = await getPaymentProvider();
 
   try {
@@ -457,7 +454,7 @@ export async function registerPaymentMethod(
     let customerId = existing[0]?.iqproCustomerId ?? null;
 
     if (!customerId) {
-      const created = await provider.createCustomer({
+      const created = await provider.createCustomer(config, {
         organizationId: params.organizationId,
         memberId: params.memberId,
         email: params.memberEmail,
@@ -477,7 +474,7 @@ export async function registerPaymentMethod(
     }
 
     // Step 2: Create payment method (no charge)
-    const pmResult = await provider.createPaymentMethod({
+    const pmResult = await provider.createPaymentMethod(config, {
       customerId,
       paymentMethod: params.paymentMethod,
       cardholderName: params.cardholderName,
@@ -613,6 +610,7 @@ function fireReceiptEmail(args: {
 }
 
 type AutopayParams = {
+  config: IQProConfig;
   provider: Awaited<ReturnType<typeof getPaymentProvider>>;
   params: ProcessMemberPaymentParams;
   customerId: string;
@@ -629,9 +627,9 @@ type AutopayParams = {
 };
 
 async function handleAutopay(args: AutopayParams): Promise<ProcessMemberPaymentResult> {
-  const { provider, params, customerId, paymentMethodId, frequency, feeBreakdown, billingAddressId, billingAddress, lineItem, achData, vaulted, isTaxable } = args;
+  const { config, provider, params, customerId, paymentMethodId, frequency, feeBreakdown, billingAddressId, billingAddress, lineItem, achData, vaulted, isTaxable } = args;
 
-  const subResult = await provider.createSubscription({
+  const subResult = await provider.createSubscription(config, {
     customerId,
     paymentMethodId,
     amount: params.amount,
@@ -660,7 +658,7 @@ async function handleAutopay(args: AutopayParams): Promise<ProcessMemberPaymentR
   // IQPro subscriptions don't auto-charge on creation. Run an immediate Sale
   // for the first period so the member is charged on signup day. The recurring
   // schedule then takes over from the next billing date.
-  const initialCharge = await provider.processPayment({
+  const initialCharge = await provider.processPayment(config, {
     customerId,
     paymentMethodId,
     amount: feeBreakdown.amount,
@@ -776,6 +774,7 @@ async function handleAutopay(args: AutopayParams): Promise<ProcessMemberPaymentR
 }
 
 type OneTimeParams = {
+  config: IQProConfig;
   provider: Awaited<ReturnType<typeof getPaymentProvider>>;
   params: ProcessMemberPaymentParams;
   customerId: string;
@@ -791,9 +790,9 @@ type OneTimeParams = {
 };
 
 async function handleOneTimePayment(args: OneTimeParams): Promise<ProcessMemberPaymentResult> {
-  const { provider, params, customerId, paymentMethodId, feeBreakdown, billingAddressId, billingAddress, lineItem, achData, vaulted, isTaxable } = args;
+  const { config, provider, params, customerId, paymentMethodId, feeBreakdown, billingAddressId, billingAddress, lineItem, achData, vaulted, isTaxable } = args;
 
-  const payResult = await provider.processPayment({
+  const payResult = await provider.processPayment(config, {
     customerId,
     paymentMethodId,
     amount: feeBreakdown.amount,
@@ -1058,6 +1057,3 @@ export async function refundTransaction(
     decrementedCoupons,
   };
 }
-
-// Re-export for tests that previously imported from this module
-export { isIQProConfigured };

--- a/src/services/PaymentProviderService.ts
+++ b/src/services/PaymentProviderService.ts
@@ -7,8 +7,7 @@
  */
 
 import type { BillingType, PaymentMethod } from '@/hooks/useAddMemberWizard';
-
-import { isIQProConfigured } from '@/libs/IQPro';
+import type { IQProConfig } from '@/libs/IQPro';
 
 // ===== Provider-agnostic types =====
 
@@ -202,32 +201,27 @@ export type SubscriptionResult = {
 };
 
 // ===== Provider interface =====
+//
+// Each method receives an `IQProConfig` so the provider can target the right
+// merchant gateway for the call (per-org for customer payments, platform for
+// SaaS billing). Resolved by the caller and passed in.
 
 export type IPaymentProvider = {
-  createCustomer: (params: CreateCustomerParams) => Promise<CreateCustomerResult>;
-  createPaymentMethod: (params: CreatePaymentMethodParams) => Promise<CreatePaymentMethodResult>;
-  processPayment: (params: ProcessPaymentParams) => Promise<PaymentResult>;
-  createSubscription: (params: CreateSubscriptionParams) => Promise<SubscriptionResult>;
+  createCustomer: (config: IQProConfig, params: CreateCustomerParams) => Promise<CreateCustomerResult>;
+  createPaymentMethod: (config: IQProConfig, params: CreatePaymentMethodParams) => Promise<CreatePaymentMethodResult>;
+  processPayment: (config: IQProConfig, params: ProcessPaymentParams) => Promise<PaymentResult>;
+  createSubscription: (config: IQProConfig, params: CreateSubscriptionParams) => Promise<SubscriptionResult>;
 };
 
 // ===== Factory =====
 
-export function isPaymentEnabled(): boolean {
-  return isIQProConfigured();
-}
-
 let cachedProvider: IPaymentProvider | null = null;
 
 export async function getPaymentProvider(): Promise<IPaymentProvider> {
-  if (!isPaymentEnabled()) {
-    throw new Error('Payment processing is not configured. Set IQPRO_* environment variables.');
-  }
-
   if (!cachedProvider) {
     const { IQProPaymentProvider } = await import('./IQProPaymentService');
     cachedProvider = new IQProPaymentProvider();
   }
-
   return cachedProvider;
 }
 

--- a/src/services/SaasSubscriptionService.test.ts
+++ b/src/services/SaasSubscriptionService.test.ts
@@ -22,20 +22,25 @@ vi.mock('@/libs/IQPro', () => ({
   iqproPost: vi.fn(),
   iqproGet: vi.fn(),
   iqproPut: vi.fn(),
-  isIQProConfigured: vi.fn().mockReturnValue(true),
   getGatewayProcessors: vi.fn().mockResolvedValue({
     cardProcessorId: 'test-card-processor-001',
     achProcessorId: 'test-ach-processor-001',
   }),
 }));
 
-// Mock Env so requireGatewayId can read IQPRO_GATEWAY_ID
 vi.mock('@/libs/Env', () => ({
-  Env: {
-    IQPRO_GATEWAY_ID: 'test-gateway-001',
-    IQPRO_BASE_URL: 'https://sandbox.api.basyspro.com',
-  },
+  Env: {},
 }));
+
+const testConfig = {
+  clientId: 'test-client-id',
+  clientSecret: 'test-client-secret',
+  gatewayId: 'test-gateway-001',
+  scope: 'test-scope',
+  oauthUrl: 'https://sandbox.oauth.example.com/token',
+  baseUrl: 'https://sandbox.api.basyspro.com',
+  source: 'env' as const,
+};
 
 // Mock logger
 vi.mock('@/libs/Logger', () => ({
@@ -59,13 +64,8 @@ describe('SaasSubscriptionService', () => {
     vi.clearAllMocks();
   });
 
-  async function setupModule(opts: { iqproConfigured?: boolean } = {}) {
+  async function setupModule() {
     const iqpro = await import('@/libs/IQPro');
-    if (opts.iqproConfigured === false) {
-      vi.mocked(iqpro.isIQProConfigured).mockReturnValue(false);
-    } else {
-      vi.mocked(iqpro.isIQProConfigured).mockReturnValue(true);
-    }
     const { db } = await import('@/libs/DB');
     const service = await import('./SaasSubscriptionService');
     return {
@@ -265,13 +265,14 @@ describe('SaasSubscriptionService', () => {
         // 3. subscription create
         .mockResolvedValueOnce({ data: { subscriptionId: 'iqpro-sub-001' } });
 
-      const result = await service.subscribe(baseParams);
+      const result = await service.subscribe(testConfig, baseParams);
 
       expect(result).toEqual({ success: true });
 
       // Customer created
       expect(iqproPost).toHaveBeenNthCalledWith(
         1,
+        testConfig,
         '/api/gateway/test-gateway-001/customer',
         expect.objectContaining({
           name: 'Test Dojo',
@@ -282,6 +283,7 @@ describe('SaasSubscriptionService', () => {
       // Payment method created with maskedCard
       expect(iqproPost).toHaveBeenNthCalledWith(
         2,
+        testConfig,
         '/api/gateway/test-gateway-001/customer/iqpro-cust-001/payment',
         expect.objectContaining({
           card: {
@@ -296,6 +298,7 @@ describe('SaasSubscriptionService', () => {
       // Subscription created
       expect(iqproPost).toHaveBeenNthCalledWith(
         3,
+        testConfig,
         '/api/gateway/test-gateway-001/subscription',
         expect.objectContaining({
           customerId: 'iqpro-cust-001',
@@ -323,13 +326,14 @@ describe('SaasSubscriptionService', () => {
         .mockResolvedValueOnce({ data: { customerPaymentMethodId: 'iqpro-pm-002' } })
         .mockResolvedValueOnce({ data: { subscriptionId: 'iqpro-sub-002' } });
 
-      const result = await service.subscribe(baseParams);
+      const result = await service.subscribe(testConfig, baseParams);
 
       expect(result.success).toBe(true);
       // Two calls: payment method + subscription. No customer create.
       expect(iqproPost).toHaveBeenCalledTimes(2);
       expect(iqproPost).toHaveBeenNthCalledWith(
         1,
+        testConfig,
         '/api/gateway/test-gateway-001/customer/existing-cust-001/payment',
         expect.any(Object),
       );
@@ -342,7 +346,7 @@ describe('SaasSubscriptionService', () => {
 
       iqproPost.mockResolvedValueOnce({ data: { customerPaymentMethodId: 'iqpro-pm-003' } });
 
-      const result = await service.subscribe({ ...baseParams, planId: 'enterprise' as any });
+      const result = await service.subscribe(testConfig, { ...baseParams, planId: 'enterprise' as any });
 
       expect(result).toEqual({ success: false, error: 'Invalid plan' });
     });
@@ -356,11 +360,11 @@ describe('SaasSubscriptionService', () => {
         .mockResolvedValueOnce({ data: { customerPaymentMethodId: 'iqpro-pm-004' } })
         .mockResolvedValueOnce({ data: { subscriptionId: 'iqpro-sub-annual' } });
 
-      const result = await service.subscribe({ ...baseParams, billingCycle: 'annual' });
+      const result = await service.subscribe(testConfig, { ...baseParams, billingCycle: 'annual' });
 
       expect(result.success).toBe(true);
 
-      const subPayload = iqproPost.mock.calls[1]![1] as Record<string, any>;
+      const subPayload = iqproPost.mock.calls[1]![2] as Record<string, any>;
 
       expect(subPayload.recurrence.billingPeriodId).toBe(6);
       expect(subPayload.recurrence.schedule.monthsOfYear).toBeDefined();
@@ -377,7 +381,7 @@ describe('SaasSubscriptionService', () => {
         .mockResolvedValueOnce({ data: { customerPaymentMethodId: 'iqpro-pm-005' } })
         .mockResolvedValueOnce({ data: { subscriptionId: 'iqpro-sub-003' } });
 
-      await service.subscribe({
+      await service.subscribe(testConfig, {
         ...baseParams,
         cardToken: undefined,
         cardFirstSix: undefined,
@@ -385,7 +389,7 @@ describe('SaasSubscriptionService', () => {
         cardNumber: '4111111111111111',
       });
 
-      const pmPayload = iqproPost.mock.calls[0]![1] as Record<string, any>;
+      const pmPayload = iqproPost.mock.calls[0]![2] as Record<string, any>;
 
       expect(pmPayload.card.token).toBe('4111111111111111');
       expect(pmPayload.card.maskedCard).toBe('411111******1111');
@@ -400,15 +404,9 @@ describe('SaasSubscriptionService', () => {
         .mockResolvedValueOnce({ data: { customerPaymentMethodId: 'iqpro-pm-006' } })
         .mockRejectedValueOnce(new Error('Gateway timeout'));
 
-      const result = await service.subscribe(baseParams);
+      const result = await service.subscribe(testConfig, baseParams);
 
       expect(result).toEqual({ success: false, error: 'Gateway timeout' });
-    });
-
-    it('throws when IQPro is not configured', async () => {
-      const { service } = await setupModule({ iqproConfigured: false });
-
-      await expect(service.subscribe(baseParams)).rejects.toThrow('IQPro is not configured');
     });
 
     it('extracts subscriptionId from response.data or response directly', async () => {
@@ -421,7 +419,7 @@ describe('SaasSubscriptionService', () => {
         // Response without nested data wrapper
         .mockResolvedValueOnce({ subscriptionId: 'iqpro-sub-direct' });
 
-      const result = await service.subscribe(baseParams);
+      const result = await service.subscribe(testConfig, baseParams);
 
       expect(result.success).toBe(true);
     });
@@ -436,11 +434,12 @@ describe('SaasSubscriptionService', () => {
       mockFindFirst().mockResolvedValue({ iqproSubscriptionId: 'iqpro-sub-001' });
       iqproPut.mockResolvedValueOnce({});
 
-      const result = await service.changePlan('test-org-123', 'growth', 'monthly');
+      const result = await service.changePlan(testConfig, 'test-org-123', 'growth', 'monthly');
 
       expect(result).toEqual({ success: true });
 
       expect(iqproPut).toHaveBeenCalledWith(
+        testConfig,
         '/api/gateway/test-gateway-001/subscription/iqpro-sub-001',
         expect.objectContaining({
           name: 'Dojo Planner Growth Plan',
@@ -463,7 +462,7 @@ describe('SaasSubscriptionService', () => {
 
       mockFindFirst().mockResolvedValue({ iqproSubscriptionId: null });
 
-      const result = await service.changePlan('test-org-123', 'growth', 'monthly');
+      const result = await service.changePlan(testConfig, 'test-org-123', 'growth', 'monthly');
 
       expect(result).toEqual({ success: false, error: 'No active subscription to change' });
       expect(iqproPut).not.toHaveBeenCalled();
@@ -474,7 +473,7 @@ describe('SaasSubscriptionService', () => {
 
       mockFindFirst().mockResolvedValue(undefined);
 
-      const result = await service.changePlan('test-org-123', 'growth', 'monthly');
+      const result = await service.changePlan(testConfig, 'test-org-123', 'growth', 'monthly');
 
       expect(result).toEqual({ success: false, error: 'No active subscription to change' });
     });
@@ -484,7 +483,7 @@ describe('SaasSubscriptionService', () => {
 
       mockFindFirst().mockResolvedValue({ iqproSubscriptionId: 'iqpro-sub-001' });
 
-      const result = await service.changePlan('test-org-123', 'enterprise' as any, 'monthly');
+      const result = await service.changePlan(testConfig, 'test-org-123', 'enterprise' as any, 'monthly');
 
       expect(result).toEqual({ success: false, error: 'Invalid plan' });
     });
@@ -495,11 +494,11 @@ describe('SaasSubscriptionService', () => {
       mockFindFirst().mockResolvedValue({ iqproSubscriptionId: 'iqpro-sub-001' });
       iqproPut.mockResolvedValueOnce({});
 
-      const result = await service.changePlan('test-org-123', 'growth', 'annual');
+      const result = await service.changePlan(testConfig, 'test-org-123', 'growth', 'annual');
 
       expect(result.success).toBe(true);
 
-      const callArgs = iqproPut.mock.calls[0]![1] as Record<string, any>;
+      const callArgs = iqproPut.mock.calls[0]![2] as Record<string, any>;
 
       expect(callArgs.lineItems[0].unitPrice).toBe(1188); // annual total for growth
       expect(callArgs.lineItems[0].unitOfMeasureId).toBe(4);
@@ -511,7 +510,7 @@ describe('SaasSubscriptionService', () => {
       mockFindFirst().mockResolvedValue({ iqproSubscriptionId: 'iqpro-sub-001' });
       iqproPut.mockRejectedValue(new Error('Update failed'));
 
-      const result = await service.changePlan('test-org-123', 'growth', 'monthly');
+      const result = await service.changePlan(testConfig, 'test-org-123', 'growth', 'monthly');
 
       expect(result).toEqual({ success: false, error: 'Update failed' });
     });
@@ -526,11 +525,12 @@ describe('SaasSubscriptionService', () => {
       mockFindFirst().mockResolvedValue({ iqproSubscriptionId: 'iqpro-sub-001' });
       iqproPost.mockResolvedValueOnce({});
 
-      const result = await service.cancelSubscription('test-org-123', false);
+      const result = await service.cancelSubscription(testConfig, 'test-org-123', false);
 
       expect(result).toEqual({ success: true });
 
       expect(iqproPost).toHaveBeenCalledWith(
+        testConfig,
         '/api/gateway/test-gateway-001/subscription/iqpro-sub-001/cancel',
         { cancel: { now: true, endOfBillingPeriod: false } },
       );
@@ -544,11 +544,12 @@ describe('SaasSubscriptionService', () => {
       mockFindFirst().mockResolvedValue({ iqproSubscriptionId: 'iqpro-sub-001' });
       iqproPost.mockResolvedValueOnce({});
 
-      const result = await service.cancelSubscription('test-org-123', true);
+      const result = await service.cancelSubscription(testConfig, 'test-org-123', true);
 
       expect(result).toEqual({ success: true });
 
       expect(iqproPost).toHaveBeenCalledWith(
+        testConfig,
         '/api/gateway/test-gateway-001/subscription/iqpro-sub-001/cancel',
         { cancel: { now: false, endOfBillingPeriod: true } },
       );
@@ -559,7 +560,7 @@ describe('SaasSubscriptionService', () => {
 
       mockFindFirst().mockResolvedValue({ iqproSubscriptionId: null });
 
-      const result = await service.cancelSubscription('test-org-123', false);
+      const result = await service.cancelSubscription(testConfig, 'test-org-123', false);
 
       expect(result).toEqual({ success: true });
 
@@ -573,7 +574,7 @@ describe('SaasSubscriptionService', () => {
       mockFindFirst().mockResolvedValue({ iqproSubscriptionId: 'iqpro-sub-001' });
       iqproPost.mockRejectedValue(new Error('Cancel API error'));
 
-      const result = await service.cancelSubscription('test-org-123', false);
+      const result = await service.cancelSubscription(testConfig, 'test-org-123', false);
 
       expect(result).toEqual({ success: false, error: 'Cancel API error' });
     });
@@ -597,14 +598,14 @@ describe('SaasSubscriptionService', () => {
         },
       });
 
-      const result = await service.getBillingHistory('test-org-123');
+      const result = await service.getBillingHistory(testConfig, 'test-org-123');
 
       expect(result).toEqual([
         { invoiceId: 'inv-001', status: 'Paid', amount: 49, invoiceDate: '2025-01-15', dueDate: '2025-01-15', paymentMethodLast4: '4242' },
         { invoiceId: 'inv-002', status: 'Pending', amount: 49, invoiceDate: '2025-02-15', dueDate: '2025-02-15', paymentMethodLast4: '4242' },
       ]);
 
-      expect(iqproGet).toHaveBeenCalledWith('/api/gateway/test-gateway-001/subscription/iqpro-sub-001');
+      expect(iqproGet).toHaveBeenCalledWith(testConfig, '/api/gateway/test-gateway-001/subscription/iqpro-sub-001');
     });
 
     it('returns empty array when no subscription exists', async () => {
@@ -612,7 +613,7 @@ describe('SaasSubscriptionService', () => {
 
       mockFindFirst().mockResolvedValue({ iqproSubscriptionId: null });
 
-      const result = await service.getBillingHistory('test-org-123');
+      const result = await service.getBillingHistory(testConfig, 'test-org-123');
 
       expect(result).toEqual([]);
     });
@@ -622,7 +623,7 @@ describe('SaasSubscriptionService', () => {
 
       mockFindFirst().mockResolvedValue(undefined);
 
-      const result = await service.getBillingHistory('test-org-123');
+      const result = await service.getBillingHistory(testConfig, 'test-org-123');
 
       expect(result).toEqual([]);
     });
@@ -633,7 +634,7 @@ describe('SaasSubscriptionService', () => {
       mockFindFirst().mockResolvedValue({ iqproSubscriptionId: 'iqpro-sub-001' });
       iqproGet.mockRejectedValueOnce(new Error('API error'));
 
-      const result = await service.getBillingHistory('test-org-123');
+      const result = await service.getBillingHistory(testConfig, 'test-org-123');
 
       expect(result).toEqual([]);
     });
@@ -646,7 +647,7 @@ describe('SaasSubscriptionService', () => {
         invoices: [{ invoiceId: 'inv-003', amountCaptured: 99 }],
       });
 
-      const result = await service.getBillingHistory('test-org-123');
+      const result = await service.getBillingHistory(testConfig, 'test-org-123');
 
       expect(result).toEqual([
         { invoiceId: 'inv-003', status: null, amount: 99, invoiceDate: null, dueDate: null, paymentMethodLast4: null },
@@ -666,7 +667,7 @@ describe('SaasSubscriptionService', () => {
         paymentMethod: { customerPaymentMethod: { card: { maskedCard: '555555******4444' } } },
       });
 
-      const result = await service.getBillingHistory('test-org-123');
+      const result = await service.getBillingHistory(testConfig, 'test-org-123');
 
       expect(result).toHaveLength(1);
       expect(result[0]!.invoiceId).toBe('inv-direct');

--- a/src/services/SaasSubscriptionService.ts
+++ b/src/services/SaasSubscriptionService.ts
@@ -5,22 +5,15 @@
  * distinct from member-level payments handled by MemberPaymentService.
  */
 
+import type { IQProConfig } from '@/libs/IQPro';
 import type { SaasPlanId } from '@/utils/SaasPlans';
 import { eq } from 'drizzle-orm';
 import { db } from '@/libs/DB';
-import { Env } from '@/libs/Env';
-import { getGatewayProcessors, iqproGet, iqproPost, iqproPut, isIQProConfigured } from '@/libs/IQPro';
+import { getGatewayProcessors, iqproGet, iqproPost, iqproPut } from '@/libs/IQPro';
 import { logger } from '@/libs/Logger';
 import { organizationSchema } from '@/models/Schema';
 import { getPlanTotalPrice, getSaasPlan } from '@/utils/SaasPlans';
 import { isExemptOrg, isSuperAdmin } from '@/utils/SuperAdmins';
-
-function requireGatewayId(): string {
-  if (!isIQProConfigured()) {
-    throw new Error('IQPro is not configured');
-  }
-  return Env.IQPRO_GATEWAY_ID!;
-}
 
 // ===== Types =====
 
@@ -115,9 +108,12 @@ export async function getCurrentSubscription(
 
 // ===== Subscribe to a plan =====
 
-export async function subscribe(params: SubscribeParams): Promise<{ success: boolean; error?: string }> {
-  const gatewayId = requireGatewayId();
-  const processors = await getGatewayProcessors();
+export async function subscribe(
+  config: IQProConfig,
+  params: SubscribeParams,
+): Promise<{ success: boolean; error?: string }> {
+  const gatewayId = config.gatewayId;
+  const processors = await getGatewayProcessors(config);
 
   try {
     // Step 1: Get or create IQPro customer for the org
@@ -130,6 +126,7 @@ export async function subscribe(params: SubscribeParams): Promise<{ success: boo
 
     if (!customerId) {
       const customerRes = await iqproPost<{ data?: Record<string, unknown> }>(
+        config,
         `/api/gateway/${gatewayId}/customer`,
         {
           name: params.orgName,
@@ -159,6 +156,7 @@ export async function subscribe(params: SubscribeParams): Promise<{ success: boo
     const maskedCard = `${first6}******${last4}`;
 
     const pmRes = await iqproPost<{ data?: Record<string, unknown> }>(
+      config,
       `/api/gateway/${gatewayId}/customer/${customerId}/payment`,
       {
         card: {
@@ -248,6 +246,7 @@ export async function subscribe(params: SubscribeParams): Promise<{ success: boo
     };
 
     const response = await iqproPost<Record<string, unknown>>(
+      config,
       `/api/gateway/${gatewayId}/subscription`,
       subscriptionPayload,
     );
@@ -286,11 +285,12 @@ export async function subscribe(params: SubscribeParams): Promise<{ success: boo
 // ===== Change plan =====
 
 export async function changePlan(
+  config: IQProConfig,
   orgId: string,
   newPlanId: SaasPlanId,
   newBillingCycle: 'monthly' | 'annual',
 ): Promise<{ success: boolean; error?: string }> {
-  const gatewayId = requireGatewayId();
+  const gatewayId = config.gatewayId;
 
   try {
     const org = await db.query.organizationSchema.findFirst({
@@ -310,6 +310,7 @@ export async function changePlan(
     const amount = getPlanTotalPrice(newPlanId, newBillingCycle);
 
     await iqproPut(
+      config,
       `/api/gateway/${gatewayId}/subscription/${org.iqproSubscriptionId}`,
       {
         name: `Dojo Planner ${plan.name} Plan`,
@@ -346,6 +347,7 @@ export async function changePlan(
 // ===== Cancel subscription =====
 
 export async function cancelSubscription(
+  config: IQProConfig | null,
   orgId: string,
   endOfPeriod: boolean,
 ): Promise<{ success: boolean; error?: string }> {
@@ -356,9 +358,10 @@ export async function cancelSubscription(
     });
 
     // If there's an IQPro subscription, cancel it
-    if (org?.iqproSubscriptionId) {
-      const gatewayId = requireGatewayId();
+    if (org?.iqproSubscriptionId && config) {
+      const gatewayId = config.gatewayId;
       await iqproPost(
+        config,
         `/api/gateway/${gatewayId}/subscription/${org.iqproSubscriptionId}/cancel`,
         {
           cancel: {
@@ -387,19 +390,23 @@ export async function cancelSubscription(
 
 // ===== Get billing history =====
 
-export async function getBillingHistory(orgId: string): Promise<BillingHistoryItem[]> {
+export async function getBillingHistory(
+  config: IQProConfig | null,
+  orgId: string,
+): Promise<BillingHistoryItem[]> {
   const org = await db.query.organizationSchema.findFirst({
     where: eq(organizationSchema.id, orgId),
     columns: { iqproSubscriptionId: true },
   });
 
-  if (!org?.iqproSubscriptionId) {
+  if (!org?.iqproSubscriptionId || !config) {
     return [];
   }
 
   try {
-    const gatewayId = requireGatewayId();
+    const gatewayId = config.gatewayId;
     const subscription = await iqproGet<Record<string, unknown>>(
+      config,
       `/api/gateway/${gatewayId}/subscription/${org.iqproSubscriptionId}`,
     );
 

--- a/src/types/Audit.test.ts
+++ b/src/types/Audit.test.ts
@@ -25,8 +25,9 @@ describe('Audit Types', () => {
       // + 3 merge field + 1 payment + 1 payment method register + 1 family member link
       // + 1 family member unlink + 1 member convert + 3 saas subscription
       // + 3 note (create + update + delete) + 3 staff (invite + update + remove)
-      // + 3 role (create + update + delete) + 1 organization location update = 88
-      expect(actionCount).toBe(88);
+      // + 3 role (create + update + delete) + 1 organization location update
+      // + 2 iqpro config (per-org + platform) = 90
+      expect(actionCount).toBe(90);
     });
   });
 

--- a/src/types/Audit.ts
+++ b/src/types/Audit.ts
@@ -126,6 +126,10 @@ export const AUDIT_ACTION = {
   // Organization operations
   ORGANIZATION_LOCATION_UPDATE: 'organizationLocation.update',
 
+  // IQPro merchant configuration
+  IQPRO_CONFIG_UPDATE: 'iqproConfig.update',
+  PLATFORM_IQPRO_CONFIG_UPDATE: 'platformIqproConfig.update',
+
   // Note operations
   NOTE_CREATE: 'note.create',
   NOTE_UPDATE: 'note.update',

--- a/src/validations/PaymentSettingsValidation.test.ts
+++ b/src/validations/PaymentSettingsValidation.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { UpdateIQProConfigValidation } from './PaymentSettingsValidation';
+
+describe('UpdateIQProConfigValidation', () => {
+  it('accepts a fully populated config', () => {
+    const result = UpdateIQProConfigValidation.safeParse({
+      clientId: 'cid',
+      clientSecret: 'shhh',
+      gatewayId: 'gid',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a config without clientSecret (means "keep existing")', () => {
+    const result = UpdateIQProConfigValidation.safeParse({
+      clientId: 'cid',
+      gatewayId: 'gid',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an empty clientId', () => {
+    const result = UpdateIQProConfigValidation.safeParse({
+      clientId: '',
+      gatewayId: 'gid',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an empty gatewayId', () => {
+    const result = UpdateIQProConfigValidation.safeParse({
+      clientId: 'cid',
+      gatewayId: '',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('trims whitespace on all fields', () => {
+    const result = UpdateIQProConfigValidation.safeParse({
+      clientId: '  cid  ',
+      clientSecret: '  s  ',
+      gatewayId: '  gid  ',
+    });
+
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      expect(result.data.clientId).toBe('cid');
+      expect(result.data.gatewayId).toBe('gid');
+      expect(result.data.clientSecret).toBe('s');
+    }
+  });
+
+  it('rejects oversized inputs', () => {
+    const tooLong = 'x'.repeat(600);
+    const result = UpdateIQProConfigValidation.safeParse({
+      clientId: 'cid',
+      clientSecret: tooLong,
+      gatewayId: 'gid',
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/validations/PaymentSettingsValidation.ts
+++ b/src/validations/PaymentSettingsValidation.ts
@@ -1,0 +1,14 @@
+import * as z from 'zod';
+
+/**
+ * Schema for both per-org (customer payments) and platform (SaaS billing)
+ * IQPro merchant credentials. `clientSecret` is optional on update — a blank
+ * or omitted value means "keep the existing secret unchanged".
+ */
+export const UpdateIQProConfigValidation = z.object({
+  clientId: z.string().trim().min(1).max(200),
+  clientSecret: z.string().trim().max(500).optional(),
+  gatewayId: z.string().trim().min(1).max(100),
+});
+
+export type UpdateIQProConfigInput = z.infer<typeof UpdateIQProConfigValidation>;


### PR DESCRIPTION
Moves IQPro merchant credentials (`clientId`, `clientSecret`, `gatewayId`) from
global env vars to per-org DB columns so each dojo can use its own merchant
account. Platform values (`scope`, `oauthUrl`, `baseUrl`, `webhookSecret`) stay
as env vars — same IQPro environment for everyone.

## What changed

**Schema** — new columns on `organization` (per-org customer payments) and a
new singleton `platform_config` table (SaaS billing). `clientSecret` is
AES-256-GCM encrypted at rest with a key from `IQPRO_CONFIG_ENCRYPTION_KEY`.

**Config resolver** — new `src/services/IQProConfigService.ts` exposes
`resolveIQProConfig(orgId)` and `resolvePlatformIQProConfig()`. Each falls back
to env vars per field, decrypts the secret, and caches for 60s. Cache is
invalidated on update.

**IQPro lib refactor** — every helper in `src/libs/IQPro.ts` (`iqproPost`,
`iqproGet`, `iqproPut`, `getTokenizationConfig`, `tokenizeAch`,
`getGatewayProcessors`, `computeFeeBreakdown`, `getCustomerPaymentMethod`) now
takes an `IQProConfig` as its first arg. OAuth token cache keyed by `clientId`
so two orgs with distinct credentials get distinct tokens (no cross-tenant
leakage). Same treatment for the gateway-processors cache (keyed by
`gatewayId`).

**Service / router threading** — `IQProPaymentService`, `MemberPaymentService`,
and `SaasSubscriptionService` all take a resolved `IQProConfig`. Routers
resolve once per request via the `guardRole` context and thread it through.
The webhook handler is unchanged (pure DB writes, no IQPro callbacks).

**Settings UI** — new IQPro Payment Gateway card on the Location Settings page:

- `org:academy_owner` and `org:admin` can view (badge shows `Source: org` vs
  `env` fallback).
- Only `org:admin` sees the edit button.
- Modal lets admins set Client ID / Client Secret / Gateway ID. Leaving the
  secret blank means "keep existing".

Defense-in-depth: `paymentSettings.getConfig` requires `ACADEMY_OWNER`;
`paymentSettings.updateConfig` requires `ADMIN`. UI gating and ORPC guards
both enforce the rule.

**Platform settings** — new super-admin-only page at
`/dashboard/platform-settings` for the dojo-planner SaaS-billing merchant
account. Reuses `PaymentSettingsForm`. Gated by `isSuperAdmin(username)` in
both the route and the ORPC handler.

**Audit** — new `IQPRO_CONFIG_UPDATE` and `PLATFORM_IQPRO_CONFIG_UPDATE`
actions. Secret values are never logged — only a `clientSecretChanged: true`
flag.

**Backfill scripts** — opt-in `src/scripts/backfillIQProConfig.ts` and
`backfillPlatformIQProConfig.ts` copy current env values into the DB for a
given org (or the platform singleton). Run once per org/platform; remove the
legacy `IQPRO_CLIENT_ID` / `IQPRO_CLIENT_SECRET` / `IQPRO_GATEWAY_ID` env vars
afterward.

## Migration

DDL applied to Neon `preview` and `main` branches out-of-band:

```sql
ALTER TABLE "organization"
  ADD COLUMN IF NOT EXISTS "iqpro_config_client_id" text,
  ADD COLUMN IF NOT EXISTS "iqpro_config_client_secret_enc" text,
  ADD COLUMN IF NOT EXISTS "iqpro_config_gateway_id" text;

CREATE TABLE IF NOT EXISTS "platform_config" (
  "id" text PRIMARY KEY NOT NULL DEFAULT 'singleton',
  "iqpro_saas_client_id" text,
  "iqpro_saas_client_secret_enc" text,
  "iqpro_saas_gateway_id" text,
  "updated_at" timestamp DEFAULT now() NOT NULL,
  CONSTRAINT "platform_config_singleton" CHECK ("id" = 'singleton')
);
```

New env var required on every environment (Production and Preview, with a
different value each): `IQPRO_CONFIG_ENCRYPTION_KEY` = 32 raw bytes,
hex-encoded (generate with `openssl rand -hex 32`).

Existing single-tenant deployments keep working unchanged — the resolver falls
back to the legacy `IQPRO_*` env vars per field until each org fills in
Payment Settings.

## Follow-up

The kiosk app (`dojo-planner-kiosk`) has its own copy of the IQPro REST client
that still reads env vars globally. A parallel refactor is needed there to
respect per-org credentials — tracked separately.

## Test plan

- [x] Type check, lint, deps, i18n: clean
- [x] 4455/4455 unit + UI tests pass (new coverage for Crypto, IQProConfigService,
      PaymentSettings router, PlatformSettings router, validation, form)
- [ ] Manual: org admin enters credentials via Location Settings → card shows
      `Source: org` → next payment uses the new credentials
- [ ] Manual: clear org columns → payment falls back to env (`Source: env`)
- [ ] Manual: non-admin academy owner sees the card but no edit button
- [ ] Manual: front-desk user does not see the card at all
- [ ] Manual: secret rotation via the modal — next charge uses the new secret
- [ ] Manual: SaaS billing under Platform Settings (super admin only)