### PR TITLE
fix(catalog): restore blank catalog images with CSP

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,16 +11,16 @@ const isDev = process.env.NODE_ENV === 'development';
 
 const contentSecurityPolicy = [
   'default-src \'self\'',
-  // Scripts: self + Clerk + Sentry + TokenEx/BasysPro (payment iframe) + unsafe-inline (required for Next.js theme/RSC scripts)
-  'script-src \'self\' \'unsafe-inline\' https://cdn.clerk.com https://*.clerk.accounts.dev https://www.sentry-cdn.com https://sandbox.api.basyspro.com https://api.basyspro.com',
+  // Scripts: self + Clerk + Sentry + TokenEx/BasysPro (payment iframe) + unsafe-inline (required for Next.js theme/RSC scripts).
+  // `unsafe-eval` is added in dev only — React/Turbopack use eval() for debugging features (callstack reconstruction); React never uses eval() in production.
+  `script-src 'self' 'unsafe-inline'${isDev ? ' \'unsafe-eval\'' : ''} https://cdn.clerk.com https://*.clerk.accounts.dev https://www.sentry-cdn.com https://sandbox.api.basyspro.com https://api.basyspro.com`,
   // Styles: self + unsafe-inline (required by Clerk inline styles - cannot be avoided) + Clerk domains
   'style-src \'self\' \'unsafe-inline\' https://cdn.clerk.com https://*.clerk.accounts.dev',
   // Fonts: self only (Inter is self-hosted via next/font)
   'font-src \'self\'',
-  // Images: self + Clerk image CDN (avatars + org images) + data URIs (catalog/member
-  // photos are stored inline as base64 data URLs) + blob (Clerk avatar processing).
-  // No blanket `https:` — catalog images never come from an external HTTPS host.
-  'img-src \'self\' https://img.clerk.com data: blob:',
+  // Images: self + any HTTPS host (catalog/event images are external URLs, e.g.
+  // placehold.co and user-supplied hosts) + data URIs + blob (Clerk avatar processing).
+  'img-src \'self\' https: data: blob:',
   // Frames: self + Clerk for OAuth flows + TokenEx/BasysPro for payment iframe
   'frame-src \'self\' https://*.clerk.com https://*.clerk.accounts.dev https://sandbox.api.basyspro.com https://api.basyspro.com https://*.tokenex.com',
   // Workers: self + blob (for Clerk)

--- a/src/app/[locale]/(auth)/layout.tsx
+++ b/src/app/[locale]/(auth)/layout.tsx
@@ -61,8 +61,6 @@ export default function AuthLayout(props: {
       signInFallbackRedirectUrl={dashboardUrl}
       signUpFallbackRedirectUrl={dashboardUrl}
       afterSignOutUrl={afterSignOutUrl}
-      afterSignInUrl={dashboardUrl}
-      afterSignUpUrl={dashboardUrl}
       dynamic
     >
       {props.children}

--- a/src/templates/Logo.tsx
+++ b/src/templates/Logo.tsx
@@ -19,6 +19,14 @@ export const Logo = (props: {
       <path d="M15.7226 3.46902C15.7226 4.10775 15.1919 4.62554 14.5372 4.62554C13.8825 4.62554 13.3517 4.10775 13.3517 3.46902C13.3517 2.83029 13.8825 2.3125 14.5372 2.3125C15.1919 2.3125 15.7226 2.83029 15.7226 3.46902Z" stroke="none" strokeWidth="0" />
       <path d="M10.8563 1.15652C10.8563 1.79525 10.3256 2.31304 9.67091 2.31304C9.01621 2.31304 8.48547 1.79525 8.48547 1.15652C8.48547 0.517792 9.01621 0 9.67091 0C10.3256 0 10.8563 0.517792 10.8563 1.15652Z" stroke="none" strokeWidth="0" />
     </svg>
-    {!props.isTextHidden && AppConfig.name}
+    {!props.isTextHidden && (
+      <div className="mt-1.5 flex flex-col leading-none">
+        <span>{AppConfig.name}</span>
+        <span className="text-right text-[0.625rem] font-normal">
+          v
+          {AppConfig.version}
+        </span>
+      </div>
+    )}
   </div>
 );

--- a/src/utils/AppConfig.ts
+++ b/src/utils/AppConfig.ts
@@ -4,6 +4,7 @@ import type { AppLocale } from '@/types/AppConfig';
 import type { PricingPlan } from '@/types/Subscription';
 import { enUS, frFR } from '@clerk/localizations';
 import { BILLING_INTERVAL } from '@/types/Subscription';
+import { version as appVersion } from '../../package.json';
 
 const localePrefix: LocalePrefixMode = 'as-needed';
 const locales = [
@@ -22,6 +23,7 @@ const locales = [
 // FIXME: Update this configuration file based on your project information
 export const AppConfig = {
   name: 'Dojo Planner',
+  version: appVersion,
   sidebarCookieName: 'sidebar:state',
   locales,
   defaultLocale: 'en',


### PR DESCRIPTION
### Summary

Fixes blank product catalog images in production (a CSP regression) and bundles several small dev-experience and UI improvements.

### Changes

**Blank catalog images in production (`next.config.ts`)**
Commit #203 tightened the CSP `img-src` from `https:` down to `https://img.clerk.com`, on the assumption that catalog images are stored as base64 data URLs. They're actually stored as external HTTPS URLs (e.g. `placehold.co` and user-supplied hosts) in `catalog_item_image.url`, so the browser blocked every catalog image → blank `<Package>` placeholders. Reverted `img-src` to `'self' https: data: blob:`.

**Dev console: `eval()` CSP error (`next.config.ts`)**
React/Turbopack use `eval()` in development for debugging (callstack reconstruction). Added `'unsafe-eval'` to `script-src` **in dev only** (gated behind the existing `isDev` flag) — production CSP is unchanged and stays strict.

**Dev console: deprecated Clerk prop (`layout.tsx`)**
Removed the deprecated `afterSignInUrl` / `afterSignUpUrl` props from `ClerkProvider`. They were redundant — `signInFallbackRedirectUrl` / `signUpFallbackRedirectUrl` were already set to the same destination. Clears the deprecation warning with no behavior change.

**App version under sidebar logo (`Logo.tsx`, `AppConfig.ts`)**
Added a very small, right-aligned version label beneath the "Dojo Planner" logo text in the sidebar. Sourced from `package.json` via `AppConfig.version`, so it stays in sync with semantic-release bumps.

### Files
- `next.config.ts` — CSP `img-src` (prod fix) + dev-only `unsafe-eval` on `script-src`
- `src/app/[locale]/(auth)/layout.tsx` — drop deprecated Clerk redirect props
- `src/templates/Logo.tsx` — render version under logo text
- `src/utils/AppConfig.ts` — expose `version` from `package.json`