### PR TITLE
feat(billing lifecycle): correct signup fee billing, next payment dat…

### DIFF
--- a/src/features/members/conversion/ConvertMemberModal.tsx
+++ b/src/features/members/conversion/ConvertMemberModal.tsx
@@ -174,20 +174,25 @@ export const ConvertMemberModal = ({
         memberType: targetMemberType,
       });
 
-      // 3. Add membership if one was selected in the wizard
+      // 3. Add membership if one was selected in the wizard. Capture the new
+      // member_membership.id so the subsequent payment call can attach the
+      // IQPro subscription + first/next payment dates to the right row.
+      let newMemberMembershipId: string | undefined;
       if (wizard.data.membershipPlanId) {
         if (hasMembership || (conversionType === 'family-to-individual')) {
           // Change existing membership (marks old as 'converted', creates new)
-          await client.member.changeMembership({
+          const r = await client.member.changeMembership({
             memberId,
             newMembershipPlanId: wizard.data.membershipPlanId,
           });
+          newMemberMembershipId = r?.id;
         } else {
           // No existing membership — add new
-          await client.member.addMembership({
+          const r = await client.member.addMembership({
             memberId,
             membershipPlanId: wizard.data.membershipPlanId,
           });
+          newMemberMembershipId = r?.id;
         }
       }
 
@@ -241,17 +246,18 @@ export const ConvertMemberModal = ({
       }
 
       // 5. Process payment (family-to-individual, or HOH-to-individual
-      // without payment method). Signup fee added on top so it's actually
-      // billed on first charge — see AddMemberModal for rationale.
+      // without payment method). Recurring (post-coupon) goes in `amount`;
+      // the signup fee rides separately so the IQPro subscription is
+      // configured at the recurring price only.
       const planPrice = wizard.data.appliedCoupon
         ? computeDiscountedPrice(wizard.data.membershipPlanPrice, wizard.data.appliedCoupon) ?? 0
         : (wizard.data.membershipPlanPrice ?? 0);
       const signupFee = wizard.data.membershipPlanSignupFee ?? 0;
-      const finalPrice = planPrice + signupFee;
+      const totalDueToday = planPrice + signupFee;
 
       let paymentDeclined = false;
 
-      if (wizard.data.paymentMethod && finalPrice > 0) {
+      if (wizard.data.paymentMethod && totalDueToday > 0) {
         try {
           wizard.updateData({ paymentStatus: 'processing' });
 
@@ -265,7 +271,8 @@ export const ConvertMemberModal = ({
             memberLastName: lastName,
             paymentMethod: wizard.data.paymentMethod,
             billingType: wizard.data.billingType || 'autopay',
-            amount: finalPrice,
+            amount: planPrice,
+            signupFee,
             description: wizard.data.membershipPlanName
               ? `Membership: ${wizard.data.membershipPlanName}`
               : 'Membership payment',
@@ -282,6 +289,9 @@ export const ConvertMemberModal = ({
             ...(wizard.data.achAccountType && { achAccountType: wizard.data.achAccountType }),
             ...(wizard.data.membershipPlanId && { membershipPlanId: wizard.data.membershipPlanId }),
             ...(wizard.data.membershipPlanFrequency && { membershipPlanFrequency: wizard.data.membershipPlanFrequency }),
+            // New membership row from step 3 — payment service attaches the
+            // IQPro subscription id + first/next payment dates here.
+            ...(newMemberMembershipId && { memberMembershipId: newMemberMembershipId }),
             ...(wizard.data.appliedCoupon && { appliedCoupon: wizard.data.appliedCoupon }),
           });
 

--- a/src/features/members/wizard/AddFamilyMembersModal.tsx
+++ b/src/features/members/wizard/AddFamilyMembersModal.tsx
@@ -335,18 +335,18 @@ export const AddFamilyMembersModal = ({
         });
       }
 
-      // 4. Process payment — add signup fee on top of the recurring price so
-      // it's actually billed on first charge. Coupon discount applies to the
-      // recurring price only.
+      // 4. Process payment. Recurring (post-coupon) goes in `amount`; the
+      // signup fee rides separately so the IQPro subscription is configured at
+      // the recurring price only (the fee is bundled into the initial Sale).
       const planPrice = wizard.data.appliedCoupon
         ? computeDiscountedPrice(wizard.data.membershipPlanPrice, wizard.data.appliedCoupon) ?? 0
         : (wizard.data.membershipPlanPrice ?? 0);
       const signupFee = wizard.data.membershipPlanSignupFee ?? 0;
-      const finalPrice = planPrice + signupFee;
+      const totalDueToday = planPrice + signupFee;
 
       let paymentDeclined = false;
 
-      if (finalPrice > 0 && result.id) {
+      if (totalDueToday > 0 && result.id) {
         try {
           wizard.updateData({ paymentStatus: 'processing' });
 
@@ -368,7 +368,8 @@ export const AddFamilyMembersModal = ({
             // without re-collecting card data.
             paymentMethodSource: wizard.data.hohHasPaymentMethod ? 'saved' : 'new',
             billingType: 'autopay',
-            amount: finalPrice,
+            amount: planPrice,
+            signupFee,
             description: wizard.data.membershipPlanName
               ? `Membership: ${wizard.data.membershipPlanName}`
               : 'Membership payment',
@@ -387,6 +388,9 @@ export const AddFamilyMembersModal = ({
             }),
             ...(wizard.data.membershipPlanId && { membershipPlanId: wizard.data.membershipPlanId }),
             ...(wizard.data.membershipPlanFrequency && { membershipPlanFrequency: wizard.data.membershipPlanFrequency }),
+            // Family member's own membership row id — the payment service
+            // updates this row with the IQPro subscription id + dates.
+            ...(result.memberMembershipId && { memberMembershipId: result.memberMembershipId }),
             ...(wizard.data.appliedCoupon && { appliedCoupon: wizard.data.appliedCoupon }),
           });
 

--- a/src/features/members/wizard/AddMemberModal.tsx
+++ b/src/features/members/wizard/AddMemberModal.tsx
@@ -417,15 +417,19 @@ export const AddMemberModal = ({ isOpen, onCloseAction, availableCoupons = [] }:
       // collects it on the plan, and the member should be billed for it on
       // registration. The coupon discount applies to the recurring price
       // only, not the signup fee.
+      // Recurring (post-coupon) — what IQPro subscription will bill every
+      // cycle. Sent to the service as `amount`.
       const planPrice = wizard.data.appliedCoupon
         ? computeDiscountedPrice(wizard.data.membershipPlanPrice, wizard.data.appliedCoupon) ?? 0
         : (wizard.data.membershipPlanPrice ?? 0);
+      // One-time signup fee — sent separately so it only hits the initial
+      // Sale, never the recurring subscription amount.
       const signupFee = wizard.data.membershipPlanSignupFee ?? 0;
-      const finalPrice = planPrice + signupFee;
+      const totalDueToday = planPrice + signupFee;
 
       let paymentDeclined = false;
 
-      if (wizard.data.paymentMethod && finalPrice > 0 && result.id) {
+      if (wizard.data.paymentMethod && totalDueToday > 0 && result.id) {
         try {
           wizard.updateData({ paymentStatus: 'processing' });
 
@@ -438,7 +442,8 @@ export const AddMemberModal = ({ isOpen, onCloseAction, availableCoupons = [] }:
             ...(wizard.data.address && { memberAddress: wizard.data.address }),
             paymentMethod: wizard.data.paymentMethod,
             billingType: wizard.data.billingType || 'one-time',
-            amount: finalPrice,
+            amount: planPrice,
+            signupFee,
             description: wizard.data.membershipPlanName
               ? `Membership: ${wizard.data.membershipPlanName}`
               : 'Membership payment',
@@ -457,9 +462,12 @@ export const AddMemberModal = ({ isOpen, onCloseAction, availableCoupons = [] }:
             ...(wizard.data.achRoutingNumber && { achRoutingNumber: wizard.data.achRoutingNumber }),
             ...(wizard.data.achAccountNumber && { achAccountNumber: wizard.data.achAccountNumber }),
             ...(wizard.data.achAccountType && { achAccountType: wizard.data.achAccountType }),
-            // Membership context
+            // Membership context — including memberMembershipId so the
+            // service can attach the IQPro subscription id + first/next
+            // payment dates to the right row on success.
             ...(wizard.data.membershipPlanId && { membershipPlanId: wizard.data.membershipPlanId }),
             ...(wizard.data.membershipPlanFrequency && { membershipPlanFrequency: wizard.data.membershipPlanFrequency }),
+            ...(result.memberMembershipId && { memberMembershipId: result.memberMembershipId }),
             ...(wizard.data.appliedCoupon && { appliedCoupon: wizard.data.appliedCoupon }),
           });
 
@@ -665,17 +673,18 @@ export const AddMemberModal = ({ isOpen, onCloseAction, availableCoupons = [] }:
         });
       }
 
-      // 4. Process payment using HOH's context (signup fee added on top —
-      // see comment in the standalone-member branch above for rationale).
+      // 4. Process payment using HOH's context. Recurring + signup fee are
+      // sent separately so the IQPro subscription is created at the recurring
+      // amount only (signup fee is charged once on the initial Sale).
       const planPrice = wizard.data.appliedCoupon
         ? computeDiscountedPrice(wizard.data.membershipPlanPrice, wizard.data.appliedCoupon) ?? 0
         : (wizard.data.membershipPlanPrice ?? 0);
       const signupFee = wizard.data.membershipPlanSignupFee ?? 0;
-      const finalPrice = planPrice + signupFee;
+      const totalDueToday = planPrice + signupFee;
 
       let paymentDeclined = false;
 
-      if (finalPrice > 0 && result.id && wizard.data.hohMemberId) {
+      if (totalDueToday > 0 && result.id && wizard.data.hohMemberId) {
         try {
           wizard.updateData({ paymentStatus: 'processing' });
 
@@ -702,7 +711,8 @@ export const AddMemberModal = ({ isOpen, onCloseAction, availableCoupons = [] }:
             // the local payment_method table.
             paymentMethodSource: wizard.data.hohHasPaymentMethod ? 'saved' : 'new',
             billingType: 'autopay',
-            amount: finalPrice,
+            amount: planPrice,
+            signupFee,
             description: wizard.data.membershipPlanName
               ? `Membership: ${wizard.data.membershipPlanName}`
               : 'Membership payment',
@@ -722,6 +732,10 @@ export const AddMemberModal = ({ isOpen, onCloseAction, availableCoupons = [] }:
             }),
             ...(wizard.data.membershipPlanId && { membershipPlanId: wizard.data.membershipPlanId }),
             ...(wizard.data.membershipPlanFrequency && { membershipPlanFrequency: wizard.data.membershipPlanFrequency }),
+            // result.memberMembershipId belongs to the FAMILY member's
+            // membership row, even though we may charge the HOH's vaulted
+            // payment method. The payment service updates this row.
+            ...(result.memberMembershipId && { memberMembershipId: result.memberMembershipId }),
             ...(wizard.data.appliedCoupon && { appliedCoupon: wizard.data.appliedCoupon }),
           });
 

--- a/src/features/members/wizard/FamilyPaymentStep.test.tsx
+++ b/src/features/members/wizard/FamilyPaymentStep.test.tsx
@@ -25,6 +25,9 @@ const translationKeys: Record<string, string> = {
   confirm_button: 'Confirm & Add Member',
   processing_button: 'Processing...',
   // PaymentStep namespace (read via tPayment)
+  membership_label: 'Membership',
+  signup_fee_label: 'Sign-up fee',
+  total_due_today_label: 'Total due today',
   card_tab_label: 'Debit / Credit Card',
   ach_tab_label: 'ACH Bank Account',
   cardholder_name_label: 'Name on card',
@@ -207,5 +210,46 @@ describe('FamilyPaymentStep — Free trial mode (#129/#135/#139)', () => {
     render(<FamilyPaymentStep {...baseProps} />);
 
     expect(page.getByText('Billing Summary')).toBeTruthy();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Signup-fee breakdown — when `membershipPlanSignupFee > 0` the single
+// "Amount" row in the summary is replaced by three rows: Membership,
+// Sign-up fee, Total due today.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('FamilyPaymentStep — signup fee breakdown', () => {
+  it('itemizes membership and signup fee when signupFee > 0', () => {
+    const dataWithFee: AddMemberWizardData = {
+      ...baseData,
+      membershipPlanPrice: 149,
+      membershipPlanSignupFee: 99,
+      membershipPlanName: '12 Month Commitment (Gold)',
+    };
+    render(<FamilyPaymentStep {...baseProps} data={dataWithFee} />);
+
+    // Three breakdown rows replace the single "Amount" row
+    expect(page.getByText('Membership').first()).toBeTruthy();
+    expect(page.getByText('Sign-up fee').first()).toBeTruthy();
+    expect(page.getByText('Total due today')).toBeTruthy();
+    // The original "Amount" label should NOT be shown when the breakdown is active
+    expect(document.body.textContent).not.toContain('Amount');
+    // The summary numbers should reflect $149 recurring + $99 fee = $248 total
+    expect(document.body.textContent).toContain('$149');
+    expect(document.body.textContent).toContain('$99');
+    expect(document.body.textContent).toContain('$248');
+  });
+
+  it('falls back to the single "Amount" row when signupFee is 0', () => {
+    const dataNoFee: AddMemberWizardData = {
+      ...baseData,
+      membershipPlanPrice: 149,
+      membershipPlanSignupFee: 0,
+    };
+    render(<FamilyPaymentStep {...baseProps} data={dataNoFee} />);
+
+    expect(page.getByText('Amount')).toBeTruthy();
+    expect(document.body.textContent).not.toContain('Total due today');
   });
 });

--- a/src/features/members/wizard/FamilyPaymentStep.tsx
+++ b/src/features/members/wizard/FamilyPaymentStep.tsx
@@ -142,11 +142,15 @@ export const FamilyPaymentStep = ({
     return { discountAmount: 0, finalPrice: originalPrice };
   }, [data.appliedCoupon, originalPrice]);
 
-  // Signup fee is added to the first charge by AddFamilyMembersModal — keep
-  // the displayed total in sync.
+  // Signup fee rides with the initial Sale only; the recurring subscription
+  // is configured at `finalPrice` (post-coupon, no signup fee). Itemize in
+  // the summary when present so the user sees what recurs vs. one-time.
   const signupFee = data.membershipPlanSignupFee ?? 0;
+  const hasSignupFee = signupFee > 0;
   const chargeTotal = finalPrice + signupFee;
   const paymentAmount = formatPaymentAmount(chargeTotal);
+  const recurringAmount = formatPaymentAmount(finalPrice);
+  const signupFeeAmount = formatPaymentAmount(signupFee);
 
   const handleCouponChange = (couponId: string) => {
     if (couponId === 'none') {
@@ -280,21 +284,51 @@ export const FamilyPaymentStep = ({
               <span className="text-muted-foreground">{t('plan_label')}</span>
               <span className="font-medium">{data.membershipPlanName || '-'}</span>
             </div>
-            <div className="flex justify-between">
-              <span className="text-muted-foreground">{t('amount_label')}</span>
-              <span className="font-medium">
-                {hasCouponApplied
-                  ? (
-                      <>
-                        {paymentAmount}
-                        {' '}
-                        <span className="text-muted-foreground line-through">{formatPaymentAmount(originalPrice)}</span>
-                      </>
-                    )
-                  : paymentAmount}
-                {frequencyLabel && `/${frequencyLabel}`}
-              </span>
-            </div>
+            {hasSignupFee
+              ? (
+                  <>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">{tPayment('membership_label')}</span>
+                      <span className="font-medium">
+                        {hasCouponApplied
+                          ? (
+                              <>
+                                {recurringAmount}
+                                {' '}
+                                <span className="text-muted-foreground line-through">{formatPaymentAmount(originalPrice)}</span>
+                              </>
+                            )
+                          : recurringAmount}
+                        {frequencyLabel && `/${frequencyLabel}`}
+                      </span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">{tPayment('signup_fee_label')}</span>
+                      <span className="font-medium">{signupFeeAmount}</span>
+                    </div>
+                    <div className="flex justify-between border-t pt-2">
+                      <span className="font-semibold">{tPayment('total_due_today_label')}</span>
+                      <span className="font-semibold">{paymentAmount}</span>
+                    </div>
+                  </>
+                )
+              : (
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">{t('amount_label')}</span>
+                    <span className="font-medium">
+                      {hasCouponApplied
+                        ? (
+                            <>
+                              {paymentAmount}
+                              {' '}
+                              <span className="text-muted-foreground line-through">{formatPaymentAmount(originalPrice)}</span>
+                            </>
+                          )
+                        : paymentAmount}
+                      {frequencyLabel && `/${frequencyLabel}`}
+                    </span>
+                  </div>
+                )}
             <div className="border-t pt-2">
               <div className="flex justify-between">
                 <span className="text-muted-foreground">{t('hoh_label')}</span>

--- a/src/features/members/wizard/PaymentStep.test.tsx
+++ b/src/features/members/wizard/PaymentStep.test.tsx
@@ -8,7 +8,12 @@ import { PaymentStep } from './PaymentStep';
 // Mock next-intl
 const translationKeys: Record<string, string> = {
   pay_amount: 'Pay {amount}',
+  pay_amount_today: 'Pay {amount} today',
   payment_description: '{plan} recurring membership ({period})',
+  payment_description_with_signup_fee: '{plan} recurring at {recurringAmount}/{period}. Plus one-time {signupFee} sign-up fee.',
+  membership_label: 'Membership',
+  signup_fee_label: 'Sign-up fee',
+  total_due_today_label: 'Total due today',
   plan_monthly: 'monthly',
   plan_annual: 'annual',
   period_month: 'month',
@@ -2311,6 +2316,69 @@ describe('PaymentStep', () => {
       render(<PaymentStep {...oddProps} />);
 
       expect(page.getByLabelText(/Name on card/)).toBeTruthy();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Signup-fee breakdown — when membershipPlanSignupFee > 0, the heading uses
+  // the "today" variant, the description names recurring + signup fee
+  // separately, and a three-row breakdown panel is rendered.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('signup fee breakdown', () => {
+    const signupFeeProps = {
+      ...defaultProps,
+      data: {
+        ...defaultProps.data,
+        membershipPlanName: '12 Month Commitment (Gold)',
+        membershipPlanPrice: 149,
+        membershipPlanSignupFee: 99,
+        membershipPlanFrequency: 'Monthly',
+      } as AddMemberWizardData,
+    };
+
+    it('shows "Pay $248 today" heading when signup fee is present', () => {
+      render(<PaymentStep {...signupFeeProps} />);
+
+      expect(page.getByText(/Pay \$248\.00 today/)).toBeTruthy();
+    });
+
+    it('description names recurring and signup fee separately, not the bundled total', () => {
+      render(<PaymentStep {...signupFeeProps} />);
+
+      // Description should mention $149/month recurring AND $99 one-time fee
+      const descriptionMatch = document.body.textContent ?? '';
+
+      expect(descriptionMatch).toContain('$149');
+      expect(descriptionMatch).toContain('$99');
+      expect(descriptionMatch).toContain('sign-up fee');
+    });
+
+    it('renders three-row breakdown panel (Membership / Sign-up fee / Total)', () => {
+      render(<PaymentStep {...signupFeeProps} />);
+
+      expect(page.getByText('Membership').first()).toBeTruthy();
+      expect(page.getByText('Sign-up fee').first()).toBeTruthy();
+      expect(page.getByText('Total due today')).toBeTruthy();
+    });
+
+    it('falls back to original heading + description when signupFee is 0', () => {
+      const noFeeProps = {
+        ...defaultProps,
+        data: {
+          ...defaultProps.data,
+          membershipPlanName: '12 Month Commitment (Gold)',
+          membershipPlanPrice: 149,
+          membershipPlanSignupFee: 0,
+          membershipPlanFrequency: 'Monthly',
+        } as AddMemberWizardData,
+      };
+
+      render(<PaymentStep {...noFeeProps} />);
+
+      // No "today" suffix in the heading, no breakdown panel
+      expect(page.getByText(/Pay \$149\.00$/).first()).toBeTruthy();
+      expect(document.body.textContent).not.toContain('Total due today');
     });
   });
 });

--- a/src/features/members/wizard/PaymentStep.tsx
+++ b/src/features/members/wizard/PaymentStep.tsx
@@ -143,12 +143,16 @@ export const PaymentStep = ({
     return { discountAmount: 0, finalPrice: originalPrice };
   }, [data.appliedCoupon, originalPrice]);
 
-  // Signup fee is added to the first charge by AddMemberModal — keep the
-  // displayed total in sync so the user sees the same number the card is
-  // billed for.
+  // Signup fee is charged once on the first transaction only; the recurring
+  // subscription (when autopay) is configured at `finalPrice` only. Display
+  // the combined total as today's charge, but break it out below so the user
+  // sees exactly what will recur vs. what's a one-time fee.
   const signupFee = data.membershipPlanSignupFee ?? 0;
+  const hasSignupFee = signupFee > 0;
   const chargeTotal = finalPrice + signupFee;
   const paymentAmount = formatPaymentAmount(chargeTotal);
+  const recurringAmount = formatPaymentAmount(finalPrice);
+  const signupFeeAmount = formatPaymentAmount(signupFee);
 
   // Free-trial detection — both flags must agree. A paid plan with a coupon
   // that brings price to $0 isn't a trial; it's a discounted plan and we
@@ -328,25 +332,66 @@ export const PaymentStep = ({
                     {hasCouponApplied
                       ? (
                           <>
-                            {t('pay_amount', { amount: paymentAmount })}
+                            {hasSignupFee
+                              ? t('pay_amount_today', { amount: paymentAmount })
+                              : t('pay_amount', { amount: paymentAmount })}
                             {' '}
                             <span className="text-base font-normal text-muted-foreground line-through">
                               {originalAmountText}
                             </span>
                           </>
                         )
-                      : t('pay_amount', { amount: paymentAmount })}
+                      : hasSignupFee
+                        ? t('pay_amount_today', { amount: paymentAmount })
+                        : t('pay_amount', { amount: paymentAmount })}
                   </h2>
                   <p className="text-sm text-muted-foreground">
-                    {t('payment_description', {
-                      plan: planText,
-                      amount: paymentAmount,
-                      period: periodText,
-                    })}
+                    {hasSignupFee
+                      ? t('payment_description_with_signup_fee', {
+                          plan: planText,
+                          recurringAmount,
+                          period: periodText,
+                          signupFee: signupFeeAmount,
+                        })
+                      : t('payment_description', {
+                          plan: planText,
+                          amount: paymentAmount,
+                          period: periodText,
+                        })}
                   </p>
                 </>
               )}
       </div>
+
+      {/* Breakdown panel — only when a signup fee is present. Shows the user
+          exactly which portion recurs vs. which is a one-time charge. */}
+      {!captureOnly && !isFreeTrial && hasSignupFee && (
+        <div className="space-y-2 rounded-lg border bg-muted/30 p-4 text-sm">
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">
+              {t('membership_label')}
+              {periodText && (
+                <span className="ml-1 text-xs text-muted-foreground">
+                  (
+                  {recurringAmount}
+                  /
+                  {periodText}
+                  )
+                </span>
+              )}
+            </span>
+            <span className="font-medium">{recurringAmount}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">{t('signup_fee_label')}</span>
+            <span className="font-medium">{signupFeeAmount}</span>
+          </div>
+          <div className="flex justify-between border-t pt-2">
+            <span className="font-semibold">{t('total_due_today_label')}</span>
+            <span className="font-semibold">{paymentAmount}</span>
+          </div>
+        </div>
+      )}
 
       {/* Capture-only info notice */}
       {captureOnly && (

--- a/src/hooks/useMembersCache.test.ts
+++ b/src/hooks/useMembersCache.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { renderHook } from 'vitest-browser-react';
 
-import { invalidateMembersCache, useMembersCache } from './useMembersCache';
+import { deriveMemberDisplayFields, invalidateMembersCache, useMembersCache } from './useMembersCache';
 
 describe('useMembersCache hook', () => {
   describe('without organization', () => {
@@ -40,5 +40,96 @@ describe('useMembersCache hook', () => {
       // Wait for the promise to settle
       await result;
     });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// deriveMemberDisplayFields — the row-mapper that powers the members table.
+// `amountDue` shows the plan's recurring price only when the member is past
+// their next payment date (or has none scheduled). For a freshly-paid
+// autopay member, the cell is empty.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('deriveMemberDisplayFields', () => {
+  const baseMember = {
+    id: 'mem_1',
+    firstName: 'Jane',
+    lastName: 'Doe',
+    email: 'jane@example.com',
+  };
+  const now = new Date('2026-06-01T12:00:00Z');
+  const oneMonthAhead = new Date('2026-07-01T12:00:00Z');
+  const oneDayAgo = new Date('2026-05-31T12:00:00Z');
+
+  it('hides amountDue when the next payment is in the future (paid + current)', () => {
+    const result = deriveMemberDisplayFields({
+      ...baseMember,
+      currentMembership: {
+        nextPaymentDate: oneMonthAhead.toISOString(),
+        membershipPlan: { price: 149, frequency: 'Monthly', isTrial: false },
+      },
+    }, now);
+
+    expect(result.amountDue).toBeUndefined();
+    expect(result.nextPayment?.getTime()).toBe(oneMonthAhead.getTime());
+    expect(result.membershipType).toBe('monthly');
+  });
+
+  it('shows amountDue (plan price) when the next payment is in the past', () => {
+    const result = deriveMemberDisplayFields({
+      ...baseMember,
+      currentMembership: {
+        nextPaymentDate: oneDayAgo.toISOString(),
+        membershipPlan: { price: 149, frequency: 'Monthly', isTrial: false },
+      },
+    }, now);
+
+    expect(result.amountDue).toBe('149.00');
+  });
+
+  it('shows amountDue when nextPaymentDate is missing entirely (no autopay scheduled)', () => {
+    const result = deriveMemberDisplayFields({
+      ...baseMember,
+      currentMembership: {
+        nextPaymentDate: null,
+        membershipPlan: { price: 149, frequency: 'Monthly', isTrial: false },
+      },
+    }, now);
+
+    expect(result.amountDue).toBe('149.00');
+    expect(result.nextPayment).toBeUndefined();
+  });
+
+  it('hides amountDue when plan price is 0 even if past due', () => {
+    const result = deriveMemberDisplayFields({
+      ...baseMember,
+      currentMembership: {
+        nextPaymentDate: oneDayAgo.toISOString(),
+        membershipPlan: { price: 0, frequency: 'Monthly', isTrial: true },
+      },
+    }, now);
+
+    expect(result.amountDue).toBeUndefined();
+    expect(result.membershipType).toBe('free-trial');
+  });
+
+  it('classifies annual plans as annual', () => {
+    const result = deriveMemberDisplayFields({
+      ...baseMember,
+      currentMembership: {
+        nextPaymentDate: oneMonthAhead.toISOString(),
+        membershipPlan: { price: 1490, frequency: 'Annual', isTrial: false },
+      },
+    }, now);
+
+    expect(result.membershipType).toBe('annual');
+  });
+
+  it('returns the member untouched (no membership) when currentMembership is absent', () => {
+    const result = deriveMemberDisplayFields(baseMember, now);
+
+    expect(result.amountDue).toBeUndefined();
+    expect(result.nextPayment).toBeUndefined();
+    expect(result.membershipType).toBeUndefined();
   });
 });

--- a/src/hooks/useMembersCache.ts
+++ b/src/hooks/useMembersCache.ts
@@ -85,6 +85,51 @@ const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
 let cacheStore: CacheEntry | null = null;
 const revalidateCallbacks: Array<() => void | Promise<void>> = [];
 
+/**
+ * Derives the display-only fields (`membershipType`, `amountDue`, `nextPayment`)
+ * on a member row for the members table. Pure — exported so unit tests can
+ * cover the "amountDue should be empty when the next payment is in the future"
+ * rule without spinning up the whole hook.
+ *
+ * `amountDue` is the plan's recurring price (one cycle), shown only when
+ * `nextPaymentDate` is in the past or absent — i.e. the member actually owes.
+ * For a freshly-paid autopay member whose next charge is in the future, the
+ * cell is empty.
+ */
+export function deriveMemberDisplayFields(member: any, now: Date = new Date()): Member {
+  const plan = member.currentMembership?.membershipPlan;
+  const membership = member.currentMembership;
+
+  let membershipType: Member['membershipType'];
+  if (plan) {
+    if (plan.isTrial) {
+      membershipType = 'free-trial';
+    } else if (plan.frequency === 'Monthly') {
+      membershipType = 'monthly';
+    } else if (plan.frequency === 'Annual') {
+      membershipType = 'annual';
+    } else {
+      membershipType = 'free';
+    }
+  }
+
+  const nextPayment = membership?.nextPaymentDate
+    ? new Date(membership.nextPaymentDate)
+    : undefined;
+
+  const isPaid = nextPayment !== undefined && nextPayment.getTime() > now.getTime();
+  const amountDue = !isPaid && plan?.price != null && plan.price > 0
+    ? Number(plan.price).toFixed(2)
+    : undefined;
+
+  return {
+    ...member,
+    membershipType,
+    amountDue,
+    nextPayment,
+  };
+}
+
 function cacheReducer(state: CacheState, action: CacheAction): CacheState {
   switch (action.type) {
     case 'RESET':
@@ -147,39 +192,7 @@ export const useMembersCache = (organizationId?: string | undefined) => {
       const membersData = await client.members.list();
       const rawMembers = (membersData.members || []) as any[];
 
-      // Derive membershipType, amountDue, and nextPayment from currentMembership
-      const detailedMembers: Member[] = rawMembers.map((member: any) => {
-        const plan = member.currentMembership?.membershipPlan;
-        const membership = member.currentMembership;
-
-        let membershipType: Member['membershipType'];
-        if (plan) {
-          if (plan.isTrial) {
-            membershipType = 'free-trial';
-          } else if (plan.frequency === 'Monthly') {
-            membershipType = 'monthly';
-          } else if (plan.frequency === 'Annual') {
-            membershipType = 'annual';
-          } else {
-            membershipType = 'free';
-          }
-        }
-
-        const amountDue = plan?.price != null && plan.price > 0
-          ? Number(plan.price).toFixed(2)
-          : undefined;
-
-        const nextPayment = membership?.nextPaymentDate
-          ? new Date(membership.nextPaymentDate)
-          : undefined;
-
-        return {
-          ...member,
-          membershipType,
-          amountDue,
-          nextPayment,
-        };
-      });
+      const detailedMembers: Member[] = rawMembers.map(member => deriveMemberDisplayFields(member));
 
       // Update cache
       cacheStore = {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -395,7 +395,12 @@
     },
     "PaymentStep": {
       "pay_amount": "Pay {amount}",
+      "pay_amount_today": "Pay {amount} today",
       "payment_description": "This signs up this member for a {plan} recurring membership. They will be charged {amount} every {period} on this day until they cancel.",
+      "payment_description_with_signup_fee": "This signs up this member for a {plan} recurring membership. They will be charged {recurringAmount} every {period} on this day until they cancel. Today's charge also includes a one-time {signupFee} sign-up fee.",
+      "membership_label": "Membership",
+      "signup_fee_label": "Sign-up fee",
+      "total_due_today_label": "Total due today",
       "card_tab_label": "Debit / Credit Card",
       "ach_tab_label": "ACH Bank Account",
       "cardholder_name_label": "Name on card",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -395,7 +395,12 @@
     },
     "PaymentStep": {
       "pay_amount": "Payer {amount}",
+      "pay_amount_today": "Payer {amount} aujourd'hui",
       "payment_description": "Ceci inscrit ce membre pour un abonnement récurrent {plan}. Il sera facturé {amount} tous les {period} à partir de ce jour jusqu'à l'annulation.",
+      "payment_description_with_signup_fee": "Ceci inscrit ce membre pour un abonnement récurrent {plan}. Il sera facturé {recurringAmount} tous les {period} à partir de ce jour jusqu'à l'annulation. Le paiement d'aujourd'hui inclut également des frais d'inscription uniques de {signupFee}.",
+      "membership_label": "Abonnement",
+      "signup_fee_label": "Frais d'inscription",
+      "total_due_today_label": "Total à payer aujourd'hui",
       "card_tab_label": "Carte de débit / crédit",
       "ach_tab_label": "Compte bancaire ACH",
       "cardholder_name_label": "Nom sur la carte",

--- a/src/routers/Member.ts
+++ b/src/routers/Member.ts
@@ -56,7 +56,10 @@ export const create = os
         status: 'success',
       });
 
-      // If a membership plan was selected, validate it exists and create the membership
+      // If a membership plan was selected, validate it exists and create the membership.
+      // We capture the new member_membership.id so downstream payment processing can
+      // attach the IQPro subscription id + first/next payment dates to the right row.
+      let memberMembershipId: string | undefined;
       if (input.membershipPlanId && member[0]?.id) {
         // Skip mock plan IDs (they start with 'mock-')
         if (input.membershipPlanId.startsWith('mock-')) {
@@ -66,8 +69,9 @@ export const create = os
           const plans = await getMembershipPlans(context.orgId);
           const planExists = plans.some(p => p.id === input.membershipPlanId);
           if (planExists) {
-            await addMemberMembership(member[0].id, input.membershipPlanId);
-            logger.info(`Membership added for new member: ${member[0].id}, planId: ${input.membershipPlanId}`);
+            const memberships = await addMemberMembership(member[0].id, input.membershipPlanId);
+            memberMembershipId = memberships[0]?.id;
+            logger.info(`Membership added for new member: ${member[0].id}, planId: ${input.membershipPlanId}, memberMembershipId: ${memberMembershipId}`);
 
             // Audit the membership addition
             await audit(context, AUDIT_ACTION.MEMBER_ADD_MEMBERSHIP, AUDIT_ENTITY_TYPE.MEMBERSHIP, {
@@ -82,6 +86,7 @@ export const create = os
 
       return {
         id: member[0]?.id,
+        memberMembershipId,
       };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/src/scripts/seed.ts
+++ b/src/scripts/seed.ts
@@ -53,6 +53,7 @@ import {
   waiverMergeFieldSchema,
   waiverTemplateSchema,
 } from '../models/Schema';
+import { computeNextPaymentDate, normalizeFrequency } from '../utils/PaymentSchedule';
 
 // Parse command line arguments
 const args = process.argv.slice(2);
@@ -1119,6 +1120,11 @@ async function seedOrganization(organizationId: string) {
       const planSlug = member.status === 'trial' ? '7-day-trial' : '12-month-gold';
       const planId = membershipPlanIdMap[planSlug];
       if (planId) {
+        // Synthetic iqproSubscriptionId for autopay members so the cancel /
+        // hold / reactivate lifecycle flows can be exercised in local dev
+        // without a real IQPro sandbox call. Trial members are one-time —
+        // no recurring subscription, so the field stays null.
+        const isAutopay = member.status === 'active';
         await db.insert(memberMembershipSchema).values({
           id: randomUUID(),
           memberId: id,
@@ -1126,6 +1132,7 @@ async function seedOrganization(organizationId: string) {
           status: 'active',
           billingType: member.status === 'trial' ? 'one-time' : 'autopay',
           startDate: new Date(),
+          iqproSubscriptionId: isAutopay ? `seed_sub_${randomUUID()}` : null,
         }).onConflictDoNothing();
       }
     }
@@ -1361,23 +1368,45 @@ async function seedOrganization(organizationId: string) {
     7: new Date('2024-05-20'), // Isabella Chen - joined May 2024
   };
 
+  // Helper: starting from joinDate, advance by one billing cycle at a time
+  // until the next payment lands in the future. Mirrors what a real autopay
+  // subscription's nextPaymentDate would be after months/years of charges.
+  const projectNextPaymentDate = (joinDate: Date, planSlug: string): Date | null => {
+    const plan = membershipPlansData.find(p => p.slug === planSlug);
+    const frequency = normalizeFrequency(plan?.frequency ?? null);
+    if (frequency === null) {
+      return null;
+    }
+    let cursor = new Date(joinDate);
+    const now = new Date();
+    // Cap iterations defensively (e.g. annual plan joined decades ago would
+    // still terminate, but we don't want a runaway loop).
+    for (let i = 0; i < 1000; i++) {
+      cursor = computeNextPaymentDate(cursor, frequency);
+      if (cursor > now) {
+        return cursor;
+      }
+    }
+    return cursor;
+  };
+
   for (let i = 0; i < membersData.length; i++) {
     const member = membersData[i]!;
     const memberId = memberIds[i]!;
     const joinDate = memberJoinDates[i]!;
 
     if (member.status === 'active' || member.status === 'trial') {
-      const nextPayment = new Date();
-      nextPayment.setDate(15);
-      if (nextPayment <= new Date()) {
-        nextPayment.setMonth(nextPayment.getMonth() + 1);
-      }
+      // Use the plan's actual frequency to compute the next payment date,
+      // honoring weekly / monthly / semi-annual / annual cadences and
+      // end-of-month clamping. Trial members get null (no recurring cycle).
+      const planSlug = member.status === 'trial' ? '7-day-trial' : '12-month-gold';
+      const nextPayment = member.status === 'trial' ? null : projectNextPaymentDate(joinDate, planSlug);
 
       await db.update(memberMembershipSchema)
         .set({
           startDate: joinDate,
           firstPaymentDate: joinDate,
-          nextPaymentDate: member.status === 'trial' ? null : nextPayment,
+          nextPaymentDate: nextPayment,
         })
         .where(eq(memberMembershipSchema.memberId, memberId));
     }
@@ -1428,12 +1457,15 @@ async function seedOrganization(organizationId: string) {
   console.info('  💰 Seeding transactions...');
   let transactionCount = 0;
 
-  // Helper to create a transaction
+  // Helper to create a transaction. Accepts an optional iqproTransactionId
+  // so the first-charge signup_fee + membership_payment rows can be linked
+  // (mirrors the wizard, which writes one IQPro Sale → two local rows).
   async function createTransaction(values: {
     organizationId: string;
     memberId: string;
     memberMembershipId?: string;
     eventRegistrationId?: string;
+    iqproTransactionId?: string;
     transactionType: string;
     amount: number;
     status: string;
@@ -1448,6 +1480,7 @@ async function seedOrganization(organizationId: string) {
       memberId: values.memberId,
       memberMembershipId: values.memberMembershipId ?? null,
       eventRegistrationId: values.eventRegistrationId ?? null,
+      iqproTransactionId: values.iqproTransactionId ?? null,
       transactionType: values.transactionType,
       amount: values.amount,
       currency: 'USD',
@@ -1496,18 +1529,27 @@ async function seedOrganization(organizationId: string) {
     { index: 7, planSlug: '12-month-gold', price: 149, signupFee: 99, startMonth: new Date('2024-05-15'), endMonth: null, paymentMethod: 'bank_transfer', last4: '' },
   ];
 
-  // Generate membership payment transactions
+  // Generate membership payment transactions. The first charge (signup fee +
+  // first month's membership payment) shares ONE iqproTransactionId — mirrors
+  // the wizard's "one IQPro Sale → two local tx rows" pattern. Each subsequent
+  // recurring cycle gets its own iqproTransactionId.
   for (const config of memberTxConfigs) {
     const memberId = memberIds[config.index]!;
     const mmId = memberMembershipIds[memberId];
 
-    // Signup fee
+    // Synthetic IQPro transaction id for the first-charge Sale that bundles
+    // signup fee + first month. Same id on both rows; null when there's no
+    // signup fee or no first-month charge (trial).
+    const firstChargeIqproId = `seed_tx_${randomUUID()}`;
+
+    // Signup fee (row 1 of the first-charge pair)
     if (config.signupFee > 0) {
       const joinDate = memberJoinDates[config.index]!;
       await createTransaction({
         organizationId,
         memberId,
         memberMembershipId: mmId,
+        iqproTransactionId: firstChargeIqproId,
         transactionType: 'signup_fee',
         amount: config.signupFee,
         status: 'paid',
@@ -1552,10 +1594,18 @@ async function seedOrganization(organizationId: string) {
         ? `Monthly membership - Card ending ${config.last4}`
         : 'Monthly membership - Bank transfer';
 
+      // First month: row 2 of the first-charge pair — shares the signup
+      // fee's iqproTransactionId. Subsequent months: each cycle is its own
+      // IQPro Sale, so each gets a fresh synthetic id.
+      const iqproTransactionId = mi === 0
+        ? firstChargeIqproId
+        : `seed_tx_${randomUUID()}`;
+
       await createTransaction({
         organizationId,
         memberId,
         memberMembershipId: mmId,
+        iqproTransactionId,
         transactionType: 'membership_payment',
         amount: config.price,
         status,

--- a/src/services/IQProPaymentService.test.ts
+++ b/src/services/IQProPaymentService.test.ts
@@ -490,6 +490,44 @@ describe('IQProPaymentProvider', () => {
       expect(result.success).toBe(false);
       expect(result.error).toBe('boom');
     });
+
+    it('lineItems array (membership + signup fee): emits one IQPro lineItem per entry', async () => {
+      const { provider, iqproPost } = await loadProvider();
+      iqproPost.mockResolvedValueOnce({
+        data: { transaction: { transactionId: 'tx_signup', status: 'Captured' } },
+      });
+
+      await provider.processPayment(testConfig, {
+        customerId: 'cust_123',
+        paymentMethodId: 'pm_card_1',
+        amount: 257.30,
+        currency: 'USD',
+        description: 'Membership: 12 Month Commitment (Gold)',
+        feeBreakdown: nonTaxableFees,
+        customerBillingAddressId: 'addr_billing_1',
+        billingAddress: baseBilling,
+        lineItems: [
+          { name: 'Membership: 12 Month Commitment (Gold)', description: 'Membership: 12 Month Commitment (Gold)', unitPrice: 149, discount: 0 },
+          { name: 'Sign-up fee', description: 'Sign-up fee — 12 Month Commitment (Gold)', unitPrice: 99, discount: 0 },
+        ],
+      });
+
+      const p = iqproPost.mock.calls[0]![2] as Record<string, any>;
+
+      expect(p.lineItems).toHaveLength(2);
+      expect(p.lineItems[0]).toEqual(expect.objectContaining({
+        name: 'Membership: 12 Month Commitment (Gold)',
+        unitPrice: 149,
+        discount: 0,
+        quantity: 1,
+      }));
+      expect(p.lineItems[1]).toEqual(expect.objectContaining({
+        name: 'Sign-up fee',
+        unitPrice: 99,
+        discount: 0,
+        quantity: 1,
+      }));
+    });
   });
 
   describe('createSubscription', () => {

--- a/src/services/IQProPaymentService.ts
+++ b/src/services/IQProPaymentService.ts
@@ -322,25 +322,25 @@ export class IQProPaymentProvider implements IPaymentProvider {
       // per-line-item tax check passes ("Remit.IsTaxExempt must be true when
       // all line items have zero tax"). IQPro charges tax via the Tax
       // paymentAdjustment, not from this percent.
-      const lineItem = params.lineItem ?? {
-        name: params.description,
-        description: params.description,
-        unitPrice: params.amount,
-        discount: 0,
-      };
-      const lineItems = [
-        {
-          name: lineItem.name,
-          description: lineItem.description,
-          quantity: 1,
-          unitPrice: lineItem.unitPrice,
-          discount: lineItem.discount,
-          freightAmount: 0,
-          unitOfMeasureId: 1,
-          localTaxPercent: isTaxable ? fb.taxPct : 0,
-          nationalTaxPercent: 0,
-        },
-      ];
+      const sourceLineItems = params.lineItems && params.lineItems.length > 0
+        ? params.lineItems
+        : [{
+            name: params.description,
+            description: params.description,
+            unitPrice: params.amount,
+            discount: 0,
+          }];
+      const lineItems = sourceLineItems.map(li => ({
+        name: li.name,
+        description: li.description,
+        quantity: 1,
+        unitPrice: li.unitPrice,
+        discount: li.discount,
+        freightAmount: 0,
+        unitOfMeasureId: 1,
+        localTaxPercent: isTaxable ? fb.taxPct : 0,
+        nationalTaxPercent: 0,
+      }));
 
       const txPayload: Record<string, unknown> = {
         type: 'Sale',

--- a/src/services/MemberPaymentService.test.ts
+++ b/src/services/MemberPaymentService.test.ts
@@ -102,11 +102,17 @@ vi.mock('./EmailService', () => ({
 // - update-set-where (set iqproCustomerId / membership fields)
 // - insert-values (payment method + transaction + coupon usage)
 
+// insertCalls stores whatever was passed to `db.insert(...).values(arg)`.
+// The orchestrator passes both single rows (payment_method, coupon_usage)
+// and arrays of rows (transactions — one row when no signup fee, two when
+// present), so the type is the union.
+type InsertArg = Record<string, unknown> | Array<Record<string, unknown>>;
+
 let dbState: {
   existingCustomerId: string | null;
   savedPmRow: { iqproPaymentMethodId: string; type: string; last4: string | null } | null;
   setCalls: Array<Record<string, unknown>>;
-  insertCalls: Array<Record<string, unknown>>;
+  insertCalls: InsertArg[];
   selectIndex: number;
 };
 
@@ -155,7 +161,7 @@ function resetDbMock(opts: {
   });
 
   dbMocks.insert.mockReturnValue({
-    values: vi.fn((vals: Record<string, unknown>) => {
+    values: vi.fn((vals: InsertArg) => {
       dbState.insertCalls.push(vals);
       return Promise.resolve();
     }),
@@ -261,6 +267,136 @@ describe('processMemberPayment', () => {
     expect(mockProvider.createSubscription).not.toHaveBeenCalled();
   });
 
+  it('autopay (monthly): writes firstPaymentDate=now and nextPaymentDate=now+1mo on success', async () => {
+    const { computeFeeBreakdown } = await import('@/libs/IQPro');
+    vi.mocked(computeFeeBreakdown).mockResolvedValueOnce(baseFees);
+
+    const { processMemberPayment } = await import('./MemberPaymentService');
+    const beforeCall = Date.now();
+    await processMemberPayment(testConfig, {
+      ...baseParams,
+      billingType: 'autopay',
+      membershipPlanFrequency: 'monthly',
+      memberMembershipId: 'mm_1',
+    });
+    const afterCall = Date.now();
+
+    const membershipSet = dbState.setCalls.find(s => s.iqproSubscriptionId === 'sub_42');
+
+    expect(membershipSet).toBeDefined();
+    expect(membershipSet?.firstPaymentDate).toBeInstanceOf(Date);
+    expect(membershipSet?.nextPaymentDate).toBeInstanceOf(Date);
+
+    // firstPaymentDate must be ~now
+    const firstPaymentMs = (membershipSet?.firstPaymentDate as Date).getTime();
+
+    expect(firstPaymentMs).toBeGreaterThanOrEqual(beforeCall);
+    expect(firstPaymentMs).toBeLessThanOrEqual(afterCall);
+
+    // nextPaymentDate should be one month later — same day-of-month when
+    // possible, clamped to the last day of the target month when not (e.g.
+    // Jan 31 → Feb 28). Either way, the month diff must be exactly 1.
+    const nextPaymentDate = membershipSet?.nextPaymentDate as Date;
+    const firstPaymentDate = membershipSet?.firstPaymentDate as Date;
+    const monthsDiff = (nextPaymentDate.getFullYear() - firstPaymentDate.getFullYear()) * 12
+      + (nextPaymentDate.getMonth() - firstPaymentDate.getMonth());
+
+    expect(monthsDiff).toBe(1);
+
+    const lastDayOfNextMonth = new Date(nextPaymentDate.getFullYear(), nextPaymentDate.getMonth() + 1, 0).getDate();
+
+    expect([firstPaymentDate.getDate(), lastDayOfNextMonth]).toContain(nextPaymentDate.getDate());
+  });
+
+  it('autopay (annual): nextPaymentDate is exactly one year later', async () => {
+    const { computeFeeBreakdown } = await import('@/libs/IQPro');
+    vi.mocked(computeFeeBreakdown).mockResolvedValueOnce(baseFees);
+
+    const { processMemberPayment } = await import('./MemberPaymentService');
+    await processMemberPayment(testConfig, {
+      ...baseParams,
+      billingType: 'autopay',
+      membershipPlanFrequency: 'annual',
+      memberMembershipId: 'mm_1',
+    });
+
+    const membershipSet = dbState.setCalls.find(s => s.iqproSubscriptionId === 'sub_42');
+    const next = membershipSet?.nextPaymentDate as Date;
+    const first = membershipSet?.firstPaymentDate as Date;
+
+    expect(next.getFullYear() - first.getFullYear()).toBe(1);
+    expect(next.getMonth()).toBe(first.getMonth());
+    expect(next.getDate()).toBe(first.getDate());
+  });
+
+  it('autopay (weekly): nextPaymentDate is exactly 7 days later', async () => {
+    const { computeFeeBreakdown } = await import('@/libs/IQPro');
+    vi.mocked(computeFeeBreakdown).mockResolvedValueOnce(baseFees);
+
+    const { processMemberPayment } = await import('./MemberPaymentService');
+    await processMemberPayment(testConfig, {
+      ...baseParams,
+      billingType: 'autopay',
+      membershipPlanFrequency: 'weekly',
+      memberMembershipId: 'mm_1',
+    });
+
+    const membershipSet = dbState.setCalls.find(s => s.iqproSubscriptionId === 'sub_42');
+    const next = membershipSet?.nextPaymentDate as Date;
+    const first = membershipSet?.firstPaymentDate as Date;
+    const diffMs = next.getTime() - first.getTime();
+
+    expect(diffMs).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+
+  it('autopay (semi-annual): nextPaymentDate is exactly six months later', async () => {
+    const { computeFeeBreakdown } = await import('@/libs/IQPro');
+    vi.mocked(computeFeeBreakdown).mockResolvedValueOnce(baseFees);
+
+    const { processMemberPayment } = await import('./MemberPaymentService');
+    await processMemberPayment(testConfig, {
+      ...baseParams,
+      billingType: 'autopay',
+      membershipPlanFrequency: 'semi-annual',
+      memberMembershipId: 'mm_1',
+    });
+
+    const membershipSet = dbState.setCalls.find(s => s.iqproSubscriptionId === 'sub_42');
+    const next = membershipSet?.nextPaymentDate as Date;
+    const first = membershipSet?.firstPaymentDate as Date;
+    const monthsDiff = (next.getFullYear() - first.getFullYear()) * 12
+      + (next.getMonth() - first.getMonth());
+
+    expect(monthsDiff).toBe(6);
+
+    // Day-of-month is preserved when possible, clamped to last day of target
+    // month otherwise (e.g. May 31 → Nov 30).
+    const lastDayOfNextMonth = new Date(next.getFullYear(), next.getMonth() + 1, 0).getDate();
+
+    expect([first.getDate(), lastDayOfNextMonth]).toContain(next.getDate());
+  });
+
+  it('autopay: writes NOTHING to membership row when memberMembershipId is missing (regression guard)', async () => {
+    const { computeFeeBreakdown } = await import('@/libs/IQPro');
+    vi.mocked(computeFeeBreakdown).mockResolvedValueOnce(baseFees);
+
+    const { processMemberPayment } = await import('./MemberPaymentService');
+    await processMemberPayment(testConfig, {
+      ...baseParams,
+      billingType: 'autopay',
+      membershipPlanFrequency: 'monthly',
+      // memberMembershipId intentionally omitted — exactly the pre-fix bug.
+    });
+
+    // The autopay db.update path is gated on memberMembershipId. Without it,
+    // no membership row gets `iqproSubscriptionId` / `nextPaymentDate` set —
+    // which is the bug this whole fix is about. Test guards that callers
+    // (the wizards) MUST pass memberMembershipId.
+    const membershipSet = dbState.setCalls.find(s => s.iqproSubscriptionId === 'sub_42');
+
+    expect(membershipSet).toBeUndefined();
+  });
+
   it('autopay: creates subscription THEN runs immediate Sale', async () => {
     const { computeFeeBreakdown } = await import('@/libs/IQPro');
     vi.mocked(computeFeeBreakdown).mockResolvedValueOnce(baseFees);
@@ -328,7 +464,13 @@ describe('processMemberPayment', () => {
 
     expect(wroteAutopay).toBe(false);
 
-    const txInsert = dbState.insertCalls.find(i => i.iqproTransactionId === 'tx_decline');
+    // Transaction inserts now use an array form (one row when no signup
+    // fee, two rows when present). Find the array containing the declined tx.
+    const txInsertArray = dbState.insertCalls.find(
+      (call): call is Array<Record<string, unknown>> =>
+        Array.isArray(call) && call.some(r => r.iqproTransactionId === 'tx_decline'),
+    );
+    const txInsert = txInsertArray?.find(r => r.iqproTransactionId === 'tx_decline');
 
     expect(txInsert?.status).toBe('declined');
   });
@@ -606,5 +748,339 @@ describe('processMemberPayment', () => {
     expect(mockSendReceipt).toHaveBeenCalledWith(expect.objectContaining({
       isRecurring: true,
     }));
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // SIGNUP FEE — load-bearing: when present, the IQPro recurring subscription
+  // MUST be created at the recurring amount only (NOT bundled with the fee),
+  // and the initial Sale MUST carry two line items + write two tx rows.
+  // Regression guard against the $149/mo plan getting billed at $248/mo.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('with signup fee', () => {
+    // Plan: $149/mo recurring + $99 one-time signup fee. Service fee 3.75%
+    // applied to the post-coupon subtotal ($149 + $99 = $248) → $9.30 SF →
+    // gross IQPro Sale ≈ $257.30 (but the local membership row records $149
+    // and the signup-fee row records $99 — fees aren't split across rows).
+    const planRecurring = 149;
+    const planSignupFee = 99;
+    const subtotal = planRecurring + planSignupFee;
+    const serviceFeeAmount = Math.round(subtotal * 0.0375 * 100) / 100;
+    const grossAmount = Math.round((subtotal + serviceFeeAmount) * 100) / 100;
+    const feesWithSignup = {
+      baseAmount: subtotal,
+      taxAmount: 0,
+      taxPct: 0,
+      serviceFeeAmount,
+      serviceFeePct: 3.75,
+      amount: grossAmount,
+    };
+
+    it('autopay: creates subscription at recurring amount only (not bundled with signup fee)', async () => {
+      const { computeFeeBreakdown } = await import('@/libs/IQPro');
+      vi.mocked(computeFeeBreakdown).mockResolvedValueOnce(feesWithSignup);
+
+      const { processMemberPayment } = await import('./MemberPaymentService');
+      await processMemberPayment(testConfig, {
+        ...baseParams,
+        amount: planRecurring,
+        signupFee: planSignupFee,
+        billingType: 'autopay',
+        membershipPlanFrequency: 'monthly',
+        memberMembershipId: 'mm_signup',
+      });
+
+      // The critical assertion: IQPro subscription created at $149, NOT $248
+      expect(mockProvider.createSubscription).toHaveBeenCalledWith(
+        testConfig,
+        expect.objectContaining({
+          amount: planRecurring,
+        }),
+      );
+
+      const subArgs = mockProvider.createSubscription.mock.calls[0]![1];
+
+      expect(subArgs.amount).not.toBe(subtotal);
+    });
+
+    it('autopay: initial Sale carries TWO line items (membership + signup fee)', async () => {
+      const { computeFeeBreakdown } = await import('@/libs/IQPro');
+      vi.mocked(computeFeeBreakdown).mockResolvedValueOnce(feesWithSignup);
+
+      const { processMemberPayment } = await import('./MemberPaymentService');
+      await processMemberPayment(testConfig, {
+        ...baseParams,
+        amount: planRecurring,
+        signupFee: planSignupFee,
+        billingType: 'autopay',
+        membershipPlanFrequency: 'monthly',
+        memberMembershipId: 'mm_signup',
+        description: 'Membership: 12 Month Commitment (Gold)',
+      });
+
+      expect(mockProvider.processPayment).toHaveBeenCalledTimes(1);
+
+      const saleArgs = mockProvider.processPayment.mock.calls[0]![1];
+
+      expect(saleArgs.lineItems).toHaveLength(2);
+      expect(saleArgs.lineItems[0]).toEqual(expect.objectContaining({
+        unitPrice: planRecurring,
+        discount: 0,
+      }));
+      expect(saleArgs.lineItems[1]).toEqual(expect.objectContaining({
+        name: 'Sign-up fee',
+        unitPrice: planSignupFee,
+        discount: 0,
+      }));
+      expect(saleArgs.amount).toBe(grossAmount);
+    });
+
+    it('autopay: writes TWO local tx rows sharing the same iqproTransactionId', async () => {
+      const { computeFeeBreakdown } = await import('@/libs/IQPro');
+      vi.mocked(computeFeeBreakdown).mockResolvedValueOnce(feesWithSignup);
+
+      const { processMemberPayment } = await import('./MemberPaymentService');
+      await processMemberPayment(testConfig, {
+        ...baseParams,
+        amount: planRecurring,
+        signupFee: planSignupFee,
+        billingType: 'autopay',
+        membershipPlanFrequency: 'monthly',
+        memberMembershipId: 'mm_signup',
+        description: 'Membership: 12 Month Commitment (Gold)',
+      });
+
+      const txInsert = dbState.insertCalls.find(
+        (call): call is Array<Record<string, unknown>> => Array.isArray(call),
+      );
+
+      expect(txInsert).toBeDefined();
+      expect(txInsert).toHaveLength(2);
+
+      const membershipRow = txInsert!.find(r => r.transactionType === 'membership_payment')!;
+      const signupRow = txInsert!.find(r => r.transactionType === 'signup_fee')!;
+
+      expect(membershipRow.amount).toBe(planRecurring);
+      expect(signupRow.amount).toBe(planSignupFee);
+      expect(membershipRow.iqproTransactionId).toBe('tx_42');
+      expect(signupRow.iqproTransactionId).toBe('tx_42');
+      expect(signupRow.description).toContain('Sign-up fee');
+      expect(signupRow.description).toContain('12 Month Commitment (Gold)');
+    });
+
+    it('one-time: single Sale with two line items + two tx rows', async () => {
+      const { computeFeeBreakdown } = await import('@/libs/IQPro');
+      vi.mocked(computeFeeBreakdown).mockResolvedValueOnce(feesWithSignup);
+
+      const { processMemberPayment } = await import('./MemberPaymentService');
+      await processMemberPayment(testConfig, {
+        ...baseParams,
+        amount: planRecurring,
+        signupFee: planSignupFee,
+        description: 'Membership: 12 Month Commitment (Gold)',
+      });
+
+      expect(mockProvider.createSubscription).not.toHaveBeenCalled();
+
+      const saleArgs = mockProvider.processPayment.mock.calls[0]![1];
+
+      expect(saleArgs.lineItems).toHaveLength(2);
+
+      const txInsert = dbState.insertCalls.find(
+        (call): call is Array<Record<string, unknown>> => Array.isArray(call),
+      );
+
+      expect(txInsert).toHaveLength(2);
+
+      const types = txInsert!.map(r => r.transactionType);
+
+      expect(types).toContain('membership_payment');
+      expect(types).toContain('signup_fee');
+    });
+
+    it('signupFee + coupon: discount applies to membership row only', async () => {
+      const { computeFeeBreakdown } = await import('@/libs/IQPro');
+      // 10% off $149 = $14.90 discount → membership row $134.10, signup $99
+      vi.mocked(computeFeeBreakdown).mockResolvedValueOnce({
+        ...feesWithSignup,
+        baseAmount: 233.10,
+        amount: 241.84,
+      });
+
+      const { processMemberPayment } = await import('./MemberPaymentService');
+      await processMemberPayment(testConfig, {
+        ...baseParams,
+        amount: planRecurring,
+        signupFee: planSignupFee,
+        billingType: 'autopay',
+        membershipPlanFrequency: 'monthly',
+        memberMembershipId: 'mm_signup_coupon',
+        appliedCoupon: {
+          id: 'coup_10pct',
+          code: 'WELCOME10',
+          type: 'Percentage',
+          amount: '10%',
+          description: '10% off',
+        },
+      });
+
+      // Recurring subscription is on the DISCOUNTED recurring price only
+      const subArgs = mockProvider.createSubscription.mock.calls[0]![1];
+
+      expect(subArgs.amount).toBeCloseTo(134.10, 2);
+
+      // Local tx rows: membership = discounted recurring, signup = full fee
+      const txInsert = dbState.insertCalls.find(
+        (call): call is Array<Record<string, unknown>> => Array.isArray(call),
+      )!;
+      const membershipRow = txInsert.find(r => r.transactionType === 'membership_payment')!;
+      const signupRow = txInsert.find(r => r.transactionType === 'signup_fee')!;
+
+      expect(membershipRow.amount as number).toBeCloseTo(134.10, 2);
+      expect(signupRow.amount).toBe(planSignupFee); // coupon NEVER applies to signup fee
+    });
+
+    it('signupFee === 0: writes ONE tx row, ONE line item (regression guard)', async () => {
+      const { computeFeeBreakdown } = await import('@/libs/IQPro');
+      vi.mocked(computeFeeBreakdown).mockResolvedValueOnce(baseFees);
+
+      const { processMemberPayment } = await import('./MemberPaymentService');
+      await processMemberPayment(testConfig, {
+        ...baseParams,
+        amount: planRecurring,
+        signupFee: 0,
+        billingType: 'autopay',
+        membershipPlanFrequency: 'monthly',
+        memberMembershipId: 'mm_no_signup',
+      });
+
+      // Subscription amount === membership amount (no signup fee folded in)
+      const subArgs = mockProvider.createSubscription.mock.calls[0]![1];
+
+      expect(subArgs.amount).toBe(planRecurring);
+
+      // Single line item, single tx row
+      const saleArgs = mockProvider.processPayment.mock.calls[0]![1];
+
+      expect(saleArgs.lineItems).toHaveLength(1);
+
+      const txInsert = dbState.insertCalls.find(
+        (call): call is Array<Record<string, unknown>> => Array.isArray(call),
+      )!;
+
+      expect(txInsert).toHaveLength(1);
+      expect(txInsert[0]!.transactionType).toBe('membership_payment');
+    });
+
+    it('receipt email: includes both line items when signupFee > 0', async () => {
+      const { computeFeeBreakdown } = await import('@/libs/IQPro');
+      vi.mocked(computeFeeBreakdown).mockResolvedValueOnce(feesWithSignup);
+
+      const { processMemberPayment } = await import('./MemberPaymentService');
+      await processMemberPayment(testConfig, {
+        ...baseParams,
+        amount: planRecurring,
+        signupFee: planSignupFee,
+        billingType: 'autopay',
+        membershipPlanFrequency: 'monthly',
+        memberMembershipId: 'mm_signup_receipt',
+        description: 'Membership: 12 Month Commitment (Gold)',
+      });
+
+      expect(mockSendReceipt).toHaveBeenCalledTimes(1);
+
+      const receiptArgs = mockSendReceipt.mock.calls[0]![0];
+
+      expect(receiptArgs.lineItems).toHaveLength(2);
+      expect(receiptArgs.lineItems[1]).toEqual(expect.objectContaining({
+        name: 'Sign-up fee',
+        unitPrice: planSignupFee,
+        discount: 0,
+      }));
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// computeNextPaymentDate — calendar-math helper used to fill
+// member_membership.nextPaymentDate after a successful autopay charge.
+// Uses real Date.setMonth / Date.setFullYear (not 30-day approximations).
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('computeNextPaymentDate', () => {
+  it('weekly: adds exactly 7 days', async () => {
+    const { computeNextPaymentDate } = await import('./MemberPaymentService');
+    const from = new Date('2026-06-01T12:00:00Z');
+    const next = computeNextPaymentDate(from, 'weekly');
+
+    expect(next.getTime() - from.getTime()).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+
+  it('monthly: adds exactly 1 month, preserving day-of-month', async () => {
+    const { computeNextPaymentDate } = await import('./MemberPaymentService');
+    const from = new Date(2026, 5, 15); // 15 June 2026 (local time, no TZ surprises)
+    const next = computeNextPaymentDate(from, 'monthly');
+
+    expect(next.getFullYear()).toBe(2026);
+    expect(next.getMonth()).toBe(6); // July
+    expect(next.getDate()).toBe(15);
+  });
+
+  it('monthly: handles year wraparound (Dec → Jan next year)', async () => {
+    const { computeNextPaymentDate } = await import('./MemberPaymentService');
+    const from = new Date(2026, 11, 15); // 15 December 2026
+    const next = computeNextPaymentDate(from, 'monthly');
+
+    expect(next.getFullYear()).toBe(2027);
+    expect(next.getMonth()).toBe(0); // January
+    expect(next.getDate()).toBe(15);
+  });
+
+  it('semi-annual: adds exactly 6 months', async () => {
+    const { computeNextPaymentDate } = await import('./MemberPaymentService');
+    const from = new Date(2026, 0, 15); // 15 January 2026
+    const next = computeNextPaymentDate(from, 'semi-annual');
+
+    expect(next.getFullYear()).toBe(2026);
+    expect(next.getMonth()).toBe(6); // July
+    expect(next.getDate()).toBe(15);
+  });
+
+  it('annual: adds exactly 1 year, preserving month and day', async () => {
+    const { computeNextPaymentDate } = await import('./MemberPaymentService');
+    const from = new Date(2026, 5, 15); // 15 June 2026
+    const next = computeNextPaymentDate(from, 'annual');
+
+    expect(next.getFullYear()).toBe(2027);
+    expect(next.getMonth()).toBe(5); // June
+    expect(next.getDate()).toBe(15);
+  });
+
+  it('null (one-time / no recurring): returns the same date unshifted', async () => {
+    const { computeNextPaymentDate } = await import('./MemberPaymentService');
+    const from = new Date('2026-06-01T12:00:00Z');
+    const next = computeNextPaymentDate(from, null);
+
+    expect(next.getTime()).toBe(from.getTime());
+  });
+
+  it('monthly: clamps day-of-month (Jan 31 → Feb 28, not Mar 3)', async () => {
+    const { computeNextPaymentDate } = await import('./MemberPaymentService');
+    const from = new Date(2026, 0, 31); // 31 January 2026 (non-leap)
+    const next = computeNextPaymentDate(from, 'monthly');
+
+    expect(next.getFullYear()).toBe(2026);
+    expect(next.getMonth()).toBe(1); // February
+    expect(next.getDate()).toBe(28); // clamped to last day of Feb
+  });
+
+  it('monthly: clamps day-of-month on a 31-day → 30-day month (May 31 → Jun 30)', async () => {
+    const { computeNextPaymentDate } = await import('./MemberPaymentService');
+    const from = new Date(2026, 4, 31); // 31 May 2026
+    const next = computeNextPaymentDate(from, 'monthly');
+
+    expect(next.getFullYear()).toBe(2026);
+    expect(next.getMonth()).toBe(5); // June
+    expect(next.getDate()).toBe(30); // clamped to last day of June
   });
 });

--- a/src/services/MemberPaymentService.ts
+++ b/src/services/MemberPaymentService.ts
@@ -36,6 +36,7 @@ import {
 } from '@/libs/IQPro';
 import { logger } from '@/libs/Logger';
 import { auditEventSchema, couponSchema, couponUsageSchema, memberMembershipSchema, memberSchema, membershipPlanSchema, paymentMethodSchema, transactionSchema } from '@/models/Schema';
+import { computeNextPaymentDate, normalizeFrequency } from '@/utils/PaymentSchedule';
 
 import { sendPaymentReceiptEmail } from './EmailService';
 import { getOrganizationTaxRate } from './OrganizationService';
@@ -62,6 +63,15 @@ export type ProcessMemberPaymentParams = {
   paymentMethod: PaymentMethod;
   billingType: BillingType;
   amount: number;
+  /**
+   * One-time signup fee charged on the FIRST transaction only. When > 0,
+   * this is added to the immediate Sale alongside `amount`, but never enters
+   * the recurring subscription amount. Coupon discounts apply to `amount`
+   * only, never to the signup fee. Recorded as a separate `signup_fee`
+   * transaction row sharing the same `iqproTransactionId` as the membership
+   * row.
+   */
+  signupFee?: number;
   description: string;
 
   // Card fields
@@ -354,7 +364,11 @@ export async function processMemberPayment(
     }
 
     const couponDiscount = computeCouponDiscount(params.amount, params.appliedCoupon);
-    const baseAmount = Math.max(0, Math.round((params.amount - couponDiscount) * 100) / 100);
+    const signupFee = params.signupFee ?? 0;
+    // baseAmount is the customer-facing subtotal sent to IQPro's fee
+    // calculator: recurring (post-coupon) + one-time signup fee. The
+    // signup fee never gets a coupon discount.
+    const baseAmount = Math.max(0, Math.round(((params.amount - couponDiscount) + signupFee) * 100) / 100);
 
     const taxStatePct = isTaxable ? await getOrganizationTaxRate(params.organizationId) : 0;
 
@@ -384,12 +398,25 @@ export async function processMemberPayment(
       country: params.memberAddress?.country ?? 'US',
     };
 
-    const lineItem: TransactionLineItem = {
-      name: params.description,
-      description: params.description,
-      unitPrice: params.amount,
-      discount: couponDiscount,
-    };
+    // Itemize the membership and (optional) signup fee as separate IQPro
+    // line items. The signup-fee line has no coupon discount.
+    const lineItems: TransactionLineItem[] = [
+      {
+        name: params.description,
+        description: params.description,
+        unitPrice: params.amount,
+        discount: couponDiscount,
+      },
+    ];
+    if (signupFee > 0) {
+      const planLabel = params.description.replace(/^Membership:\s*/i, '').trim() || 'membership';
+      lineItems.push({
+        name: 'Sign-up fee',
+        description: `Sign-up fee — ${planLabel}`,
+        unitPrice: signupFee,
+        discount: 0,
+      });
+    }
 
     // ── Step 3: Route by billing type ───────────────────────────────
     // Recurring frequencies that map to an IQPro subscription. 'none' / null
@@ -410,7 +437,7 @@ export async function processMemberPayment(
         feeBreakdown,
         billingAddressId,
         billingAddress,
-        lineItem,
+        lineItems,
         achData,
         vaulted,
         isTaxable,
@@ -427,7 +454,7 @@ export async function processMemberPayment(
       feeBreakdown,
       billingAddressId,
       billingAddress,
-      lineItem,
+      lineItems,
       achData,
       vaulted,
       isTaxable,
@@ -522,37 +549,11 @@ export async function registerPaymentMethod(
 
 // ===== Internal helpers =====
 
-/**
- * Normalize a membership-plan frequency string (case-insensitive) to the
- * IQPro-subscription frequency enum. Null/undefined/empty/'None'/'one-time'
- * all collapse to `null`, meaning "no recurring subscription — use a one-time
- * charge."
- */
-export function normalizeFrequency(frequency: string | null | undefined): SubscriptionFrequency | null {
-  if (!frequency) {
-    return null;
-  }
-  const lower = frequency.toLowerCase();
-  switch (lower) {
-    case 'weekly':
-      return 'weekly';
-    case 'monthly':
-      return 'monthly';
-    case 'semi-annual':
-    case 'semi-annually':
-    case 'semiannual':
-      return 'semi-annual';
-    case 'annual':
-    case 'annually':
-    case 'yearly':
-      return 'annual';
-    case 'none':
-    case 'one-time':
-    case 'onetime':
-    default:
-      return null;
-  }
-}
+// Re-export the schedule helpers so callers (tests, lifecycle code) that
+// historically imported them from this module keep working. The actual
+// implementations live in `@/utils/PaymentSchedule` — a pure module the
+// seed script can import without pulling in DB/IQPro/Env.
+export { computeNextPaymentDate, normalizeFrequency };
 
 function computeCouponDiscount(amount: number, coupon?: AppliedCoupon | null): number {
   if (!coupon) {
@@ -594,7 +595,9 @@ function buildPaymentAdjustments(
 
 /**
  * Build the receipt-email line items from a member-payment context. For
- * memberships, this is a single line: plan name + frequency + price.
+ * memberships, this is a single line (plan name + frequency + price). When a
+ * signup fee is present, an additional one-time line is emitted with no
+ * discount (coupons never apply to signup fees).
  */
 function buildReceiptLineItems(params: ProcessMemberPaymentParams): Array<{
   name: string;
@@ -604,7 +607,8 @@ function buildReceiptLineItems(params: ProcessMemberPaymentParams): Array<{
   discount?: number;
 }> {
   const couponDiscount = computeCouponDiscount(params.amount, params.appliedCoupon);
-  return [
+  const signupFee = params.signupFee ?? 0;
+  const items = [
     {
       name: params.description,
       description: params.description,
@@ -613,6 +617,17 @@ function buildReceiptLineItems(params: ProcessMemberPaymentParams): Array<{
       discount: couponDiscount,
     },
   ];
+  if (signupFee > 0) {
+    const planLabel = params.description.replace(/^Membership:\s*/i, '').trim() || 'membership';
+    items.push({
+      name: 'Sign-up fee',
+      description: `Sign-up fee — ${planLabel}`,
+      quantity: 1,
+      unitPrice: signupFee,
+      discount: 0,
+    });
+  }
+  return items;
 }
 
 /**
@@ -659,7 +674,7 @@ type AutopayParams = {
   feeBreakdown: FeeBreakdown;
   billingAddressId?: string;
   billingAddress: TransactionBillingAddress;
-  lineItem: TransactionLineItem;
+  lineItems: TransactionLineItem[];
   achData?: { achToken: string; secCode: string; routingNumber: string; accountType: string };
   vaulted: boolean;
   isTaxable: boolean;
@@ -667,12 +682,19 @@ type AutopayParams = {
 };
 
 async function handleAutopay(args: AutopayParams): Promise<ProcessMemberPaymentResult> {
-  const { config, provider, params, customerId, paymentMethodId, frequency, feeBreakdown, billingAddressId, billingAddress, lineItem, achData, vaulted, isTaxable } = args;
+  const { config, provider, params, customerId, paymentMethodId, frequency, feeBreakdown, billingAddressId, billingAddress, lineItems, achData, vaulted, isTaxable } = args;
+
+  const signupFee = params.signupFee ?? 0;
+  const couponDiscount = computeCouponDiscount(params.amount, params.appliedCoupon);
+  // Recurring price — what IQPro will bill every cycle. Coupon discount
+  // applies to recurring only; signup fee is NEVER part of the recurring
+  // amount (it's a one-time charge on the initial Sale only).
+  const recurringAmount = Math.max(0, Math.round((params.amount - couponDiscount) * 100) / 100);
 
   const subResult = await provider.createSubscription(config, {
     customerId,
     paymentMethodId,
-    amount: params.amount,
+    amount: recurringAmount,
     frequency,
     startDate: new Date(),
     description: params.description,
@@ -696,8 +718,9 @@ async function handleAutopay(args: AutopayParams): Promise<ProcessMemberPaymentR
   }
 
   // IQPro subscriptions don't auto-charge on creation. Run an immediate Sale
-  // for the first period so the member is charged on signup day. The recurring
-  // schedule then takes over from the next billing date.
+  // for the first period so the member is charged on signup day. This Sale
+  // includes both the recurring portion AND the one-time signup fee; the
+  // recurring schedule then takes over with `recurringAmount` only.
   const initialCharge = await provider.processPayment(config, {
     customerId,
     paymentMethodId,
@@ -707,7 +730,7 @@ async function handleAutopay(args: AutopayParams): Promise<ProcessMemberPaymentR
     feeBreakdown,
     customerBillingAddressId: billingAddressId,
     billingAddress,
-    lineItem,
+    lineItems,
     ach: achData,
     vaulted,
     isTaxable,
@@ -720,27 +743,52 @@ async function handleAutopay(args: AutopayParams): Promise<ProcessMemberPaymentR
     },
   });
 
-  // Persist the initial transaction regardless of outcome so the failure is
-  // visible in the transactions table.
+  // Persist the initial transaction(s). When signup fee > 0, split into TWO
+  // rows sharing the same IQPro transaction id (one Sale, two local rows) —
+  // mirrors the cancellation_fee / hold_fee pattern and gives clean per-type
+  // revenue reporting. The membership row's amount is the post-coupon
+  // recurring portion; the signup-fee row is the full fee.
+  const txStatus = initialCharge.status === 'approved'
+    ? 'paid' as const
+    : initialCharge.status === 'declined'
+      ? 'declined' as const
+      : 'processing' as const;
+  const processedAt = initialCharge.success ? new Date() : null;
   const txId = randomUUID();
-  await db.insert(transactionSchema).values({
-    id: txId,
-    organizationId: params.organizationId,
-    memberId: params.memberId,
-    memberMembershipId: params.memberMembershipId ?? null,
-    iqproTransactionId: initialCharge.transactionId ?? null,
-    transactionType: 'membership_payment',
-    amount: feeBreakdown.amount,
-    currency: 'USD',
-    status: initialCharge.status === 'approved'
-      ? 'paid'
-      : initialCharge.status === 'declined'
-        ? 'declined'
-        : 'processing',
-    paymentMethod: params.paymentMethod,
-    description: params.description,
-    processedAt: initialCharge.success ? new Date() : null,
-  });
+  const txRows: Array<typeof transactionSchema.$inferInsert> = [
+    {
+      id: txId,
+      organizationId: params.organizationId,
+      memberId: params.memberId,
+      memberMembershipId: params.memberMembershipId ?? null,
+      iqproTransactionId: initialCharge.transactionId ?? null,
+      transactionType: 'membership_payment',
+      amount: recurringAmount,
+      currency: 'USD',
+      status: txStatus,
+      paymentMethod: params.paymentMethod,
+      description: params.description,
+      processedAt,
+    },
+  ];
+  if (signupFee > 0) {
+    const planLabel = params.description.replace(/^Membership:\s*/i, '').trim() || 'membership';
+    txRows.push({
+      id: randomUUID(),
+      organizationId: params.organizationId,
+      memberId: params.memberId,
+      memberMembershipId: params.memberMembershipId ?? null,
+      iqproTransactionId: initialCharge.transactionId ?? null,
+      transactionType: 'signup_fee',
+      amount: signupFee,
+      currency: 'USD',
+      status: txStatus,
+      paymentMethod: params.paymentMethod,
+      description: `Sign-up fee — ${planLabel}`,
+      processedAt,
+    });
+  }
+  await db.insert(transactionSchema).values(txRows);
 
   if (!initialCharge.success) {
     // Subscription was created in IQPro but the initial charge failed. Surface
@@ -764,16 +812,15 @@ async function handleAutopay(args: AutopayParams): Promise<ProcessMemberPaymentR
 
   // Persist subscription ID + dates on membership only after both succeed.
   if (params.memberMembershipId) {
-    const nextPayment = frequency === 'annual'
-      ? new Date(Date.now() + 365 * 24 * 60 * 60 * 1000)
-      : new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+    const firstPaymentDate = new Date();
+    const nextPayment = computeNextPaymentDate(firstPaymentDate, frequency);
 
     await db
       .update(memberMembershipSchema)
       .set({
         iqproSubscriptionId: subResult.subscriptionId,
         billingType: 'autopay',
-        firstPaymentDate: new Date(),
+        firstPaymentDate,
         nextPaymentDate: nextPayment,
       })
       .where(eq(memberMembershipSchema.id, params.memberMembershipId));
@@ -822,7 +869,7 @@ type OneTimeParams = {
   feeBreakdown: FeeBreakdown;
   billingAddressId?: string;
   billingAddress: TransactionBillingAddress;
-  lineItem: TransactionLineItem;
+  lineItems: TransactionLineItem[];
   achData?: { achToken: string; secCode: string; routingNumber: string; accountType: string };
   vaulted: boolean;
   isTaxable: boolean;
@@ -830,7 +877,11 @@ type OneTimeParams = {
 };
 
 async function handleOneTimePayment(args: OneTimeParams): Promise<ProcessMemberPaymentResult> {
-  const { config, provider, params, customerId, paymentMethodId, feeBreakdown, billingAddressId, billingAddress, lineItem, achData, vaulted, isTaxable } = args;
+  const { config, provider, params, customerId, paymentMethodId, feeBreakdown, billingAddressId, billingAddress, lineItems, achData, vaulted, isTaxable } = args;
+
+  const signupFee = params.signupFee ?? 0;
+  const couponDiscount = computeCouponDiscount(params.amount, params.appliedCoupon);
+  const membershipAmount = Math.max(0, Math.round((params.amount - couponDiscount) * 100) / 100);
 
   const payResult = await provider.processPayment(config, {
     customerId,
@@ -841,7 +892,7 @@ async function handleOneTimePayment(args: OneTimeParams): Promise<ProcessMemberP
     feeBreakdown,
     customerBillingAddressId: billingAddressId,
     billingAddress,
-    lineItem,
+    lineItems,
     ach: achData,
     vaulted,
     isTaxable,
@@ -853,22 +904,50 @@ async function handleOneTimePayment(args: OneTimeParams): Promise<ProcessMemberP
     },
   });
 
-  // Persist transaction record
+  // Persist transaction record(s). When signupFee > 0, split into TWO rows
+  // sharing the same IQPro transaction id — mirrors handleAutopay and the
+  // cancellation_fee / hold_fee pattern.
+  const txStatus = payResult.status === 'approved'
+    ? 'paid' as const
+    : payResult.status === 'declined'
+      ? 'declined' as const
+      : 'processing' as const;
+  const processedAt = payResult.success ? new Date() : null;
   const txId = randomUUID();
-  await db.insert(transactionSchema).values({
-    id: txId,
-    organizationId: params.organizationId,
-    memberId: params.memberId,
-    memberMembershipId: params.memberMembershipId ?? null,
-    iqproTransactionId: payResult.transactionId ?? null,
-    transactionType: 'membership_payment',
-    amount: feeBreakdown.amount,
-    currency: 'USD',
-    status: payResult.status === 'approved' ? 'paid' : payResult.status === 'declined' ? 'declined' : 'processing',
-    paymentMethod: params.paymentMethod,
-    description: params.description,
-    processedAt: payResult.success ? new Date() : null,
-  });
+  const txRows: Array<typeof transactionSchema.$inferInsert> = [
+    {
+      id: txId,
+      organizationId: params.organizationId,
+      memberId: params.memberId,
+      memberMembershipId: params.memberMembershipId ?? null,
+      iqproTransactionId: payResult.transactionId ?? null,
+      transactionType: 'membership_payment',
+      amount: membershipAmount,
+      currency: 'USD',
+      status: txStatus,
+      paymentMethod: params.paymentMethod,
+      description: params.description,
+      processedAt,
+    },
+  ];
+  if (signupFee > 0) {
+    const planLabel = params.description.replace(/^Membership:\s*/i, '').trim() || 'membership';
+    txRows.push({
+      id: randomUUID(),
+      organizationId: params.organizationId,
+      memberId: params.memberId,
+      memberMembershipId: params.memberMembershipId ?? null,
+      iqproTransactionId: payResult.transactionId ?? null,
+      transactionType: 'signup_fee',
+      amount: signupFee,
+      currency: 'USD',
+      status: txStatus,
+      paymentMethod: params.paymentMethod,
+      description: `Sign-up fee — ${planLabel}`,
+      processedAt,
+    });
+  }
+  await db.insert(transactionSchema).values(txRows);
 
   // Update membership billing info
   if (params.memberMembershipId && payResult.success) {

--- a/src/services/PaymentProviderService.ts
+++ b/src/services/PaymentProviderService.ts
@@ -125,8 +125,13 @@ export type ProcessPaymentParams = {
   feeBreakdown: FeeBreakdown;
   /** IQPro `customerAddressId` to attach to the transaction's customer ref. */
   customerBillingAddressId?: string;
-  /** Single line item describing what's being charged. */
-  lineItem?: TransactionLineItem;
+  /**
+   * Line items describing what's being charged. When more than one is
+   * provided (e.g. membership + signup fee), each becomes a row in the
+   * IQPro Sale's `lineItems[]` array. When omitted, the provider falls
+   * back to a single item built from `description` + `amount`.
+   */
+  lineItems?: TransactionLineItem[];
   /** Buyer billing address — used in the transaction's `address[]` block. */
   billingAddress?: TransactionBillingAddress;
   /**

--- a/src/utils/PaymentSchedule.ts
+++ b/src/utils/PaymentSchedule.ts
@@ -1,0 +1,84 @@
+/**
+ * Pure date/billing-cycle helpers used by the payment service AND the seed
+ * script. Kept in `utils/` (not `services/`) so it has no I/O or env-var
+ * dependencies — importing this module from the seed must not pull in Env,
+ * DB, IQPro, or any service-layer code.
+ */
+
+export type SubscriptionFrequency = 'weekly' | 'monthly' | 'semi-annual' | 'annual';
+
+/**
+ * Map a free-form plan frequency string to the canonical
+ * `SubscriptionFrequency` enum, or null for "no recurring cycle" (one-time,
+ * trial, punchcard). Accepts the common variants (Monthly / monthly,
+ * semi-annually / semi-annual, yearly / annual).
+ */
+export function normalizeFrequency(frequency: string | null | undefined): SubscriptionFrequency | null {
+  if (!frequency) {
+    return null;
+  }
+  const lower = frequency.toLowerCase();
+  switch (lower) {
+    case 'weekly':
+      return 'weekly';
+    case 'monthly':
+      return 'monthly';
+    case 'semi-annual':
+    case 'semi-annually':
+    case 'semiannual':
+      return 'semi-annual';
+    case 'annual':
+    case 'annually':
+    case 'yearly':
+      return 'annual';
+    case 'none':
+    case 'one-time':
+    case 'onetime':
+    default:
+      return null;
+  }
+}
+
+/**
+ * Add N months to a date, clamping the day-of-month to the last valid day
+ * of the target month. Without clamping, JS's `setMonth` overflows — e.g.
+ * Jan 31 + 1 month becomes Mar 3 (because Feb has 28 days). For a billing
+ * date, we want the last day of Feb instead. Mirrors IQPro's `daysOfMonth`
+ * behavior for end-of-month subscriptions.
+ */
+function addMonths(date: Date, months: number): Date {
+  const result = new Date(date);
+  const targetDay = result.getDate();
+  // Move to the 1st of the target month, then clamp to the last day if the
+  // original day-of-month doesn't exist there.
+  result.setDate(1);
+  result.setMonth(result.getMonth() + months);
+  const lastDayOfTargetMonth = new Date(result.getFullYear(), result.getMonth() + 1, 0).getDate();
+  result.setDate(Math.min(targetDay, lastDayOfTargetMonth));
+  return result;
+}
+
+/**
+ * Compute the next payment date from a start date and recurring frequency.
+ * Uses real calendar math (months & weeks), not 30-day approximations, so
+ * the date lands on the same day-of-month for monthly / semi-annual /
+ * annual, mirroring IQPro's `daysOfMonth` subscription schedule.
+ */
+export function computeNextPaymentDate(from: Date, frequency: SubscriptionFrequency | null): Date {
+  const next = new Date(from);
+  switch (frequency) {
+    case 'weekly':
+      next.setDate(next.getDate() + 7);
+      return next;
+    case 'monthly':
+      return addMonths(next, 1);
+    case 'semi-annual':
+      return addMonths(next, 6);
+    case 'annual':
+      return addMonths(next, 12);
+    default:
+      // null / one-time — no recurring cycle. Caller shouldn't ask, but
+      // returning `from` is the safe default (no shift).
+      return next;
+  }
+}

--- a/src/validations/PaymentValidation.test.ts
+++ b/src/validations/PaymentValidation.test.ts
@@ -97,6 +97,53 @@ describe('ProcessPaymentValidation', () => {
   });
 
   // ===========================================================================
+  // SIGNUP FEE
+  // ===========================================================================
+
+  describe('signupFee', () => {
+    it('should accept a positive signupFee', () => {
+      const result = ProcessPaymentValidation.safeParse({
+        ...validCardPayment,
+        signupFee: 99,
+      });
+
+      expect(result.success).toBe(true);
+
+      if (result.success) {
+        expect(result.data.signupFee).toBe(99);
+      }
+    });
+
+    it('should default signupFee to 0 when omitted', () => {
+      const result = ProcessPaymentValidation.safeParse(validCardPayment);
+
+      expect(result.success).toBe(true);
+
+      if (result.success) {
+        expect(result.data.signupFee).toBe(0);
+      }
+    });
+
+    it('should accept signupFee of zero', () => {
+      const result = ProcessPaymentValidation.safeParse({
+        ...validCardPayment,
+        signupFee: 0,
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject negative signupFee', () => {
+      const result = ProcessPaymentValidation.safeParse({
+        ...validCardPayment,
+        signupFee: -10,
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // ===========================================================================
   // MISSING REQUIRED FIELDS
   // ===========================================================================
 

--- a/src/validations/PaymentValidation.ts
+++ b/src/validations/PaymentValidation.ts
@@ -20,6 +20,11 @@ export const ProcessPaymentValidation = z.object({
   paymentMethod: z.enum(['card', 'ach']),
   billingType: z.enum(['autopay', 'one-time']),
   amount: z.number().min(0),
+  // One-time signup fee charged on the FIRST transaction only. Bundled into
+  // the initial Sale alongside `amount`, but never carried into the recurring
+  // subscription. Coupon discounts apply to `amount` (recurring) only, never
+  // to the signup fee.
+  signupFee: z.number().min(0).optional().default(0),
   description: z.string(),
 
   // Card fields


### PR DESCRIPTION
## Summary

Three related fixes to the member billing lifecycle, plus seed-data hygiene.

### 1. Signup fee no longer bundled into recurring subscription amount

Previously, the Add Member / Add Family Members / Convert Member wizards bundled the plan's signup fee into the `amount` field on `payment.process`. The payment service then passed that bundled amount as the recurring subscription amount to IQPro — so a $149/mo plan with a $99 signup fee was being configured to charge $248 **every** month, forever. The receipt also showed a single $248 line item instead of itemizing the membership and the fee.

- `ProcessPaymentValidation` now accepts a separate `signupFee` field
- `MemberPaymentService.handleAutopay` passes the post-coupon recurring price (without signup fee) to `createSubscription`, and the initial Sale carries both as separate line items
- Initial-charge transaction is split into two local `transaction` rows (`membership_payment` + `signup_fee`) sharing the same `iqproTransactionId`, mirroring the existing `cancellation_fee` / `hold_fee` pattern
- Receipt email itemizes membership and signup fee separately
- All three wizards (AddMember, AddFamilyMembers, ConvertMember) send `amount` and `signupFee` separately
- `PaymentStep` / `FamilyPaymentStep` now show a three-row breakdown (Membership / Sign-up fee / Total due today) when a signup fee is present

### 2. Next payment date written for wizard-created members

The Add Member wizard created the `member_membership` row via `client.member.create`, but the router returned only the member id — not the new membership row id. So when `payment.process` ran, it had no `memberMembershipId` to update, and the autopay branch's `firstPaymentDate` / `nextPaymentDate` / `iqproSubscriptionId` writes were silently skipped. Result: every wizard-created member had `nextPaymentDate=null` and no IQPro subscription id on file, breaking the cancel / hold / reactivate lifecycle flows for them.

- `member.create` now returns `{ id, memberMembershipId }`; `addMembership` / `changeMembership` already did
- All three wizards plumb `memberMembershipId` through to `payment.process`
- New `computeNextPaymentDate(from, frequency)` helper in `src/utils/PaymentSchedule.ts` — real calendar math handling weekly / monthly / semi-annual / annual, with end-of-month clamping (Jan 31 → Feb 28, May 31 → Nov 30 for semi-annual). Replaces inline 30d/365d approximation that ignored weekly and semi-annual entirely

### 3. "Amount due" no longer shown for paid, current members

`useMembersCache` was deriving `amountDue` as the plan's recurring price unconditionally, so freshly-paid members showed the next-cycle amount as if it were owed today. It now hides `amountDue` when `nextPaymentDate` is in the future. When shown, the value is still the plan's recurring price for one cycle (matches what's actually due for a missed cycle).

Extracted the row-mapper into an exported pure `deriveMemberDisplayFields` function for testability.

### 4. Seed data brought into line

- Each active autopay member's `member_membership` row gets a synthetic `iqproSubscriptionId` (`seed_sub_<uuid>`), so lifecycle flows can be exercised against seeded members in local dev
- `nextPaymentDate` is now computed by iterating `computeNextPaymentDate` from the actual join date, honoring the plan's real frequency — not a hardcoded "next 15th"
- First-charge transaction pair (signup_fee + first month's membership_payment) shares one synthetic `iqproTransactionId`; subsequent recurring cycles each get their own. Matches the wizard's behavior.

## Architectural change

`computeNextPaymentDate` and `normalizeFrequency` were originally inside `MemberPaymentService.ts`, which transitively imports DB / IQPro / Env. Extracted both to a new pure module `src/utils/PaymentSchedule.ts` so the seed script (and any other tooling) can use them without pulling in service-layer dependencies. `MemberPaymentService.ts` re-exports both for backwards compatibility.

