### PR TITLE
fix(members/catalog/reports/auth): polish + payment-method detail, admin dashboard access

### DIFF
--- a/migrations/0000_baseline.sql
+++ b/migrations/0000_baseline.sql
@@ -431,7 +431,9 @@ CREATE TABLE "payment_method" (
 	"stripe_payment_method_id" text,
 	"iqpro_payment_method_id" text,
 	"type" text NOT NULL,
+	"first_six" text,
 	"last4" text,
+	"account_type" text,
 	"is_default" boolean DEFAULT false
 );
 --> statement-breakpoint

--- a/migrations/meta/0000_snapshot.json
+++ b/migrations/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "dfac82cb-5e86-4b86-a553-51bc36d67e73",
+  "id": "0f7ccf58-ad42-43c0-9947-fc375575b1d3",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -3941,8 +3941,20 @@
           "primaryKey": false,
           "notNull": true
         },
+        "first_six": {
+          "name": "first_six",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "last4": {
           "name": "last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
           "type": "text",
           "primaryKey": false,
           "notNull": false

--- a/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx
+++ b/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx
@@ -7,7 +7,7 @@ import type { Member } from '@/hooks/useMembersCache';
 import type { MemberPaymentMethodData } from '@/services/MembersService';
 import type { SignedWaiverWithTemplateName } from '@/services/WaiversService';
 import { useOrganization } from '@clerk/nextjs';
-import { ArrowRightLeft, Download, MoreVertical, Pencil, Plus, Trash2 } from 'lucide-react';
+import { ArrowRightLeft, Download, MoreVertical, Pencil, Plus, Unlink } from 'lucide-react';
 import Link from 'next/link';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
@@ -36,6 +36,7 @@ import { client } from '@/libs/Orpc';
 // download handler so it is excluded from this page's initial bundle.
 import {
   formatCurrency,
+  formatPaymentMethodDetail,
   formatTransactionType,
   getInitials,
   getPaymentTypeIcon,
@@ -1381,12 +1382,10 @@ export default function EditMemberPage() {
                                 <div className="min-w-0 flex-1">
                                   <p className="font-medium text-foreground">
                                     {getPaymentTypeLabel(pm.type).toUpperCase()}
-                                    {pm.last4 && (
+                                    {formatPaymentMethodDetail(pm) && (
                                       <>
                                         {' '}
-                                        ••••
-                                        {' '}
-                                        {pm.last4}
+                                        {formatPaymentMethodDetail(pm)}
                                       </>
                                     )}
                                   </p>
@@ -1542,14 +1541,15 @@ export default function EditMemberPage() {
                   {familyMembersData.map((member: FamilyMember) => (
                     <Card key={member.id} className="relative p-6">
                       <Button
-                        variant="destructive"
+                        variant="outline"
                         size="sm"
                         className="absolute top-4 right-4"
                         onClick={() => handleRemoveFamilyMember(member.id)}
-                        aria-label={`Remove ${member.name}`}
-                        title={`Remove ${member.name}`}
+                        aria-label={`Unlink ${member.name}`}
+                        title={`Unlink ${member.name} from this household`}
                       >
-                        <Trash2 className="h-4 w-4" />
+                        <Unlink className="mr-1 h-4 w-4" />
+                        Unlink
                       </Button>
 
                       <div className="mb-4 flex flex-col gap-3 pr-10">

--- a/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/utils.test.ts
+++ b/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   formatCurrency,
+  formatPaymentMethodDetail,
   formatTransactionType,
   getInitials,
   getPaymentTypeIcon,
@@ -100,6 +101,41 @@ describe('Member Detail Page Utilities', () => {
 
     it('returns raw type for unknown type', () => {
       expect(getPaymentTypeLabel('crypto')).toBe('crypto');
+    });
+
+    it('returns "Bank Transfer" for ach', () => {
+      expect(getPaymentTypeLabel('ach')).toBe('Bank Transfer');
+    });
+  });
+
+  describe('formatPaymentMethodDetail', () => {
+    it('shows BIN(6) + last4 for a card when the BIN is known', () => {
+      expect(formatPaymentMethodDetail({ type: 'card', firstSix: '424242', last4: '4242' }))
+        .toBe('424242 •••••• 4242');
+    });
+
+    it('falls back to •••• last4 for a card with no BIN', () => {
+      expect(formatPaymentMethodDetail({ type: 'card', firstSix: null, last4: '4242' }))
+        .toBe('•••• 4242');
+    });
+
+    it('returns empty string for a card with no last4', () => {
+      expect(formatPaymentMethodDetail({ type: 'card', firstSix: null, last4: null })).toBe('');
+    });
+
+    it('shows the account type + last4 for an ACH method', () => {
+      expect(formatPaymentMethodDetail({ type: 'ach', accountType: 'Checking', last4: '4111' }))
+        .toBe('Checking •••• 4111');
+    });
+
+    it('handles the legacy bank_transfer type the same as ach', () => {
+      expect(formatPaymentMethodDetail({ type: 'bank_transfer', accountType: 'Savings', last4: '9999' }))
+        .toBe('Savings •••• 9999');
+    });
+
+    it('omits the account type for ACH when it is unknown', () => {
+      expect(formatPaymentMethodDetail({ type: 'ach', accountType: null, last4: '4111' }))
+        .toBe('•••• 4111');
     });
   });
 

--- a/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/utils.ts
+++ b/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/utils.ts
@@ -26,6 +26,7 @@ export const formatCurrency = (amount: number): string => {
 export const getPaymentTypeIcon = (type: string): string => {
   const iconMap: Record<string, string> = {
     card: '💳',
+    ach: '🏦',
     bank_transfer: '🏦',
     cash: '💵',
     check: '📝',
@@ -39,11 +40,52 @@ export const getPaymentTypeIcon = (type: string): string => {
 export const getPaymentTypeLabel = (type: string): string => {
   const labelMap: Record<string, string> = {
     card: 'Card',
+    ach: 'Bank Transfer',
     bank_transfer: 'Bank Transfer',
     cash: 'Cash',
     check: 'Check',
   };
   return labelMap[type.toLowerCase()] || type;
+};
+
+/**
+ * True when a payment method type is a bank account (ACH), for which we show
+ * the Checking/Savings account type.
+ */
+const isBankTransfer = (type: string): boolean => {
+  const t = type.toLowerCase();
+  return t === 'ach' || t === 'bank_transfer';
+};
+
+/**
+ * Build the masked payment-method detail line for the member detail page.
+ *
+ * - Card: BIN(6) + last4 when the BIN is known (e.g. `424242 •••••• 4242`),
+ *   otherwise just `•••• 4242`.
+ * - ACH: the account's Checking/Savings type plus the last 4 (e.g.
+ *   `Checking •••• 4242`), so the card no longer shows a bare "ACH".
+ */
+export const formatPaymentMethodDetail = (pm: {
+  type: string;
+  firstSix?: string | null;
+  last4?: string | null;
+  accountType?: string | null;
+}): string => {
+  if (isBankTransfer(pm.type)) {
+    const parts = [pm.accountType?.trim()].filter(Boolean) as string[];
+    if (pm.last4) {
+      parts.push(`•••• ${pm.last4}`);
+    }
+    return parts.join(' ');
+  }
+
+  if (!pm.last4) {
+    return '';
+  }
+  if (pm.firstSix) {
+    return `${pm.firstSix} •••••• ${pm.last4}`;
+  }
+  return `•••• ${pm.last4}`;
 };
 
 /**

--- a/src/features/catalog/AddEditCatalogItemModal.test.tsx
+++ b/src/features/catalog/AddEditCatalogItemModal.test.tsx
@@ -549,6 +549,36 @@ describe('AddEditCatalogItemModal', () => {
       await expect.element(page.getByTestId('variant-row-0')).toBeVisible();
       await expect.element(page.getByTestId('variant-row-1')).not.toBeInTheDocument();
     });
+
+    it('hides the add form and shows a notice at the max variant limit (#272)', async () => {
+      // Build an item already at the 8-variant maximum.
+      const maxedItem = {
+        ...mockItem,
+        variants: Array.from({ length: 8 }, (_, i) => ({
+          id: `v${i}`,
+          catalogItemId: 'item-1',
+          name: `V${i}`,
+          price: 10,
+          stockQuantity: 1,
+          sortOrder: i,
+        })),
+      };
+
+      render(
+        <AddEditCatalogItemModal
+          isOpen={true}
+          onCloseAction={mockHandlers.onCloseAction}
+          onSaveAction={mockHandlers.onSaveAction}
+          item={maxedItem}
+          categories={mockCategories}
+          events={mockEvents}
+        />,
+      );
+
+      // Add form is gone, and a notice explains why (rather than nothing).
+      await expect.element(page.getByText('max_variants_notice')).toBeVisible();
+      expect(page.getByTestId('add-variant-button').elements()).toHaveLength(0);
+    });
   });
 
   describe('Categories', () => {

--- a/src/features/catalog/AddEditCatalogItemModal.tsx
+++ b/src/features/catalog/AddEditCatalogItemModal.tsx
@@ -532,6 +532,14 @@ function CatalogItemFormContent({
                     </div>
                   )}
 
+                  {/* At the limit, explain why the add form is gone instead of
+                      silently hiding it (#272). */}
+                  {formData.variants.length >= MAX_VARIANTS_PER_ITEM && (
+                    <p className="border-t pt-3 text-sm text-muted-foreground">
+                      {t('max_variants_notice', { max: MAX_VARIANTS_PER_ITEM })}
+                    </p>
+                  )}
+
                   <p className="text-xs text-muted-foreground">{t('variants_help')}</p>
                 </div>
 

--- a/src/features/dashboard/DashboardCharts.tsx
+++ b/src/features/dashboard/DashboardCharts.tsx
@@ -107,6 +107,7 @@ export default function DashboardCharts({ memberAverageData, earningsData }: Das
             <XAxis dataKey={memberAverageXKey} axisLine={false} tickLine={false} />
             <YAxis axisLine={false} tickLine={false} width={60} />
             <Tooltip
+              cursor={{ className: 'fill-[#cccccc] dark:fill-[#666666]' }}
               contentStyle={{
                 backgroundColor: 'hsl(222.2 84% 4.9%)',
                 border: '1px solid hsl(217.2 32.6% 17.5%)',
@@ -184,6 +185,7 @@ export default function DashboardCharts({ memberAverageData, earningsData }: Das
             <XAxis dataKey={earningsXKey} axisLine={false} tickLine={false} />
             <YAxis axisLine={false} tickLine={false} width={60} tickFormatter={value => value >= 1000 ? `${(value / 1000).toFixed(0)}k` : value} />
             <Tooltip
+              cursor={{ className: 'fill-[#cccccc] dark:fill-[#666666]' }}
               contentStyle={{
                 backgroundColor: 'hsl(222.2 84% 4.9%)',
                 border: '1px solid hsl(217.2 32.6% 17.5%)',

--- a/src/features/members/lifecycle/CancelMembershipModal.test.tsx
+++ b/src/features/members/lifecycle/CancelMembershipModal.test.tsx
@@ -90,4 +90,27 @@ describe('CancelMembershipModal', () => {
 
     await expect.element(page.getByText('boom')).toBeInTheDocument();
   });
+
+  it('keeps the modal open with a warning when the fee charge fails (#240)', async () => {
+    cancelMembership.mockResolvedValue({ feeChargeError: 'card declined' });
+    const onSuccess = vi.fn();
+    const onClose = vi.fn();
+    render(<CancelMembershipModal {...baseProps} onSuccess={onSuccess} onClose={onClose} />);
+
+    await userEvent.click(page.getByText('confirm_button'));
+
+    // The cancellation still succeeded, so the parent is refreshed...
+    await vi.waitFor(() => expect(onSuccess).toHaveBeenCalled());
+
+    // ...but the modal stays open showing the partial-success warning (it used
+    // to close instantly, so the warning was never seen), with a Done button.
+    await expect.element(page.getByText(/partial_success/)).toBeInTheDocument();
+    await expect.element(page.getByText('done_button')).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+
+    // Acknowledging via Done closes the modal.
+    await userEvent.click(page.getByText('done_button'));
+
+    expect(onClose).toHaveBeenCalled();
+  });
 });

--- a/src/features/members/lifecycle/CancelMembershipModal.tsx
+++ b/src/features/members/lifecycle/CancelMembershipModal.tsx
@@ -55,13 +55,18 @@ export function CancelMembershipModal({
         waiveFee,
       });
 
-      if (result.feeChargeError) {
-        // Cancellation succeeded but the fee charge failed — surface as a
-        // warning rather than rolling back, since the kiosk behaves the same.
-        setResultMessage(t('partial_success', { error: result.feeChargeError }));
-      }
+      // The cancellation itself has succeeded at this point; refresh the parent.
       onSuccess?.();
-      onClose();
+
+      if (result.feeChargeError) {
+        // Cancellation succeeded but the fee charge failed. Keep the modal open
+        // showing the warning so it's actually seen — previously we set the
+        // message and immediately closed, so the user never saw it. The user
+        // acknowledges it via the "Done" button (see resultMessage branch below).
+        setResultMessage(t('partial_success', { error: result.feeChargeError }));
+      } else {
+        onClose();
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : t('error_generic'));
     } finally {
@@ -69,12 +74,16 @@ export function CancelMembershipModal({
     }
   };
 
+  const handleClose = () => {
+    setWaiveFee(false);
+    setError(null);
+    setResultMessage(null);
+    onClose();
+  };
+
   const handleOpenChange = (open: boolean) => {
     if (!open && !isLoading) {
-      setWaiveFee(false);
-      setError(null);
-      setResultMessage(null);
-      onClose();
+      handleClose();
     }
   };
 
@@ -137,12 +146,22 @@ export function CancelMembershipModal({
         </div>
 
         <div className="flex justify-end gap-3">
-          <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={isLoading}>
-            {t('back_button')}
-          </Button>
-          <Button variant="destructive" onClick={handleConfirm} disabled={isLoading}>
-            {isLoading ? t('confirming_button') : t('confirm_button')}
-          </Button>
+          {resultMessage
+            ? (
+                <Button variant="outline" onClick={handleClose}>
+                  {t('done_button')}
+                </Button>
+              )
+            : (
+                <>
+                  <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={isLoading}>
+                    {t('back_button')}
+                  </Button>
+                  <Button variant="destructive" onClick={handleConfirm} disabled={isLoading}>
+                    {isLoading ? t('confirming_button') : t('confirm_button')}
+                  </Button>
+                </>
+              )}
         </div>
       </DialogContent>
     </Dialog>

--- a/src/features/reports/ReportsPage.tsx
+++ b/src/features/reports/ReportsPage.tsx
@@ -276,7 +276,10 @@ function renderChart(
         <BarChart {...commonProps}>
           <XAxis {...xAxisProps} />
           <YAxis {...yAxisProps} />
-          <Tooltip contentStyle={tooltipStyle} labelStyle={tooltipLabelStyle} itemStyle={tooltipItemStyle} formatter={tooltipFormatter} />
+          {/* Hover cursor: #cccccc is fine in light mode but too bright in dark
+              mode, so drop to #666666 there via a dark: variant (#213). */}
+          <Tooltip cursor={{ className: 'fill-[#cccccc] dark:fill-[#666666]' }} contentStyle={tooltipStyle} labelStyle={tooltipLabelStyle} itemStyle={tooltipItemStyle} formatter={tooltipFormatter} />
+
           {hasPreviousYearData && (
             <Legend
               wrapperStyle={{ paddingTop: '10px' }}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -147,6 +147,7 @@
     "variant_name_required": "Please enter a variant name.",
     "variant_name_duplicate": "A variant with this name already exists.",
     "max_variants_reached": "Maximum of {max} variants allowed.",
+    "max_variants_notice": "You've reached the maximum of {max} variants. Remove one to add another.",
     "track_inventory_label": "Track Inventory",
     "low_stock_threshold_label": "Low Stock Alert Threshold",
     "is_active_label": "Active",
@@ -2058,7 +2059,8 @@
       "confirm_button": "Confirm cancellation",
       "confirming_button": "Cancelling...",
       "error_generic": "Failed to cancel the membership. Please try again.",
-      "partial_success": "Membership cancelled, but the fee charge failed: {error}"
+      "partial_success": "Membership cancelled, but the fee charge failed: {error}",
+      "done_button": "Done"
     },
     "HoldMembershipModal": {
       "title": "Place Membership on Hold",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -147,6 +147,7 @@
     "variant_name_required": "Veuillez entrer un nom de variante.",
     "variant_name_duplicate": "Une variante avec ce nom existe déjà.",
     "max_variants_reached": "Maximum de {max} variantes autorisées.",
+    "max_variants_notice": "Vous avez atteint le maximum de {max} variantes. Supprimez-en une pour en ajouter une autre.",
     "track_inventory_label": "Suivre l'inventaire",
     "low_stock_threshold_label": "Seuil d'alerte stock faible",
     "is_active_label": "Actif",
@@ -2063,7 +2064,8 @@
       "confirm_button": "Confirmer l'annulation",
       "confirming_button": "Annulation...",
       "error_generic": "Échec de l'annulation de l'adhésion. Veuillez réessayer.",
-      "partial_success": "Adhésion annulée, mais le prélèvement des frais a échoué : {error}"
+      "partial_success": "Adhésion annulée, mais le prélèvement des frais a échoué : {error}",
+      "done_button": "Terminé"
     },
     "HoldMembershipModal": {
       "title": "Suspendre l'adhésion",

--- a/src/models/Schema.ts
+++ b/src/models/Schema.ts
@@ -434,7 +434,9 @@ export const paymentMethodSchema = pgTable('payment_method', {
   stripePaymentMethodId: text('stripe_payment_method_id'),
   iqproPaymentMethodId: text('iqpro_payment_method_id'), // IQPro payment method ID
   type: text('type').notNull(),
+  firstSix: text('first_six'), // Card BIN — first 6 digits, for the BIN(6)+last4 masked display. Null for ACH.
   last4: text('last4'),
+  accountType: text('account_type'), // ACH bank account type: 'Checking' | 'Savings'. Null for cards.
   isDefault: boolean('is_default').default(false),
 });
 

--- a/src/scripts/seed.ts
+++ b/src/scripts/seed.ts
@@ -1667,11 +1667,16 @@ async function seedOrganization(organizationId: string) {
     const memberId = memberIds[i]!;
     const type = pmTypeByIndex[i] ?? 'card';
     const last4 = last4ByIndex[i] ?? '0000';
+    const isCard = type === 'card';
     await db.insert(paymentMethodSchema).values({
       id: randomUUID(),
       memberId,
       type,
-      last4: type === 'card' ? last4 : null,
+      // Cards store a BIN (first 6) for the BIN(6)+last4 masked display; the
+      // bank_transfer member stores a Checking/Savings account type + last4.
+      firstSix: isCard ? '424242' : null,
+      last4,
+      accountType: isCard ? null : 'Checking',
       iqproPaymentMethodId: `seed_pm_${randomUUID()}`,
       isDefault: true,
     }).onConflictDoNothing();

--- a/src/services/MemberPaymentService.ts
+++ b/src/services/MemberPaymentService.ts
@@ -342,7 +342,9 @@ export async function processMemberPayment(
         memberId: params.memberId,
         iqproPaymentMethodId: pmResult.paymentMethodId,
         type: params.paymentMethod,
+        firstSix: params.paymentMethod === 'card' ? params.cardFirstSix ?? null : null,
         last4: pmResult.last4,
+        accountType: params.paymentMethod === 'ach' ? params.achAccountType ?? null : null,
         isDefault: true,
       });
       logger.info('[MemberPayment] Payment method saved', { paymentMethodDbId });
@@ -541,7 +543,9 @@ export async function registerPaymentMethod(
       memberId: params.memberId,
       iqproPaymentMethodId: pmResult.paymentMethodId,
       type: params.paymentMethod,
+      firstSix: params.paymentMethod === 'card' ? params.cardFirstSix ?? null : null,
       last4: pmResult.last4,
+      accountType: params.paymentMethod === 'ach' ? params.achAccountType ?? null : null,
       isDefault: true,
     });
 

--- a/src/services/MembersService.test.ts
+++ b/src/services/MembersService.test.ts
@@ -48,7 +48,9 @@ vi.mock('@/models/Schema', () => ({
     id: 'id',
     memberId: 'member_id',
     type: 'type',
+    firstSix: 'first_six',
     last4: 'last4',
+    accountType: 'account_type',
     isDefault: 'is_default',
   },
   transactionSchema: {
@@ -285,11 +287,11 @@ describe('MembersService', () => {
   });
 
   describe('getMemberPaymentMethods', () => {
-    it('should return payment methods for a member', async () => {
+    it('should return payment methods for a member, including firstSix + accountType', async () => {
       const { db } = await import('@/libs/DB');
       const mockPaymentMethods = [
-        { id: 'pm-1', type: 'card', last4: '4242', isDefault: true },
-        { id: 'pm-2', type: 'bank_transfer', last4: '6789', isDefault: false },
+        { id: 'pm-1', type: 'card', firstSix: '424242', last4: '4242', accountType: null, isDefault: true },
+        { id: 'pm-2', type: 'bank_transfer', firstSix: null, last4: '6789', accountType: 'Checking', isDefault: false },
       ];
 
       const mockOrderBy = vi.fn(() => Promise.resolve(mockPaymentMethods));
@@ -302,7 +304,14 @@ describe('MembersService', () => {
       const result = await getMemberPaymentMethods('member-123', 'org-123');
 
       expect(result).toEqual(mockPaymentMethods);
-      expect(db.select).toHaveBeenCalled();
+      // The BIN + account-type columns must be part of the projection so the
+      // member detail page can render the masked card / Checking-Savings label.
+      expect(db.select).toHaveBeenCalledWith(
+        expect.objectContaining({
+          firstSix: expect.anything(),
+          accountType: expect.anything(),
+        }),
+      );
     });
 
     it('should return empty array when no payment methods exist', async () => {

--- a/src/services/MembersService.ts
+++ b/src/services/MembersService.ts
@@ -554,7 +554,9 @@ export async function getAllMembershipPlans(organizationId: string): Promise<Mem
 export type MemberPaymentMethodData = {
   id: string;
   type: string;
+  firstSix: string | null;
   last4: string | null;
+  accountType: string | null;
   isDefault: boolean | null;
 };
 
@@ -573,7 +575,9 @@ export async function getMemberPaymentMethods(
     .select({
       id: paymentMethodSchema.id,
       type: paymentMethodSchema.type,
+      firstSix: paymentMethodSchema.firstSix,
       last4: paymentMethodSchema.last4,
+      accountType: paymentMethodSchema.accountType,
       isDefault: paymentMethodSchema.isDefault,
     })
     .from(paymentMethodSchema)

--- a/src/utils/Auth.test.ts
+++ b/src/utils/Auth.test.ts
@@ -60,9 +60,10 @@ const mockIsExemptOrg = vi.mocked(isExemptOrg);
 
 const owner = { clerkUserId: 'user-owner', email: 'o@e.com', firstName: 'O', lastName: 'E' };
 
-function setAuth(orgId: string | null, username?: string) {
+function setAuth(orgId: string | null, username?: string, orgRole: string = 'org:front_desk') {
   mockAuth.mockResolvedValue({
     orgId,
+    orgRole,
     sessionClaims: username ? { username } : {},
   } as any);
 }
@@ -144,10 +145,26 @@ describe('requireActiveSubscription', () => {
     expect(mockGetAcademyOwner).not.toHaveBeenCalled();
   });
 
-  it('redirects when active but no academy owner exists', async () => {
-    setAuth('org-1');
+  it('redirects a non-admin when active but no academy owner exists', async () => {
+    setAuth('org-1', undefined, 'org:front_desk');
     mockHasActiveSubscription.mockResolvedValue(true);
     mockGetAcademyOwner.mockResolvedValue(null);
+
+    await expect(requireActiveSubscription('/en/dashboard/members')).rejects.toThrow('REDIRECT:/en/dashboard/subscription-expired');
+  });
+
+  it('lets an admin through even when no academy owner exists', async () => {
+    setAuth('org-1', undefined, 'org:admin');
+    mockHasActiveSubscription.mockResolvedValue(true);
+    mockGetAcademyOwner.mockResolvedValue(null);
+
+    await expect(requireActiveSubscription('/en/dashboard/members')).resolves.toBeUndefined();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it('still redirects an admin when the subscription is inactive', async () => {
+    setAuth('org-1', undefined, 'org:admin');
+    mockHasActiveSubscription.mockResolvedValue(false);
 
     await expect(requireActiveSubscription('/en/dashboard/members')).rejects.toThrow('REDIRECT:/en/dashboard/subscription-expired');
   });

--- a/src/utils/Auth.ts
+++ b/src/utils/Auth.ts
@@ -13,6 +13,7 @@ import { db } from '@/libs/DB';
 import { organizationSchema } from '@/models/Schema';
 import { getAcademyOwner } from '@/services/ClerkRolesService';
 import { hasActiveSubscription } from '@/services/SaasSubscriptionService';
+import { ORG_ROLE } from '@/types/Auth';
 import { isExemptOrg, isSuperAdmin } from '@/utils/SuperAdmins';
 
 /**
@@ -58,7 +59,7 @@ export const requireActiveSubscription = async (pathname: string) => {
     return;
   }
 
-  const { orgId, sessionClaims } = await auth();
+  const { orgId, orgRole, sessionClaims } = await auth();
   if (!orgId) {
     return; // org enforcement is handled elsewhere (requireOrganization / proxy)
   }
@@ -78,9 +79,13 @@ export const requireActiveSubscription = async (pathname: string) => {
   }
 
   const active = await hasActiveSubscription(orgId);
-  const owner = active ? await getAcademyOwner(orgId) : null;
+  // The org needs a person responsible for the subscription. That's normally the
+  // academy owner, but an org admin also qualifies — an admin managing the org
+  // shouldn't be locked out just because the academy_owner role isn't assigned.
+  const hasResponsiblePerson
+    = orgRole === ORG_ROLE.ADMIN || (active && !!(await getAcademyOwner(orgId)));
 
-  if (!active || !owner) {
+  if (!active || !hasResponsiblePerson) {
     const localePrefix = pathname.match(/^(\/[^/]+)\/dashboard/)?.[1] ?? '';
     redirect(`${localePrefix}/dashboard/subscription-expired`);
   }


### PR DESCRIPTION
## Summary

Tier 1 "Group C" cleanup across members, catalog, reports, and the membership
lifecycle, plus a fix so org admins can reach the dashboard. Two of the items
(#263, #265) required storing new payment-method data, so this adds two nullable
columns to `payment_method`.

Fixes:

- Fixes #263
- Fixes #265
- Fixes #231
- Fixes #240
- Fixes #213
- Fixes #272

## Changes

### Payment-method detail (#263, #265) — needs new columns
- **Schema**: add nullable `first_six` (card BIN) and `account_type`
  (ACH Checking/Savings) to `payment_method`. Folded into the baseline
  migration (`0000_baseline.sql` + snapshot) — see "Database" below.
- **Persist** both at registration in `MemberPaymentService.ts` (charge and
  capture-only paths) — the ACH account type was previously captured in the UI
  but dropped before insert.
- **Fetch** them in `getMemberPaymentMethods` (`MembersService.ts`).
- **Render** on the member detail page via a new pure helper
  `formatPaymentMethodDetail` (edit/utils.ts):
  - Card: `424242 •••••• 4242` (BIN + last4), falling back to `•••• 4242` when
    the BIN is unknown.
  - ACH: `Checking •••• 4111` instead of a bare "ACH".
  - `getPaymentTypeIcon` / `getPaymentTypeLabel` now handle the `ach` type.
- **Seed** enriched so cards carry a BIN and the bank-transfer member carries a
  Checking account type + last4.

### Unlink family member (#231)
- The family-member card action is now an outlined **"Unlink"** button (icon +
  label + clearer aria/title) instead of an ambiguous red trash icon. It already
  called `unlinkFamilyMember`, so this is a labelling fix.

### Cancellation warning (#240)
- `CancelMembershipModal` no longer auto-closes when the cancellation-fee charge
  fails. It now keeps the modal open showing the partial-success warning with a
  "Done" button, so the warning is actually seen (previously it was set and the
  modal closed in the same tick). Clean success still closes immediately.
- New i18n key `done_button` (en + fr).

### Dark-mode chart hover (#213)
- Bar-chart hover cursor now uses `#cccccc` in light mode and `#666666` in dark
  via a Tailwind `dark:` variant, on both the reports and dashboard charts.

### Max variants message (#272)
- At the 8-variant limit, the catalog item modal now shows an explanatory
  notice instead of silently hiding the add-variant form.
- New i18n key `max_variants_notice` (en + fr).

### Admin dashboard access
- `requireActiveSubscription` (`Auth.ts`) previously redirected to
  subscription-expired unless a Clerk `org:academy_owner` existed — locking out
  org admins. The gate now treats the org as having a responsible person when
  there's an academy owner **OR** the current user is an admin (`orgRole ===
  ORG_ROLE.ADMIN`). Admins still require an active subscription; non-admins still
  require active + a real academy owner. `getAcademyOwner` is untouched, so SaaS
  billing still targets the academy owner, not any admin.

## Database

`first_six` and `account_type` are folded into `0000_baseline.sql` (no separate
migration file). Both are nullable with no default — a fast, non-locking,
backfill-free change; existing rows get NULL, which the display handles.

Run on each Neon branch (main, and preview if present):

```sql
ALTER TABLE "payment_method" ADD COLUMN IF NOT EXISTS "first_six" text;
ALTER TABLE "payment_method" ADD COLUMN IF NOT EXISTS "account_type" text;