### PR TITLE
fix(members): block adding a membership to a member who is on hold

### DIFF
--- a/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx
+++ b/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx
@@ -508,6 +508,9 @@ export default function EditMemberPage() {
   const currentMember: Member | undefined = members?.find(m => m.id === memberId);
   const currentMembership = currentMember?.currentMembership;
   const hasActiveMembership = currentMembership?.status === 'active';
+  // A held member can't take on a new membership until reactivated (#262) —
+  // otherwise they'd be both on hold and active at once.
+  const isOnHold = currentMember?.status === 'hold';
 
   // Build HOH data for family member modal
   const hohMemberData = useMemo(() => {
@@ -1309,14 +1312,20 @@ export default function EditMemberPage() {
                         </Button>
                       </>
                     )
-                  : (
-                      <Button
-                        className="w-fit bg-foreground text-background hover:bg-foreground/90"
-                        onClick={() => handleOpenMembershipModal('add')}
-                      >
-                        Add Membership
-                      </Button>
-                    )}
+                  : isOnHold
+                    ? (
+                        <p className="text-sm text-muted-foreground">
+                          Reactivate this member's membership before adding a new one.
+                        </p>
+                      )
+                    : (
+                        <Button
+                          className="w-fit bg-foreground text-background hover:bg-foreground/90"
+                          onClick={() => handleOpenMembershipModal('add')}
+                        >
+                          Add Membership
+                        </Button>
+                      )}
               </div>
             </Card>
 

--- a/src/routers/Member.ts
+++ b/src/routers/Member.ts
@@ -7,7 +7,7 @@ import { audit } from '@/services/AuditService';
 import { sendMemberConfirmationEmail } from '@/services/EmailService';
 import { resolveIQProConfig } from '@/services/IQProConfigService';
 import { cancelMembershipLifecycle, getLifecycleContext, HoldLimitReachedError, holdMembershipLifecycle, reactivateMembershipLifecycle } from '@/services/MemberPaymentService';
-import { addMemberMembership, changeMemberMembership, createMember, getAllMembershipPlans, getFamilyMembers, getHeadOfHouseholdMembers, getHOHForFamilyMember, getMemberPaymentMethods, getMembershipPlans, getMemberTransactions, linkFamilyMember, removeFully, unlinkFamilyMember, updateMember, updateMemberContactInfo, updateMemberPhoto, updateMemberStatus } from '@/services/MembersService';
+import { addMemberMembership, changeMemberMembership, createMember, getAllMembershipPlans, getFamilyMembers, getHeadOfHouseholdMembers, getHOHForFamilyMember, getMemberPaymentMethods, getMembershipPlans, getMemberTransactions, linkFamilyMember, MemberOnHoldError, removeFully, unlinkFamilyMember, updateMember, updateMemberContactInfo, updateMemberPhoto, updateMemberStatus } from '@/services/MembersService';
 import { generatePdfFilename } from '@/services/WaiverPdfService';
 import { generateWaiverPdfBuffer } from '@/services/WaiverPdfService.server';
 import { AUDIT_ACTION, AUDIT_ENTITY_TYPE } from '@/types/Audit';
@@ -580,6 +580,12 @@ export const addMembership = os
         status: 'failure',
         error: errorMessage,
       });
+
+      // A member on hold can't take a new membership — surface as a 409 with a
+      // clear message instead of a generic 500 (#262).
+      if (error instanceof MemberOnHoldError) {
+        throw new ORPCError('Conflict', { status: 409, message: error.message });
+      }
 
       throw error instanceof ORPCError ? error : new ORPCError('Failed to add membership. Please try again.', { status: 500 });
     }

--- a/src/services/MembersService.test.ts
+++ b/src/services/MembersService.test.ts
@@ -91,6 +91,48 @@ describe('MembersService', () => {
     vi.clearAllMocks();
   });
 
