### PR TITLE
fix(delete): delete classes, events, waivers cleanly

### DIFF
--- a/src/services/ClassesService.ts
+++ b/src/services/ClassesService.ts
@@ -72,11 +72,11 @@ export type ClassData = {
  * Get all classes for an organization with their schedules, tags, and exceptions
  */
 export async function getOrganizationClasses(organizationId: string): Promise<ClassData[]> {
-  // Fetch all classes for the organization
+  // Fetch all active classes for the organization (exclude soft-deleted)
   const classes = await db
     .select()
     .from(classSchema)
-    .where(eq(classSchema.organizationId, organizationId));
+    .where(and(eq(classSchema.organizationId, organizationId), eq(classSchema.isActive, true)));
 
   if (classes.length === 0) {
     return [];

--- a/src/services/EventsService.test.ts
+++ b/src/services/EventsService.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Capturing mocks for the drizzle predicate builders so we can assert that the
+// list query filters out soft-deleted (isActive = false) events.
+const eqMock = vi.fn((col: unknown, value: unknown) => ({ __op: 'eq', col, value }));
+const andMock = vi.fn((...conds: unknown[]) => ({ __op: 'and', conds }));
+const inArrayMock = vi.fn((col: unknown, values: unknown) => ({ __op: 'inArray', col, values }));
+
+vi.mock('drizzle-orm', () => ({
+  and: (...args: unknown[]) => andMock(...args),
+  eq: (col: unknown, value: unknown) => eqMock(col, value),
+  inArray: (col: unknown, values: unknown) => inArrayMock(col, values),
+}));
+
+const dbMock = {
+  select: vi.fn(),
+  insert: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+};
+
+vi.mock('@/libs/DB', () => ({ db: dbMock }));
+
+vi.mock('@/models/Schema', () => ({
+  attendanceSchema: {},
+  eventBillingSchema: { eventId: 'eb_event_id' },
+  eventSchema: { id: 'event_id', organizationId: 'event_org_id', isActive: 'event_is_active' },
+  eventSessionSchema: { eventId: 'es_event_id' },
+  eventTagSchema: { eventId: 'et_event_id', tagId: 'et_tag_id' },
+  tagSchema: { id: 'tag_id', organizationId: 'tag_org_id' },
+}));
+
+describe('EventsService.getOrganizationEvents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('filters the list query to active events (excludes soft-deleted)', async () => {
+    // First select() resolves the events for the org; capture its where predicate.
+    let capturedWhere: any;
+    dbMock.select.mockReturnValueOnce({
+      from: () => ({
+        where: (predicate: unknown) => {
+          capturedWhere = predicate;
+          return Promise.resolve([]); // no events → short-circuits related fetches
+        },
+      }),
+    });
+
+    const { getOrganizationEvents } = await import('./EventsService');
+    const result = await getOrganizationEvents('org-123');
+
+    expect(result).toEqual([]);
+    // The where clause must AND together the org filter and an isActive = true filter.
+    expect(andMock).toHaveBeenCalled();
+    expect(eqMock).toHaveBeenCalledWith('event_org_id', 'org-123');
+    expect(eqMock).toHaveBeenCalledWith('event_is_active', true);
+    expect(capturedWhere).toEqual({
+      __op: 'and',
+      conds: [
+        { __op: 'eq', col: 'event_org_id', value: 'org-123' },
+        { __op: 'eq', col: 'event_is_active', value: true },
+      ],
+    });
+  });
+});

