### PR TITLE
fix(members/finances): membership hold lifecycle, refunds

### DIFF
--- a/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx
+++ b/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx
@@ -30,8 +30,10 @@ import { CancelMembershipModal } from '@/features/members/lifecycle/CancelMember
 import { HoldMembershipModal } from '@/features/members/lifecycle/HoldMembershipModal';
 import { AddFamilyMembersModal } from '@/features/members/wizard/AddFamilyMembersModal';
 import { useCouponsCache } from '@/hooks/useCouponsCache';
+import { useHasRole } from '@/hooks/useHasRole';
 import { invalidateMembersCache, useMembersCache } from '@/hooks/useMembersCache';
 import { client } from '@/libs/Orpc';
+import { ORG_ROLE } from '@/types/Auth';
 // WaiverPdfService pulls in jspdf (large). Imported dynamically inside the
 // download handler so it is excluded from this page's initial bundle.
 import {
@@ -673,37 +675,58 @@ export default function EditMemberPage() {
     void reloadPaymentMethods();
   }, [reloadPaymentMethods]);
 
-  // Fetch billing history for this member
-  useEffect(() => {
-    const fetchBillingHistory = async () => {
-      if (!memberId) {
-        return;
-      }
-      setIsLoadingBilling(true);
-      try {
-        const result = await client.member.listMemberTransactions({ memberId, limit: 50 });
-        const items: BillingHistoryItem[] = result.transactions.map(tx => ({
-          id: tx.id,
-          date: new Date(tx.createdAt).toLocaleDateString('en-US', {
-            year: 'numeric',
-            month: 'short',
-            day: 'numeric',
-          }),
-          member: `${tx.memberFirstName || ''} ${tx.memberLastName || ''}`.trim(),
-          amount: tx.amount,
-          purpose: formatTransactionType(tx.transactionType),
-          method: tx.paymentMethod || 'N/A',
-        }));
-        setBillingHistory(items);
-      } catch (err) {
-        console.warn('[Edit Member] Failed to fetch billing history:', err);
-        setBillingHistory([]);
-      } finally {
-        setIsLoadingBilling(false);
-      }
-    };
-    fetchBillingHistory();
+  // Fetch billing history for this member. Extracted into a useCallback so a
+  // refund can re-run it to reflect the reversed transaction immediately.
+  const reloadBillingHistory = useCallback(async () => {
+    if (!memberId) {
+      return;
+    }
+    setIsLoadingBilling(true);
+    try {
+      const result = await client.member.listMemberTransactions({ memberId, limit: 50 });
+      const items: BillingHistoryItem[] = result.transactions.map(tx => ({
+        id: tx.id,
+        date: new Date(tx.createdAt).toLocaleDateString('en-US', {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+        }),
+        member: `${tx.memberFirstName || ''} ${tx.memberLastName || ''}`.trim(),
+        amount: tx.amount,
+        purpose: formatTransactionType(tx.transactionType),
+        method: tx.paymentMethod || 'N/A',
+      }));
+      setBillingHistory(items);
+    } catch (err) {
+      console.warn('[Edit Member] Failed to fetch billing history:', err);
+      setBillingHistory([]);
+    } finally {
+      setIsLoadingBilling(false);
+    }
   }, [memberId]);
+
+  useEffect(() => {
+    void reloadBillingHistory();
+  }, [reloadBillingHistory]);
+
+  // Refunds are ADMIN-only (mirrors the transactions.refund guard). Non-admins
+  // don't see the Refund button at all (#233).
+  const canRefund = useHasRole(ORG_ROLE.ADMIN);
+  const [refundingId, setRefundingId] = useState<string | null>(null);
+  const [refundError, setRefundError] = useState<string | null>(null);
+
+  const handleRefund = useCallback(async (transactionId: string) => {
+    setRefundingId(transactionId);
+    setRefundError(null);
+    try {
+      await client.transactions.refund({ transactionId });
+      await reloadBillingHistory();
+    } catch (err) {
+      setRefundError(err instanceof Error ? err.message : 'Refund failed. Please try again.');
+    } finally {
+      setRefundingId(null);
+    }
+  }, [reloadBillingHistory]);
 
   // Fetch family members if this member is a head of household
   const isHOH = currentMember?.memberType === 'head-of-household';
@@ -1307,7 +1330,11 @@ export default function EditMemberPage() {
                         >
                           Change Membership
                         </Button>
-                        <Button variant="destructive" className="w-fit">
+                        <Button
+                          variant="destructive"
+                          className="w-fit"
+                          onClick={() => setIsHoldMembershipOpen(true)}
+                        >
                           Hold
                         </Button>
                       </>
@@ -1488,6 +1515,9 @@ export default function EditMemberPage() {
           {/* Billing History */}
           <Card className="p-6">
             <h2 className="mb-6 text-lg font-semibold text-foreground">Billing History</h2>
+            {refundError && (
+              <p className="mb-4 text-sm text-destructive">{refundError}</p>
+            )}
             {isLoadingBilling
               ? (
                   <p className="text-sm text-muted-foreground">Loading billing history...</p>
@@ -1524,13 +1554,16 @@ export default function EditMemberPage() {
                               <td className="px-4 py-4 text-sm text-muted-foreground">{item.purpose}</td>
                               <td className="hidden px-4 py-4 text-sm text-muted-foreground sm:table-cell">{item.method}</td>
                               <td className="px-4 py-4">
-                                <Button
-                                  size="sm"
-                                  onClick={() => console.info('Refund', item.id)}
-                                  className="w-fit bg-foreground text-background hover:bg-foreground/90"
-                                >
-                                  Refund
-                                </Button>
+                                {canRefund && (
+                                  <Button
+                                    size="sm"
+                                    disabled={refundingId === item.id}
+                                    onClick={() => handleRefund(item.id)}
+                                    className="w-fit bg-foreground text-background hover:bg-foreground/90"
+                                  >
+                                    {refundingId === item.id ? 'Refunding…' : 'Refund'}
+                                  </Button>
+                                )}
                               </td>
                             </tr>
                           ))}

--- a/src/app/[locale]/(auth)/dashboard/transactions/finances.test.tsx
+++ b/src/app/[locale]/(auth)/dashboard/transactions/finances.test.tsx
@@ -1,9 +1,29 @@
 import type { Transaction } from '@/features/finances/FinancesTable';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { page, userEvent } from 'vitest/browser';
 import { FinancesTable } from '@/features/finances/FinancesTable';
 import { I18nWrapper } from '@/lib/test-utils';
+
+// FinancesTable renders TransactionDetailModal, which pulls in Clerk (via
+// useHasRole) and the transactions cache. Mock them so the browser test env
+// doesn't try to read `process` at import time.
+vi.mock('@/hooks/useHasRole', () => ({
+  useHasRole: () => false,
+}));
+
+vi.mock('@/hooks/useTransactionsCache', () => ({
+  invalidateTransactionsCache: vi.fn(),
+}));
+
+vi.mock('@/libs/Orpc', () => ({
+  client: {
+    transactions: {
+      get: vi.fn(),
+      refund: vi.fn(),
+    },
+  },
+}));
 
 // Note: Card numbers shown are masked display values (****1234), not actual card numbers
 const mockTransactions: Transaction[] = [

--- a/src/features/finances/FinancesTable.test.tsx
+++ b/src/features/finances/FinancesTable.test.tsx
@@ -9,6 +9,26 @@ vi.mock('next-intl', () => ({
   useTranslations: () => (key: string) => key,
 }));
 
+// FinancesTable renders TransactionDetailModal, which pulls in Clerk (via
+// useHasRole) and the transactions cache. Mock them so the browser test env
+// doesn't try to read `process` at import time.
+vi.mock('@/hooks/useHasRole', () => ({
+  useHasRole: () => false,
+}));
+
+vi.mock('@/hooks/useTransactionsCache', () => ({
+  invalidateTransactionsCache: vi.fn(),
+}));
+
+vi.mock('@/libs/Orpc', () => ({
+  client: {
+    transactions: {
+      get: vi.fn(),
+      refund: vi.fn(),
+    },
+  },
+}));
+
 // Helper to create mock transactions
 const createMockTransaction = (overrides: Partial<Transaction> = {}): Transaction => ({
   id: '1',

--- a/src/features/finances/TransactionDetailModal.test.tsx
+++ b/src/features/finances/TransactionDetailModal.test.tsx
@@ -1,7 +1,7 @@
 import type { Transaction, TransactionStatus } from './FinancesTable';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
-import { page } from 'vitest/browser';
+import { page, userEvent } from 'vitest/browser';
 import { TransactionDetailModal } from './TransactionDetailModal';
 
 // Mock next-intl
@@ -11,12 +11,25 @@ vi.mock('next-intl', () => ({
 
 // Mock ORPC client
 const mockGetTransaction = vi.fn();
+const mockRefundTransaction = vi.fn();
 vi.mock('@/libs/Orpc', () => ({
   client: {
     transactions: {
       get: (...args: unknown[]) => mockGetTransaction(...args),
+      refund: (...args: unknown[]) => mockRefundTransaction(...args),
     },
   },
+}));
+
+// Refund button is ADMIN-gated; default the hook to true so it renders.
+const mockUseHasRole = vi.fn(() => true);
+vi.mock('@/hooks/useHasRole', () => ({
+  useHasRole: () => mockUseHasRole(),
+}));
+
+const mockInvalidateTransactionsCache = vi.fn();
+vi.mock('@/hooks/useTransactionsCache', () => ({
+  invalidateTransactionsCache: () => mockInvalidateTransactionsCache(),
 }));
 
 // Helper to create mock transactions
@@ -706,6 +719,59 @@ describe('TransactionDetailModal', () => {
       );
 
       await expect.element(page.getByText('type_label')).toBeInTheDocument();
+    });
+  });
+
+  describe('Refund (#273)', () => {
+    beforeEach(() => {
+      mockUseHasRole.mockReturnValue(true);
+      mockRefundTransaction.mockReset();
+      mockInvalidateTransactionsCache.mockReset();
+      mockGetTransaction.mockResolvedValue({ transaction: mockMembershipDetails });
+    });
+
+    it('shows a Refund button for an admin on a paid, refundable transaction', async () => {
+      render(
+        <TransactionDetailModal isOpen={true} onCloseAction={() => {}} transaction={createMockTransaction()} />,
+      );
+
+      await expect.element(page.getByText('refund_button')).toBeInTheDocument();
+    });
+
+    it('hides the Refund button for non-admins', async () => {
+      mockUseHasRole.mockReturnValue(false);
+      render(
+        <TransactionDetailModal isOpen={true} onCloseAction={() => {}} transaction={createMockTransaction()} />,
+      );
+
+      await expect.element(page.getByText('close_button')).toBeInTheDocument();
+      expect(page.getByText('refund_button').elements()).toHaveLength(0);
+    });
+
+    it('hides the Refund button for an already-refunded transaction', async () => {
+      render(
+        <TransactionDetailModal
+          isOpen={true}
+          onCloseAction={() => {}}
+          transaction={createMockTransaction({ status: 'refunded' })}
+        />,
+      );
+
+      await expect.element(page.getByText('close_button')).toBeInTheDocument();
+      expect(page.getByText('refund_button').elements()).toHaveLength(0);
+    });
+
+    it('calls the refund endpoint and invalidates the cache when clicked', async () => {
+      mockRefundTransaction.mockResolvedValue({ refundTransactionId: 'r1' });
+      render(
+        <TransactionDetailModal isOpen={true} onCloseAction={() => {}} transaction={createMockTransaction()} />,
+      );
+
+      await userEvent.click(page.getByText('refund_button'));
+
+      await vi.waitFor(() => expect(mockRefundTransaction).toHaveBeenCalledWith({ transactionId: 'txn-uuid-1' }));
+
+      expect(mockInvalidateTransactionsCache).toHaveBeenCalled();
     });
   });
 });

--- a/src/features/finances/TransactionDetailModal.tsx
+++ b/src/features/finances/TransactionDetailModal.tsx
@@ -14,13 +14,19 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Spinner } from '@/components/ui/spinner';
+import { useHasRole } from '@/hooks/useHasRole';
+import { invalidateTransactionsCache } from '@/hooks/useTransactionsCache';
 import { client } from '@/libs/Orpc';
+import { ORG_ROLE } from '@/types/Auth';
 
 type TransactionDetailModalProps = {
   isOpen: boolean;
   onCloseAction: () => void;
   transaction: Transaction | null;
 };
+
+// Transaction types that represent a real charge and can therefore be refunded.
+const REFUNDABLE_TYPES = new Set(['membership_payment', 'signup_fee', 'event_registration', 'product_purchase', 'adjustment']);
 
 const statusVariantMap: Record<TransactionStatus, 'default' | 'secondary' | 'destructive' | 'outline' | 'warning'> = {
   paid: 'default',
@@ -59,7 +65,13 @@ export function TransactionDetailModal({
   const t = useTranslations('TransactionDetailModal');
   const [details, setDetails] = useState<TransactionDetailData | null>(null);
   const [loading, setLoading] = useState(false);
+  const [refunding, setRefunding] = useState(false);
+  const [refundError, setRefundError] = useState<string | null>(null);
   const prevTransactionIdRef = useRef<string | null>(null);
+
+  // Refunds are ADMIN-only (mirrors the transactions.refund guard). Only a
+  // paid charge (not an already-refunded/declined one) can be refunded (#273).
+  const canRefund = useHasRole(ORG_ROLE.ADMIN);
 
   const handleOpenChange = useCallback((open: boolean) => {
     if (!open) {
@@ -80,6 +92,25 @@ export function TransactionDetailModal({
     }
   }, []);
 
+  const handleRefund = useCallback(async () => {
+    if (!transaction) {
+      return;
+    }
+    setRefunding(true);
+    setRefundError(null);
+    try {
+      await client.transactions.refund({ transactionId: transaction.id });
+      // Refresh the modal's own view + the finances list so the reversed
+      // transaction and its 'refunded' status show up immediately.
+      await fetchDetails(transaction.id);
+      await invalidateTransactionsCache();
+    } catch (err) {
+      setRefundError(err instanceof Error ? err.message : t('refund_error'));
+    } finally {
+      setRefunding(false);
+    }
+  }, [transaction, fetchDetails, t]);
+
   useEffect(() => {
     if (!isOpen || !transaction) {
       prevTransactionIdRef.current = null;
@@ -95,6 +126,10 @@ export function TransactionDetailModal({
   if (!transaction) {
     return null;
   }
+
+  const isRefundable = canRefund
+    && transaction.status === 'paid'
+    && REFUNDABLE_TYPES.has(transaction.transactionType);
 
   const typeKey = TRANSACTION_TYPE_LABELS[transaction.transactionType] ?? transaction.transactionType;
   const hasMembershipDetails = details?.membershipPlanName
@@ -201,7 +236,16 @@ export function TransactionDetailModal({
           )}
         </div>
 
+        {refundError && (
+          <p className="text-sm text-destructive">{refundError}</p>
+        )}
+
         <DialogFooter>
+          {isRefundable && (
+            <Button variant="destructive" disabled={refunding} onClick={handleRefund}>
+              {refunding ? t('refunding_button') : t('refund_button')}
+            </Button>
+          )}
           <Button variant="outline" onClick={onCloseAction}>
             {t('close_button')}
           </Button>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -985,6 +985,9 @@
     "subtotal_label": "Subtotal",
     "tax_label": "Tax",
     "total_label": "Total",
+    "refund_button": "Refund",
+    "refunding_button": "Refunding…",
+    "refund_error": "Refund failed. Please try again.",
     "close_button": "Close"
   },
   "ReportsPage": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1020,6 +1020,9 @@
     "subtotal_label": "Sous-total",
     "tax_label": "Taxe",
     "total_label": "Total",
+    "refund_button": "Rembourser",
+    "refunding_button": "Remboursement…",
+    "refund_error": "Le remboursement a échoué. Veuillez réessayer.",
     "close_button": "Fermer"
   },
   "MarketingPage": {

--- a/src/services/MemberPaymentService.test.ts
+++ b/src/services/MemberPaymentService.test.ts
@@ -54,6 +54,11 @@ vi.mock('@/libs/IQPro', () => ({
     cardProcessorId: 'card_proc_001',
     achProcessorId: 'ach_proc_001',
   }),
+  iqproGet: vi.fn(),
+  iqproPost: vi.fn(),
+  iqproPut: vi.fn(),
+  assertTransactionApproved: vi.fn(),
+  buildServiceFeeAdjustment: vi.fn(() => ({ type: 'ServiceFee', percentage: 3.75, flatAmount: null })),
 }));
 
 const testConfig = {
@@ -1082,5 +1087,53 @@ describe('computeNextPaymentDate', () => {
     expect(next.getFullYear()).toBe(2026);
     expect(next.getMonth()).toBe(5); // June
     expect(next.getDate()).toBe(30); // clamped to last day of June
+  });
+});
+
+describe('chargeOneTimeFee (resilience — #237)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a captured error (never throws) when the subscription fetch fails', async () => {
+    const { iqproGet } = await import('@/libs/IQPro');
+    // A synthetic/seed subscription id makes IQPro reject the initial fetch —
+    // this used to throw straight through and 500 the hold/cancel endpoints.
+    vi.mocked(iqproGet).mockRejectedValue(new Error('IQPro 404: subscription not found'));
+
+    const { chargeOneTimeFee } = await import('./MemberPaymentService');
+    const result = await chargeOneTimeFee({
+      config: testConfig,
+      iqproSubscriptionId: 'seed_sub_does_not_exist',
+      iqproCustomerId: 'seed_cus_1',
+      orgId: 'org-1',
+      memberId: 'member-1',
+      memberMembershipId: 'mm-1',
+      amount: 25,
+      transactionType: 'hold_fee',
+      description: 'Hold fee',
+      caption: 'Hold fee',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('subscription not found');
+  });
+
+  it('short-circuits to success with no charge when the amount is zero', async () => {
+    const { chargeOneTimeFee } = await import('./MemberPaymentService');
+    const result = await chargeOneTimeFee({
+      config: testConfig,
+      iqproSubscriptionId: 'seed_sub_1',
+      iqproCustomerId: 'seed_cus_1',
+      orgId: 'org-1',
+      memberId: 'member-1',
+      memberMembershipId: 'mm-1',
+      amount: 0,
+      transactionType: 'hold_fee',
+      description: 'Hold fee',
+      caption: 'Hold fee',
+    });
+
+    expect(result).toEqual({ success: true, amountCharged: 0 });
   });
 });

--- a/src/services/MemberPaymentService.ts
+++ b/src/services/MemberPaymentService.ts
@@ -1334,79 +1334,85 @@ export async function chargeOneTimeFee(args: {
     return { success: true, amountCharged: 0 };
   }
 
-  // Pull the subscription so we can resolve customerId + payment-method id
-  // exactly the way the kiosk does. IQPro lets us reference the saved PM
-  // by customerPaymentMethodId on the Sale payload.
-  const subRes = await iqproGet<{ data?: Record<string, unknown> }>(
-    config,
-    `/api/gateway/${gatewayId}/subscription/${iqproSubscriptionId}`,
-  );
-  const sub = (subRes.data ?? subRes) as Record<string, unknown>;
-  const subPM = sub.paymentMethod as Record<string, unknown> | undefined;
-  const custPM = subPM?.customerPaymentMethod as Record<string, unknown> | undefined;
-  const customerId = ((sub.customer as Record<string, unknown> | undefined)?.customerId ?? iqproCustomerId) as string;
-  const pmId = (custPM?.paymentMethodId ?? '') as string;
-
-  if (!pmId) {
-    return {
-      success: false,
-      error: 'No saved payment method on the existing subscription. Cannot charge fee.',
-    };
-  }
-
-  const paymentMethodName: 'card' | 'ach' = custPM?.card ? 'card' : 'ach';
-
-  // /calculatefees needs processorId + BIN for cards. Fall back to '400000'
-  // for the test BIN when the vault doesn't expose one — matches kiosk.
-  const { cardProcessorId, achProcessorId } = await getGatewayProcessors(config);
-  const processorId = paymentMethodName === 'card' ? cardProcessorId : achProcessorId;
-  if (!processorId) {
-    return { success: false, error: `No ${paymentMethodName} processor configured` };
-  }
-  const cardInfo = custPM?.card as Record<string, unknown> | undefined;
-  const maskedNumber = (cardInfo?.maskedNumber ?? cardInfo?.maskedCard ?? '') as string;
-  const bin = maskedNumber && maskedNumber.length >= 6 ? maskedNumber.slice(0, 6) : '400000';
-
-  // Cancellation / hold fees are NOT taxable (per Basys guidance on non-store charges).
-  const serverFees = await computeFeeBreakdown(config, baseAmount, /* isTaxable */ false, /* taxStatePct */ 0, {
-    processorId,
-    creditCardBin: paymentMethodName === 'card' ? bin : undefined,
-  });
-  const paymentAdjustments: Array<Record<string, unknown>> = [buildServiceFeeAdjustment(serverFees)];
-
-  const feeTxPayload = {
-    type: 'Sale',
-    remit: {
-      baseAmount: serverFees.baseAmount,
-      taxAmount: serverFees.taxAmount,
-      isTaxExempt: serverFees.taxAmount <= 0,
-      currencyCode: 'USD',
-      addTaxToTotal: true,
-      paymentAdjustments,
-    },
-    paymentMethod: {
-      customer: {
-        customerId,
-        customerPaymentMethodId: pmId,
-      },
-    },
-    lineItems: [
-      {
-        name: caption,
-        description,
-        quantity: 1,
-        unitPrice: baseAmount,
-        discount: 0,
-        freightAmount: 0,
-        unitOfMeasureId: 1,
-        localTaxPercent: 0,
-        nationalTaxPercent: 0,
-      },
-    ],
-    caption,
-  };
-
+  // Everything below talks to IQPro. Any failure here (including the initial
+  // subscription fetch against a synthetic/seed subscription id, the processor
+  // lookup, or the fee calculation) must be returned as a best-effort error
+  // rather than thrown — a fee-charge failure should degrade to a partial
+  // success in the caller, never a 500 (#237). Previously only the final
+  // charge POST was wrapped, so the earlier iqproGet threw straight through.
   try {
+    // Pull the subscription so we can resolve customerId + payment-method id
+    // exactly the way the kiosk does. IQPro lets us reference the saved PM
+    // by customerPaymentMethodId on the Sale payload.
+    const subRes = await iqproGet<{ data?: Record<string, unknown> }>(
+      config,
+      `/api/gateway/${gatewayId}/subscription/${iqproSubscriptionId}`,
+    );
+    const sub = (subRes.data ?? subRes) as Record<string, unknown>;
+    const subPM = sub.paymentMethod as Record<string, unknown> | undefined;
+    const custPM = subPM?.customerPaymentMethod as Record<string, unknown> | undefined;
+    const customerId = ((sub.customer as Record<string, unknown> | undefined)?.customerId ?? iqproCustomerId) as string;
+    const pmId = (custPM?.paymentMethodId ?? '') as string;
+
+    if (!pmId) {
+      return {
+        success: false,
+        error: 'No saved payment method on the existing subscription. Cannot charge fee.',
+      };
+    }
+
+    const paymentMethodName: 'card' | 'ach' = custPM?.card ? 'card' : 'ach';
+
+    // /calculatefees needs processorId + BIN for cards. Fall back to '400000'
+    // for the test BIN when the vault doesn't expose one — matches kiosk.
+    const { cardProcessorId, achProcessorId } = await getGatewayProcessors(config);
+    const processorId = paymentMethodName === 'card' ? cardProcessorId : achProcessorId;
+    if (!processorId) {
+      return { success: false, error: `No ${paymentMethodName} processor configured` };
+    }
+    const cardInfo = custPM?.card as Record<string, unknown> | undefined;
+    const maskedNumber = (cardInfo?.maskedNumber ?? cardInfo?.maskedCard ?? '') as string;
+    const bin = maskedNumber && maskedNumber.length >= 6 ? maskedNumber.slice(0, 6) : '400000';
+
+    // Cancellation / hold fees are NOT taxable (per Basys guidance on non-store charges).
+    const serverFees = await computeFeeBreakdown(config, baseAmount, /* isTaxable */ false, /* taxStatePct */ 0, {
+      processorId,
+      creditCardBin: paymentMethodName === 'card' ? bin : undefined,
+    });
+    const paymentAdjustments: Array<Record<string, unknown>> = [buildServiceFeeAdjustment(serverFees)];
+
+    const feeTxPayload = {
+      type: 'Sale',
+      remit: {
+        baseAmount: serverFees.baseAmount,
+        taxAmount: serverFees.taxAmount,
+        isTaxExempt: serverFees.taxAmount <= 0,
+        currencyCode: 'USD',
+        addTaxToTotal: true,
+        paymentAdjustments,
+      },
+      paymentMethod: {
+        customer: {
+          customerId,
+          customerPaymentMethodId: pmId,
+        },
+      },
+      lineItems: [
+        {
+          name: caption,
+          description,
+          quantity: 1,
+          unitPrice: baseAmount,
+          discount: 0,
+          freightAmount: 0,
+          unitOfMeasureId: 1,
+          localTaxPercent: 0,
+          nationalTaxPercent: 0,
+        },
+      ],
+      caption,
+    };
+
     const txRes = await iqproPost<{ data?: Record<string, unknown> }>(
       config,
       `/api/gateway/${gatewayId}/transaction`,
@@ -1799,9 +1805,15 @@ export async function holdMembershipLifecycle(args: {
     }
   }
 
-  // Pause the original membership subscription
+  // Pause the original membership subscription. A failure here (e.g. IQPro
+  // rejecting a synthetic/seed subscription id) must NOT abort the hold — the
+  // local status change still proceeds and the error is surfaced, matching the
+  // cancellation path's best-effort behaviour (#237).
   if (config && ctx.membership.iqproSubscriptionId) {
-    await setSubscriptionAutoRenewal(config, ctx.membership.iqproSubscriptionId, false);
+    const pauseResult = await setSubscriptionAutoRenewal(config, ctx.membership.iqproSubscriptionId, false);
+    if (!pauseResult.success && !chargeError) {
+      chargeError = pauseResult.error;
+    }
   }
 
   // Update local DB rows
@@ -1838,11 +1850,21 @@ export async function reactivateMembershipLifecycle(args: {
   const { config, ctx } = args;
   const now = new Date();
 
+  // Both IQPro calls are best-effort: a failure (e.g. a synthetic/seed
+  // subscription id IQPro rejects) is surfaced but never blocks the local
+  // reactivation, mirroring the hold/cancel paths (#237).
+  let error: string | undefined;
   if (config && ctx.membership.iqproHoldFeeSubscriptionId) {
-    await cancelIQProSubscription(config, ctx.membership.iqproHoldFeeSubscriptionId);
+    const cancelResult = await cancelIQProSubscription(config, ctx.membership.iqproHoldFeeSubscriptionId);
+    if (!cancelResult.success) {
+      error = cancelResult.error;
+    }
   }
   if (config && ctx.membership.iqproSubscriptionId) {
-    await setSubscriptionAutoRenewal(config, ctx.membership.iqproSubscriptionId, true);
+    const resumeResult = await setSubscriptionAutoRenewal(config, ctx.membership.iqproSubscriptionId, true);
+    if (!resumeResult.success && !error) {
+      error = resumeResult.error;
+    }
   }
 
   await db.update(memberMembershipSchema)
@@ -1856,5 +1878,5 @@ export async function reactivateMembershipLifecycle(args: {
     .set({ status: 'active', statusChangedAt: now })
     .where(eq(memberSchema.id, ctx.member.id));
 
-  return { success: true };
+  return { success: true, error };
 }

--- a/src/services/MembersService.ts
+++ b/src/services/MembersService.ts
@@ -224,10 +224,18 @@ export async function getOrganizationMembers(
     history.push(memberMembership);
     membershipHistoryMap.set(membership.memberId, history);
 
-    // Set current membership (active status, most recent)
-    if (membership.status === 'active') {
+    // Set current membership. A held membership is still the member's current
+    // one — excluding it made the detail page's "Actions" menu (which owns the
+    // Reactivate action) disappear exactly when the member was on hold (#235).
+    // Prefer an active membership over a held one; otherwise take the most
+    // recent of the same kind.
+    if (membership.status === 'active' || membership.status === 'hold') {
       const current = currentMembershipMap.get(membership.memberId);
-      if (!current || membership.startDate > current.startDate) {
+      const isMoreCurrent
+        = !current
+          || (current.status === 'hold' && membership.status === 'active')
+          || (current.status === membership.status && membership.startDate > current.startDate);
+      if (isMoreCurrent) {
         currentMembershipMap.set(membership.memberId, memberMembership);
       }
     }


### PR DESCRIPTION
## Summary

Fixes the membership-hold lifecycle (dead Hold button, 500 on confirm,
disappearing Actions menu) and wires up the refund buttons that were previously
no-ops, gated to admins.

Fixes:

- Fixes #236
- Fixes #237
- Fixes #235
- Fixes #233
- Fixes #273

## Group E — hold lifecycle

- **#236 red "Hold" button did nothing** — the button had no `onClick` at all.
  Wired it to open the Hold modal (`setIsHoldMembershipOpen(true)`), matching the
  Actions-dropdown handler.
- **#237 500 on confirm hold** — `chargeOneTimeFee`'s try/catch wrapped only the
  final charge POST, so the earlier subscription `iqproGet` threw straight
  through (e.g. a synthetic/seed subscription id IQPro rejects) and 500'd the
  endpoint. Only the recurring hold-fee branch was protected. Widened the try to
  cover the whole IQPro interaction (subscription fetch → processor lookup → fee
  calc → charge) so it always returns `{success, error}` and degrades to a
  partial success. This also protects the cancellation path (same helper).
  Added best-effort capture on the hold/reactivate pause+resume calls too.
- **#235 "Actions" menu vanished after hold** — `currentMembership` in
  `getOrganizationMembers` was only populated for `status === 'active'`, so a
  held membership became `null` and the Actions dropdown (guarded by
  `{currentMembership && …}`) disappeared exactly when Reactivate was needed.
  Now includes `'hold'` memberships (preferring an active one); the dropdown's
  existing `status === 'hold'` branch renders Reactivate + Cancel.

## Group F — refunds

- **#233 member-edit refund button was a no-op** (`console.info`). Wired to
  `client.transactions.refund`, ADMIN-gated via `useHasRole(ORG_ROLE.ADMIN)` so
  non-admins don't see it at all (per the report), refreshes billing history on
  success, inline error on failure.
- **#273 no refund option in the transaction detail modal.** Added a Refund
  button, shown only for admins on a `paid`, refundable-type transaction. Calls
  the endpoint, refetches the modal's details, and invalidates the finances
  cache so the reversed transaction + `refunded` status appear immediately.
- New i18n keys: `TransactionDetailModal.refund_button` / `refunding_button` /
  `refund_error` (en + fr).

## Notes

- Refunds remain DB bookkeeping only (mark refunded + reverse coupons); the
  IQPro-side refund is still handled manually by operators, as designed. The
  `useHasRole(ADMIN)` gate mirrors the existing `transactions.refund` ADMIN
  guard, so academy owners correctly don't see the button.
- The #237 500 is Preview-only (locally `resolveIQProConfig` returns null, so all
  IQPro calls are skipped and there was no throw path). The fix is verified by
  unit test; recommend confirming on Preview against a seeded held member.

## Tests

- `chargeOneTimeFee` resilience: returns a captured error (never throws) when the
  subscription fetch fails; short-circuits to success on a zero amount.
- `TransactionDetailModal`: Refund button shows for admin on a paid transaction,
  hidden for non-admins and already-refunded transactions, and clicking it calls
  the refund endpoint + invalidates the cache.
- `npm run lint`, `npm run check:types`, `npm run check:i18n`, and
  `npm run check:deps` all pass (144 affected tests green).