+  describe('addMemberMembership', () => {
+    it('throws MemberOnHoldError when the member is on hold', async () => {
+      const { db } = await import('@/libs/DB');
+      // The member-status lookup returns a held member.
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([{ status: 'hold' }])) })),
+        })),
+      } as never);
+
+      const { addMemberMembership, MemberOnHoldError } = await import('./MembersService');
+
+      await expect(addMemberMembership('member-123', 'plan-1')).rejects.toBeInstanceOf(MemberOnHoldError);
+      // The insert must not run for a held member.
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('inserts an active membership when the member is not on hold', async () => {
+      const { db } = await import('@/libs/DB');
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([{ status: 'active' }])) })),
+        })),
+      } as never);
+
+      const returning = vi.fn(() => Promise.resolve([{ id: 'mm-1' }]));
+      const values = vi.fn(() => ({ returning }));
+      vi.mocked(db.insert).mockReturnValue({ values } as never);
+
+      const { addMemberMembership } = await import('./MembersService');
+      const result = await addMemberMembership('member-123', 'plan-1');
+
+      expect(db.insert).toHaveBeenCalled();
+      expect(values).toHaveBeenCalledWith(expect.objectContaining({
+        memberId: 'member-123',
+        membershipPlanId: 'plan-1',
+        status: 'active',
+      }));
+      expect(result).toEqual([{ id: 'mm-1' }]);
+    });
+  });
+
   describe('updateMemberContactInfo', () => {
     it('should update member email and phone', async () => {
       const { updateMemberContactInfo } = await import('./MembersService');

--- a/src/services/MembersService.ts
+++ b/src/services/MembersService.ts
@@ -428,12 +428,37 @@ export async function updateMemberContactInfo(input: UpdateMemberContactInfoInpu
 }
 
 /**
+ * Thrown when a new membership is added to a member who is currently on hold.
+ * Held members must be reactivated before taking on a new active membership,
+ * otherwise they'd be both 'hold' and 'active' at once. Mapped to a 409 by the
+ * router.
+ */
+export class MemberOnHoldError extends Error {
+  constructor() {
+    super('This member is on hold. Reactivate their membership before adding a new one.');
+    this.name = 'MemberOnHoldError';
+  }
+}
+
+/**
  * Add a membership to a member
  * @param memberId - The member ID
  * @param membershipPlanId - The membership plan ID
  * @returns The created membership record
  */
 export async function addMemberMembership(memberId: string, membershipPlanId: string) {
+  // A held member can't take on a new active membership — that would leave them
+  // simultaneously on hold and active (#262). Require a reactivation first.
+  const member = await db
+    .select({ status: memberSchema.status })
+    .from(memberSchema)
+    .where(eq(memberSchema.id, memberId))
+    .limit(1);
+
+  if (member[0]?.status === 'hold') {
+    throw new MemberOnHoldError();
+  }
+
   const result = await db
     .insert(memberMembershipSchema)
     .values({


### PR DESCRIPTION
## Summary

A member on hold could be given a new membership, leaving them simultaneously
on hold (member status) and active (membership status). Adding a membership now
requires the member to be reactivated first.

Fixes #262.

## Root cause

`addMemberMembership` inserted a new `member_membership` row with
`status='active'` unconditionally — it never checked the parent `member.status`.
A held member (member.status='hold') who was given a new membership ended up in
an inconsistent hold + active state, with no DB constraint or app guard
preventing it.

## Changes

- **Service guard (authoritative)** — `MembersService.ts`: `addMemberMembership`
  now looks up `member.status` before inserting and throws a new
  `MemberOnHoldError` when the member is on hold. This protects every caller,
  not just the current UI path.
- **Router mapping** — `Member.ts`: the `addMembership` handler maps
  `MemberOnHoldError` to a **409** with a clear message, mirroring the existing
  `HoldLimitReachedError` → 409 pattern, instead of a generic 500.
- **UI affordance** — member edit page: when the member is on hold, the
  "Add Membership" button is replaced with a note ("Reactivate this member's
  membership before adding a new one."), so users don't hit the 409. Reactivate
  is already a one-click action and clears the hold.

## Design note

We chose to **block** rather than auto-clear the hold: adding a membership
should not silently reactivate a held member. The member must be explicitly
reactivated first, which is an existing one-click action.

## Tests

- New `addMemberMembership` service tests: throws `MemberOnHoldError` (and does
  NOT insert) when the member is on hold; inserts an active membership when the
  member is not on hold.
- `npm run lint`, `npm run check:types`, and `npm run check:i18n` all pass.