--- a/src/services/EventsService.ts
+++ b/src/services/EventsService.ts
@@ -58,11 +58,11 @@ export type EventData = {
  * Get all events for an organization with their sessions, billing, and tags
  */
 export async function getOrganizationEvents(organizationId: string): Promise<EventData[]> {
-  // Fetch all events for the organization
+  // Fetch all active events for the organization (exclude soft-deleted)
   const events = await db
     .select()
     .from(eventSchema)
-    .where(eq(eventSchema.organizationId, organizationId));
+    .where(and(eq(eventSchema.organizationId, organizationId), eq(eventSchema.isActive, true)));
 
   if (events.length === 0) {
     return [];

--- a/src/services/WaiversService.test.ts
+++ b/src/services/WaiversService.test.ts
@@ -591,20 +591,32 @@ describe('WaiversService', () => {
   // ===========================================================================
 
   describe('deleteWaiverTemplate', () => {
-    it('should throw when template has signed waivers', async () => {
+    it('should soft-delete (deactivate) when template has signed waivers', async () => {
       const { db } = await import('@/libs/DB');
 
+      // Signed waivers exist for this template.
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockResolvedValue([{ waiverTemplateId: 'template-1', memberId: 'member-1' }]),
         }),
       } as any);
 
+      const deleteWhere = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(db.delete).mockReturnValue({ where: deleteWhere } as any);
+
+      const updateSet = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+      vi.mocked(db.update).mockReturnValue({ set: updateSet } as any);
+
       const { deleteWaiverTemplate } = await import('./WaiversService');
 
-      await expect(
-        deleteWaiverTemplate('template-1', 'test-org-123'),
-      ).rejects.toThrow('Cannot delete waiver template that has signed waivers. Deactivate it instead.');
+      // Does not throw — the template is deactivated instead of hard-deleted.
+      await expect(deleteWaiverTemplate('template-1', 'test-org-123')).resolves.toBeUndefined();
+
+      // Membership associations are removed (one delete), and the template rows
+      // are soft-deleted via update({ isActive: false }) rather than hard-deleted.
+      expect(db.delete).toHaveBeenCalledTimes(1);
+      expect(db.update).toHaveBeenCalledTimes(1);
+      expect(updateSet).toHaveBeenCalledWith({ isActive: false });
     });
 
     it('should delete membership associations, archive versions, and root template', async () => {

--- a/src/services/WaiversService.ts
+++ b/src/services/WaiversService.ts
@@ -185,6 +185,7 @@ export async function getOrganizationWaiverTemplates(organizationId: string): Pr
     .where(and(
       eq(waiverTemplateSchema.organizationId, organizationId),
       isNull(waiverTemplateSchema.parentId),
+      eq(waiverTemplateSchema.isActive, true),
     ));
 
   if (templates.length === 0) {
@@ -435,14 +436,26 @@ export async function deleteWaiverTemplate(templateId: string, organizationId: s
     .from(signedWaiverSchema)
     .where(eq(signedWaiverSchema.waiverTemplateId, templateId));
 
-  if (signedWaivers.length > 0) {
-    throw new Error('Cannot delete waiver template that has signed waivers. Deactivate it instead.');
-  }
-
-  // Remove membership associations first
+  // Remove membership associations first — the template should no longer be
+  // offered for new memberships regardless of which delete path we take.
   await db.delete(membershipWaiverSchema).where(eq(membershipWaiverSchema.waiverTemplateId, templateId));
 
-  // Delete archive versions and the root template
+  if (signedWaivers.length > 0) {
+    // Signed waivers are legally immutable and reference this template, so we
+    // cannot hard-delete it. Soft-delete instead: mark the root (and its
+    // archive versions) inactive so it disappears from the templates list
+    // while preserving the records the signed waivers point at.
+    await db
+      .update(waiverTemplateSchema)
+      .set({ isActive: false })
+      .where(and(
+        eq(waiverTemplateSchema.organizationId, organizationId),
+        or(eq(waiverTemplateSchema.id, templateId), eq(waiverTemplateSchema.parentId, templateId)),
+      ));
+    return;
+  }
+
+  // No signed waivers — safe to hard-delete archive versions and the root template.
   await db
     .delete(waiverTemplateSchema)
     .where(and(


### PR DESCRIPTION
## Summary

Deleting a class, event, or waiver template appeared to do nothing — the item
stayed in the list and its detail page kept working after a refresh. The delete
endpoints were already soft-deleting correctly; the bug was that the **read
paths never filtered out soft-deleted rows**. This closes the Tier 1 "deleted
item still appears" cluster from the QA acceptance pass.

Fixes:

- Fixes #246
- Fixes #256
- Fixes #269

## Root cause

- `getOrganizationClasses` / `getOrganizationEvents` selected every row for the
  org with no `isActive` filter, so soft-deleted rows kept appearing. Because
  `getClassById` / `getEventById` delegate to these list functions, the detail
  pages also continued to load deleted items (the "still working" part of #256).
- `deleteWaiverTemplate` hard-deleted the template and **threw** when signed
  waivers existed ("Failed to delete waiver..."), so any in-use template was
  impossible to remove.

## Changes

- **Classes** (`ClassesService.ts`): list query now filters `isActive = true`,
  so soft-deleted classes drop off the grid and their detail pages 404.
- **Events** (`EventsService.ts`): same `isActive = true` filter on the list
  query (also fixes the deleted-event detail page).
- **Waivers** (`WaiversService.ts`):
  - When a template has signed waivers, **soft-delete** it (set
    `isActive = false`) instead of throwing. Signed waivers are legally
    immutable and reference the template, so the template row is preserved and
    the association stays valid; it just disappears from the list.
  - Templates with no signed waivers still hard-delete as before.
  - `getOrganizationWaiverTemplates` now filters `isActive = true` so
    deactivated templates no longer appear.
  - `membership_waiver` associations are removed on both delete paths so the
    template is no longer offered to new signups.

## Notes

- No schema change — this is read-path logic only, so existing local/preview
  data does not need re-seeding (just restart `npm run dev`).
- `signed_waiver.waiverTemplateId` has no DB-level FK/cascade; the guard against
  orphaning signed waivers is application-level in `deleteWaiverTemplate` (the
  only delete path). Each `signed_waiver` also stores a self-contained content +
  plan snapshot, so historical records remain intact regardless.

## Tests

- Added `EventsService.test.ts` asserting the list query filters on
  `isActive = true`.
- Updated the `deleteWaiverTemplate` test: signed waivers present now
  soft-deletes (no throw) — verifies one `delete` (associations) + one
  `update({ isActive: false })`.
- `npm run lint`, `npm run check:types`, and the affected service suites
  (ClassesService, EventsService, WaiversService — 96 tests) all pass.