### PR TITLE
fix(members): payment method management

### DIFF
--- a/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx
+++ b/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx
@@ -7,7 +7,7 @@ import type { Member } from '@/hooks/useMembersCache';
 import type { MemberPaymentMethodData } from '@/services/MembersService';
 import type { SignedWaiverWithTemplateName } from '@/services/WaiversService';
 import { useOrganization } from '@clerk/nextjs';
-import { ArrowRightLeft, Download, MoreVertical, Pencil, Plus, Unlink } from 'lucide-react';
+import { ArrowRightLeft, Download, MoreVertical, Pencil, Plus, Trash2, Unlink } from 'lucide-react';
 import Link from 'next/link';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
@@ -670,6 +670,36 @@ export default function EditMemberPage() {
       setIsLoadingPayment(false);
     }
   }, [memberId]);
+
+  // Per-method mutation state for the payment-method list (delete / set-primary).
+  const [pmActionId, setPmActionId] = useState<string | null>(null);
+  const [pmError, setPmError] = useState<string | null>(null);
+
+  const handleSetPrimaryPaymentMethod = useCallback(async (paymentMethodId: string) => {
+    setPmActionId(paymentMethodId);
+    setPmError(null);
+    try {
+      await client.member.setPrimaryPaymentMethod({ memberId, paymentMethodId });
+      await reloadPaymentMethods();
+    } catch (err) {
+      setPmError(err instanceof Error ? err.message : 'Failed to update the default payment method.');
+    } finally {
+      setPmActionId(null);
+    }
+  }, [memberId, reloadPaymentMethods]);
+
+  const handleDeletePaymentMethod = useCallback(async (paymentMethodId: string) => {
+    setPmActionId(paymentMethodId);
+    setPmError(null);
+    try {
+      await client.member.deletePaymentMethod({ memberId, paymentMethodId });
+      await reloadPaymentMethods();
+    } catch (err) {
+      setPmError(err instanceof Error ? err.message : 'Failed to delete the payment method.');
+    } finally {
+      setPmActionId(null);
+    }
+  }, [memberId, reloadPaymentMethods]);
 
   useEffect(() => {
     void reloadPaymentMethods();
@@ -1378,23 +1408,11 @@ export default function EditMemberPage() {
                       variant="outline"
                       size="sm"
                       onClick={() => setIsEditPaymentMethodOpen(true)}
-                      aria-label={paymentMethods.length === 0 ? 'Add payment method' : 'Edit payment method'}
+                      aria-label="Add payment method"
                     >
-                      {paymentMethods.length === 0
-                        ? (
-                            <>
-                              <Plus className="mr-1 h-4 w-4" />
-                              {' '}
-                              Add
-                            </>
-                          )
-                        : (
-                            <>
-                              <Pencil className="mr-1 h-4 w-4" />
-                              {' '}
-                              Edit
-                            </>
-                          )}
+                      <Plus className="mr-1 h-4 w-4" />
+                      {' '}
+                      Add
                     </Button>
                   )}
                 </div>
@@ -1408,10 +1426,12 @@ export default function EditMemberPage() {
                       )
                     : (
                         <>
-                          {(() => {
-                            const pm = paymentMethods.find(p => p.isDefault) || paymentMethods[0]!;
-                            return (
-                              <div className="flex items-start gap-4">
+                          {pmError && (
+                            <p className="mb-3 text-sm text-destructive">{pmError}</p>
+                          )}
+                          <div className="space-y-3">
+                            {paymentMethods.map(pm => (
+                              <div key={pm.id} className="flex items-center gap-4 rounded-lg border border-border p-3">
                                 <div className="rounded-lg bg-blue-600 p-3">
                                   <span className="text-2xl">{getPaymentTypeIcon(pm.type)}</span>
                                 </div>
@@ -1425,13 +1445,38 @@ export default function EditMemberPage() {
                                       </>
                                     )}
                                   </p>
-                                  <p className="mt-1 text-xs text-muted-foreground">
-                                    {pm.isDefault ? 'Default payment method' : ''}
-                                  </p>
+                                  {pm.isDefault && (
+                                    <p className="mt-1 text-xs text-muted-foreground">Default payment method</p>
+                                  )}
+                                </div>
+                                <div className="flex shrink-0 items-center gap-2">
+                                  {pm.isDefault
+                                    ? (
+                                        <Badge variant="secondary">Default</Badge>
+                                      )
+                                    : (
+                                        <Button
+                                          variant="outline"
+                                          size="sm"
+                                          disabled={pmActionId === pm.id}
+                                          onClick={() => handleSetPrimaryPaymentMethod(pm.id)}
+                                        >
+                                          Set as primary
+                                        </Button>
+                                      )}
+                                  <Button
+                                    variant="outline"
+                                    size="sm"
+                                    disabled={pmActionId === pm.id}
+                                    aria-label="Delete payment method"
+                                    onClick={() => handleDeletePaymentMethod(pm.id)}
+                                  >
+                                    <Trash2 className="h-4 w-4" />
+                                  </Button>
                                 </div>
                               </div>
-                            );
-                          })()}
+                            ))}
+                          </div>
                           {/* Applied Coupon Info */}
                           {appliedCoupon && (
                             <div className="mt-4 rounded-lg border border-green-200 bg-green-50 p-3 dark:border-green-800 dark:bg-green-950/30">

--- a/src/features/members/details/EditPaymentMethodModal.tsx
+++ b/src/features/members/details/EditPaymentMethodModal.tsx
@@ -257,6 +257,7 @@ export function EditPaymentMethodModal({
               <span className="font-medium">{t('ach_tab_label')}</span>
             </button>
           </div>
+          <p className="text-xs text-muted-foreground">{tEdit('tabs_help')}</p>
 
           {form.paymentMethod === 'card' && (
             <div className="space-y-3">

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2220,7 +2220,8 @@
     }
   },
   "EditPaymentMethodModal": {
-    "title": "Edit payment method",
+    "title": "Add payment method",
+    "tabs_help": "Choose whether to add a card or a bank account (ACH).",
     "save_button": "Save",
     "saving_button": "Saving...",
     "cancel_button": "Cancel",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -2225,7 +2225,8 @@
     }
   },
   "EditPaymentMethodModal": {
-    "title": "Modifier le mode de paiement",
+    "title": "Ajouter un mode de paiement",
+    "tabs_help": "Choisissez d'ajouter une carte ou un compte bancaire (ACH).",
     "save_button": "Enregistrer",
     "saving_button": "Enregistrement...",
     "cancel_button": "Annuler",

--- a/src/routers/Member.ts
+++ b/src/routers/Member.ts
@@ -7,12 +7,12 @@ import { audit } from '@/services/AuditService';
 import { sendMemberConfirmationEmail } from '@/services/EmailService';
 import { resolveIQProConfig } from '@/services/IQProConfigService';
 import { cancelMembershipLifecycle, getLifecycleContext, HoldLimitReachedError, holdMembershipLifecycle, reactivateMembershipLifecycle } from '@/services/MemberPaymentService';
-import { addMemberMembership, changeMemberMembership, createMember, getAllMembershipPlans, getFamilyMembers, getHeadOfHouseholdMembers, getHOHForFamilyMember, getMemberPaymentMethods, getMembershipPlans, getMemberTransactions, linkFamilyMember, MemberOnHoldError, removeFully, unlinkFamilyMember, updateMember, updateMemberContactInfo, updateMemberPhoto, updateMemberStatus } from '@/services/MembersService';
+import { addMemberMembership, changeMemberMembership, createMember, deleteMemberPaymentMethod, getAllMembershipPlans, getFamilyMembers, getHeadOfHouseholdMembers, getHOHForFamilyMember, getMemberPaymentMethods, getMembershipPlans, getMemberTransactions, linkFamilyMember, MemberOnHoldError, removeFully, setPrimaryPaymentMethod as setPrimaryPaymentMethodService, unlinkFamilyMember, updateMember, updateMemberContactInfo, updateMemberPhoto, updateMemberStatus } from '@/services/MembersService';
 import { generatePdfFilename } from '@/services/WaiverPdfService';
 import { generateWaiverPdfBuffer } from '@/services/WaiverPdfService.server';
 import { AUDIT_ACTION, AUDIT_ENTITY_TYPE } from '@/types/Audit';
 import { ORG_ROLE } from '@/types/Auth';
-import { CancelMembershipValidation, DeleteMemberValidation, EditMemberValidation, GetHOHForMemberValidation, GetHOHPaymentMethodsValidation, HoldMembershipValidation, LinkFamilyMemberValidation, ListFamilyMembersValidation, MemberPaymentMethodsValidation, MemberTransactionsValidation, MemberValidation, ReactivateMembershipValidation, RemoveFullyMemberValidation, SearchHOHValidation, SendConfirmationEmailValidation, UnlinkFamilyMemberValidation, UpdateMemberContactInfoValidation, UpdateMemberPhotoValidation, UpdateMemberTypeValidation } from '@/validations/MemberValidation';
+import { CancelMembershipValidation, DeleteMemberValidation, EditMemberValidation, GetHOHForMemberValidation, GetHOHPaymentMethodsValidation, HoldMembershipValidation, LinkFamilyMemberValidation, ListFamilyMembersValidation, MemberPaymentMethodsValidation, MemberTransactionsValidation, MemberValidation, PaymentMethodMutationValidation, ReactivateMembershipValidation, RemoveFullyMemberValidation, SearchHOHValidation, SendConfirmationEmailValidation, UnlinkFamilyMemberValidation, UpdateMemberContactInfoValidation, UpdateMemberPhotoValidation, UpdateMemberTypeValidation } from '@/validations/MemberValidation';
 import { guardAuth, guardRole } from './AuthGuards';
 
 export const create = os
@@ -666,6 +666,40 @@ export const listPaymentMethods = os
       status: 'success',
     });
     return { paymentMethods };
+  });
+
+export const deletePaymentMethod = os
+  .input(PaymentMethodMutationValidation)
+  .handler(async ({ input }) => {
+    const context = await guardRole(ORG_ROLE.FRONT_DESK);
+    const result = await deleteMemberPaymentMethod(input.paymentMethodId, input.memberId, context.orgId);
+
+    await audit(context, AUDIT_ACTION.PAYMENT_METHOD_DELETE, AUDIT_ENTITY_TYPE.PAYMENT_METHOD, {
+      entityId: input.paymentMethodId,
+      status: result.deleted ? 'success' : 'failure',
+    });
+
+    if (!result.deleted) {
+      throw new ORPCError('Payment method not found', { status: 404 });
+    }
+    return result;
+  });
+
+export const setPrimaryPaymentMethod = os
+  .input(PaymentMethodMutationValidation)
+  .handler(async ({ input }) => {
+    const context = await guardRole(ORG_ROLE.FRONT_DESK);
+    const result = await setPrimaryPaymentMethodService(input.paymentMethodId, input.memberId, context.orgId);
+
+    await audit(context, AUDIT_ACTION.PAYMENT_METHOD_SET_PRIMARY, AUDIT_ENTITY_TYPE.PAYMENT_METHOD, {
+      entityId: input.paymentMethodId,
+      status: result.updated ? 'success' : 'failure',
+    });
+
+    if (!result.updated) {
+      throw new ORPCError('Payment method not found', { status: 404 });
+    }
+    return result;
   });
 
 export const listMemberTransactions = os

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -22,7 +22,7 @@ import { create as createCoupon, getTotalSavings as getCouponTotalSavings, listA
 import { earningsChart, financialStats, memberAverageChart, membershipStats } from './Dashboard';
 import { create as createEvent, list as listEvents, remove as removeEvent, update as updateEvent } from './Events';
 import { list as listInstructors, updatePhoto as updateInstructorPhoto } from './Instructors';
-import { addMembership, cancelMembership, changeMembership, create as createMember, getHOHForMember, getHOHPaymentMethods, holdMembership, linkFamily, listAllMembershipPlans, listFamily, listMembershipPlans, listMemberTransactions, listPaymentMethods, reactivateMembership, removeFullyMember, remove as removeMember, restore as restoreMember, searchHOH, sendConfirmationEmail, unlinkFamily, updateLastAccessed, update as updateMember, updateContactInfo as updateMemberContactInfo, updatePhoto as updateMemberPhoto, updateMemberType } from './Member';
+import { addMembership, cancelMembership, changeMembership, create as createMember, deletePaymentMethod, getHOHForMember, getHOHPaymentMethods, holdMembership, linkFamily, listAllMembershipPlans, listFamily, listMembershipPlans, listMemberTransactions, listPaymentMethods, reactivateMembership, removeFullyMember, remove as removeMember, restore as restoreMember, searchHOH, sendConfirmationEmail, setPrimaryPaymentMethod, unlinkFamily, updateLastAccessed, update as updateMember, updateContactInfo as updateMemberContactInfo, updatePhoto as updateMemberPhoto, updateMemberType } from './Member';
 import { list as listMembers } from './Members';
 import { create as createMembershipPlan, remove as removeMembershipPlan, update as updateMembershipPlan } from './MembershipPlans';
 import { create as createNoteHandler, list as listNotes, remove as removeNoteHandler, update as updateNoteHandler } from './Notes';
@@ -74,6 +74,8 @@ export const router = {
     listMembershipPlans,
     listAllMembershipPlans,
     listPaymentMethods,
+    deletePaymentMethod,
+    setPrimaryPaymentMethod,
     listMemberTransactions,
     remove: removeMember,
     removeFully: removeFullyMember,

--- a/src/services/MemberPaymentService.ts
+++ b/src/services/MemberPaymentService.ts
@@ -538,15 +538,24 @@ export async function registerPaymentMethod(
     });
 
     const paymentMethodDbId = randomUUID();
-    await db.insert(paymentMethodSchema).values({
-      id: paymentMethodDbId,
-      memberId: params.memberId,
-      iqproPaymentMethodId: pmResult.paymentMethodId,
-      type: params.paymentMethod,
-      firstSix: params.paymentMethod === 'card' ? params.cardFirstSix ?? null : null,
-      last4: pmResult.last4,
-      accountType: params.paymentMethod === 'ach' ? params.achAccountType ?? null : null,
-      isDefault: true,
+    // The newly-added method becomes the default; clear the flag on any existing
+    // methods first so exactly one stays default (avoids multiple defaults when
+    // a member adds a second card/ACH).
+    await db.transaction(async (tx) => {
+      await tx
+        .update(paymentMethodSchema)
+        .set({ isDefault: false })
+        .where(eq(paymentMethodSchema.memberId, params.memberId));
+      await tx.insert(paymentMethodSchema).values({
+        id: paymentMethodDbId,
+        memberId: params.memberId,
+        iqproPaymentMethodId: pmResult.paymentMethodId,
+        type: params.paymentMethod,
+        firstSix: params.paymentMethod === 'card' ? params.cardFirstSix ?? null : null,
+        last4: pmResult.last4,
+        accountType: params.paymentMethod === 'ach' ? params.achAccountType ?? null : null,
+        isDefault: true,
+      });
     });
 
     logger.info('[MemberPayment] Payment method registered (no charge)', { paymentMethodDbId });

--- a/src/services/MembersService.test.ts
+++ b/src/services/MembersService.test.ts
@@ -24,6 +24,7 @@ vi.mock('@/libs/DB', () => ({
         returning: vi.fn(() => Promise.resolve([])),
       })),
     })),
+    transaction: vi.fn(),
   },
 }));
 
@@ -369,6 +370,98 @@ describe('MembersService', () => {
       const result = await getMemberPaymentMethods('member-no-pm', 'org-123');
 
       expect(result).toEqual([]);
+    });
+  });
+
+  // Mocks the org-scoped ownership lookup (findOwnedPaymentMethod) to return the
+  // given row, and returns a `tx` recorder for db.transaction assertions.
+  function mockOwnershipAndTx(owned: { id: string; isDefault: boolean } | null) {
+    const ownershipChain = {
+      from: () => ({ innerJoin: () => ({ where: () => ({ limit: () => Promise.resolve(owned ? [owned] : []) }) }) }),
+    };
+    return ownershipChain;
+  }
+
+  describe('deleteMemberPaymentMethod', () => {
+    it('returns { deleted: false } when the method is not owned by the member/org', async () => {
+      const { db } = await import('@/libs/DB');
+      vi.mocked(db.select).mockReturnValue(mockOwnershipAndTx(null) as never);
+
+      const { deleteMemberPaymentMethod } = await import('./MembersService');
+      const result = await deleteMemberPaymentMethod('pm-x', 'member-1', 'org-1');
+
+      expect(result).toEqual({ deleted: false });
+      expect(db.transaction).not.toHaveBeenCalled();
+    });
+
+    it('deletes and promotes another method to default when the deleted one was default', async () => {
+      const { db } = await import('@/libs/DB');
+      vi.mocked(db.select).mockReturnValue(mockOwnershipAndTx({ id: 'pm-1', isDefault: true }) as never);
+
+      const txDelete = vi.fn(() => ({ where: vi.fn(() => Promise.resolve(undefined)) }));
+      const txUpdateWhere = vi.fn(() => Promise.resolve(undefined));
+      const txUpdate = vi.fn(() => ({ set: vi.fn(() => ({ where: txUpdateWhere })) }));
+      // Inside the tx, the "remaining methods" lookup returns one row to promote.
+      const txSelect = vi.fn(() => ({ from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'pm-2' }]) }) }) }));
+      vi.mocked(db.transaction).mockImplementation(async (cb: any) =>
+        cb({ delete: txDelete, update: txUpdate, select: txSelect }));
+
+      const { deleteMemberPaymentMethod } = await import('./MembersService');
+      const result = await deleteMemberPaymentMethod('pm-1', 'member-1', 'org-1');
+
+      expect(result).toEqual({ deleted: true });
+      expect(txDelete).toHaveBeenCalled();
+      // A remaining method is promoted to default.
+      expect(txUpdate).toHaveBeenCalled();
+    });
+
+    it('does not promote anything when a non-default method is deleted', async () => {
+      const { db } = await import('@/libs/DB');
+      vi.mocked(db.select).mockReturnValue(mockOwnershipAndTx({ id: 'pm-2', isDefault: false }) as never);
+
+      const txDelete = vi.fn(() => ({ where: vi.fn(() => Promise.resolve(undefined)) }));
+      const txUpdate = vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn() })) }));
+      const txSelect = vi.fn();
+      vi.mocked(db.transaction).mockImplementation(async (cb: any) =>
+        cb({ delete: txDelete, update: txUpdate, select: txSelect }));
+
+      const { deleteMemberPaymentMethod } = await import('./MembersService');
+      const result = await deleteMemberPaymentMethod('pm-2', 'member-1', 'org-1');
+
+      expect(result).toEqual({ deleted: true });
+      expect(txDelete).toHaveBeenCalled();
+      // No default was removed, so no promotion lookup/update runs.
+      expect(txSelect).not.toHaveBeenCalled();
+      expect(txUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setPrimaryPaymentMethod', () => {
+    it('returns { updated: false } when the method is not owned', async () => {
+      const { db } = await import('@/libs/DB');
+      vi.mocked(db.select).mockReturnValue(mockOwnershipAndTx(null) as never);
+
+      const { setPrimaryPaymentMethod } = await import('./MembersService');
+      const result = await setPrimaryPaymentMethod('pm-x', 'member-1', 'org-1');
+
+      expect(result).toEqual({ updated: false });
+      expect(db.transaction).not.toHaveBeenCalled();
+    });
+
+    it('unsets all defaults then sets the chosen method as default', async () => {
+      const { db } = await import('@/libs/DB');
+      vi.mocked(db.select).mockReturnValue(mockOwnershipAndTx({ id: 'pm-2', isDefault: false }) as never);
+
+      const setWhere = vi.fn(() => Promise.resolve(undefined));
+      const txUpdate = vi.fn(() => ({ set: vi.fn(() => ({ where: setWhere })) }));
+      vi.mocked(db.transaction).mockImplementation(async (cb: any) => cb({ update: txUpdate }));
+
+      const { setPrimaryPaymentMethod } = await import('./MembersService');
+      const result = await setPrimaryPaymentMethod('pm-2', 'member-1', 'org-1');
+
+      expect(result).toEqual({ updated: true });
+      // Two updates: clear all defaults, then set the chosen one.
+      expect(txUpdate).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/services/MembersService.ts
+++ b/src/services/MembersService.ts
@@ -623,6 +623,96 @@ export async function getMemberPaymentMethods(
 }
 
 /**
+ * Look up a payment method by id and confirm it belongs to the given member in
+ * the given org (payment_method has no org column, so we join through member).
+ * Returns the row (id + isDefault) or null.
+ */
+async function findOwnedPaymentMethod(paymentMethodId: string, memberId: string, organizationId: string) {
+  const rows = await db
+    .select({ id: paymentMethodSchema.id, isDefault: paymentMethodSchema.isDefault })
+    .from(paymentMethodSchema)
+    .innerJoin(memberSchema, eq(paymentMethodSchema.memberId, memberSchema.id))
+    .where(and(
+      eq(paymentMethodSchema.id, paymentMethodId),
+      eq(paymentMethodSchema.memberId, memberId),
+      eq(memberSchema.organizationId, organizationId),
+    ))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+/**
+ * Delete a saved payment method (#218). Org-scoped for safety. If the deleted
+ * method was the default and other methods remain, promotes the most-recent
+ * remaining one to default so the member always has a usable default.
+ *
+ * Returns `{ deleted: false }` when the method doesn't exist or isn't owned by
+ * this member/org. Local DB only — the IQPro vault entry is left in place
+ * (nothing else in the app deletes vault entries either).
+ */
+export async function deleteMemberPaymentMethod(
+  paymentMethodId: string,
+  memberId: string,
+  organizationId: string,
+): Promise<{ deleted: boolean }> {
+  const owned = await findOwnedPaymentMethod(paymentMethodId, memberId, organizationId);
+  if (!owned) {
+    return { deleted: false };
+  }
+
+  return db.transaction(async (tx) => {
+    await tx.delete(paymentMethodSchema).where(eq(paymentMethodSchema.id, paymentMethodId));
+
+    // If we removed the default, promote another remaining method so there's
+    // still a default to charge against.
+    if (owned.isDefault) {
+      const remaining = await tx
+        .select({ id: paymentMethodSchema.id })
+        .from(paymentMethodSchema)
+        .where(eq(paymentMethodSchema.memberId, memberId))
+        .limit(1);
+      const next = remaining[0];
+      if (next) {
+        await tx
+          .update(paymentMethodSchema)
+          .set({ isDefault: true })
+          .where(eq(paymentMethodSchema.id, next.id));
+      }
+    }
+
+    return { deleted: true };
+  });
+}
+
+/**
+ * Mark a saved payment method as the member's default (#226), unsetting the
+ * default flag on all their other methods so exactly one is default.
+ * Org-scoped. Returns `{ updated: false }` when the method isn't owned.
+ */
+export async function setPrimaryPaymentMethod(
+  paymentMethodId: string,
+  memberId: string,
+  organizationId: string,
+): Promise<{ updated: boolean }> {
+  const owned = await findOwnedPaymentMethod(paymentMethodId, memberId, organizationId);
+  if (!owned) {
+    return { updated: false };
+  }
+
+  return db.transaction(async (tx) => {
+    await tx
+      .update(paymentMethodSchema)
+      .set({ isDefault: false })
+      .where(eq(paymentMethodSchema.memberId, memberId));
+    await tx
+      .update(paymentMethodSchema)
+      .set({ isDefault: true })
+      .where(eq(paymentMethodSchema.id, paymentMethodId));
+    return { updated: true };
+  });
+}
+
+/**
  * Get transactions for a specific member within an organization
  * @param memberId - The member ID
  * @param organizationId - The organization ID

--- a/src/types/Audit.test.ts
+++ b/src/types/Audit.test.ts
@@ -25,13 +25,14 @@ describe('Audit Types', () => {
       // + 4 transaction (create + refund + update + view) + 3 tag + 2 image
       // + 12 catalog (6 item + 3 variant + 3 category + 1 stock + 2 image)
       // + 8 waiver (4 template + 1 signed + 3 membership waiver)
-      // + 3 merge field + 1 payment + 1 payment method register + 1 payment method view
+      // + 3 merge field + 1 payment
+      // + 3 payment method (register + delete + set primary) + 1 payment method view
       // + 1 family member link
       // + 1 family member unlink + 1 member convert + 3 saas subscription
       // + 3 note (create + update + delete) + 3 staff (invite + update + remove)
       // + 3 role (create + update + delete) + 1 organization location update
-      // + 2 iqpro config (per-org + platform) + 1 instructor photo update = 98
-      expect(actionCount).toBe(98);
+      // + 2 iqpro config (per-org + platform) + 1 instructor photo update = 100
+      expect(actionCount).toBe(100);
     });
   });
 

--- a/src/types/Audit.ts
+++ b/src/types/Audit.ts
@@ -75,6 +75,8 @@ export const AUDIT_ACTION = {
   // Payment operations
   PAYMENT_PROCESS: 'payment.process',
   PAYMENT_METHOD_REGISTER: 'paymentMethod.register',
+  PAYMENT_METHOD_DELETE: 'paymentMethod.delete',
+  PAYMENT_METHOD_SET_PRIMARY: 'paymentMethod.setPrimary',
   // Read-access logging for saved payment methods (SOC2 CC7.2)
   PAYMENT_METHOD_VIEW: 'paymentMethod.view',
 

--- a/src/validations/MemberValidation.ts
+++ b/src/validations/MemberValidation.ts
@@ -66,6 +66,11 @@ export const MemberPaymentMethodsValidation = z.object({
   memberId: z.string().min(1),
 });
 
+export const PaymentMethodMutationValidation = z.object({
+  memberId: z.string().min(1),
+  paymentMethodId: z.string().min(1),
+});
+
 export const MemberTransactionsValidation = z.object({
   memberId: z.string().min(1),
   limit: z.number().min(1).max(200).optional(),


### PR DESCRIPTION
## Summary

Turns the member payment-method section into a full manager: it now lists every
saved method with per-method "Set as primary" and "Delete" actions, so a newly
added method (e.g. ACH) shows up immediately and members aren't stuck with a
single, non-editable default.

Fixes:

- Fixes #218
- Fixes #226
- Fixes #227
- Fixes #228

## Root causes

- **#228** (added ACH doesn't appear): the payment card rendered ONLY the
  default/first method, so a newly added method — also flagged default — was
  hidden behind the existing one. The modal already refreshed the list.
- **#218 / #226**: no delete or set-primary endpoints existed, and the register
  path hardcoded `isDefault: true` without clearing other defaults, so a member
  could end up with multiple defaults.
- **#227**: the QA instruction referenced an "Add Bank Account" button that
  doesn't exist; the Card/ACH toggle just read "ACH Bank Account" with no
  guidance.

## Changes

### Backend
- **`MembersService.ts`**: new `deleteMemberPaymentMethod` and
  `setPrimaryPaymentMethod`, both org-scoped via a shared `findOwnedPaymentMethod`
  guard (payment_method has no org column, so we join through member). Delete
  promotes another remaining method to default when the removed one was default;
  set-primary unsets all others then sets the chosen one. Both run in a
  transaction to keep exactly one default.
- **`MemberPaymentService.ts`**: the register (capture-only) path now clears
  existing defaults before inserting the new method as default — fixes the
  multiple-defaults drift.
- **`Member.ts` + `index.ts`**: new `member.deletePaymentMethod` and
  `member.setPrimaryPaymentMethod` endpoints (FRONT_DESK), audited, returning 404
  when the method isn't owned by the member/org.
- **`Audit.ts`**: new `PAYMENT_METHOD_DELETE` and `PAYMENT_METHOD_SET_PRIMARY`
  actions.
- **`MemberValidation.ts`**: new `PaymentMethodMutationValidation`
  (`memberId` + `paymentMethodId`).

### Frontend
- **Member edit page**: payment section renders ALL methods as a list. Each row
  shows the type + masked detail, a "Default" badge (or "Set as primary" button
  for non-defaults), and a Delete button, with inline error + per-row loading.
  Header button is now a single "Add".
- **`EditPaymentMethodModal.tsx`**: title → "Add payment method", plus helper
  text under the Card/ACH toggle clarifying it selects the method type (#227).

## Notes

- Delete and set-primary are local-DB only — the IQPro vault entry is left in
  place, consistent with the rest of the app (nothing deletes vault entries).
  True vault deletion would be a follow-up needing an IQPro delete-PM call.

## Tests

- New `MembersService` tests: delete (not-owned / promotes-default /
  no-promote-on-non-default) and set-primary (not-owned / unset-then-set).
- Updated the `AUDIT_ACTION` count assertion (98 → 100) for the two new actions.
- Full suite: 253 files, 4630 tests pass. `npm run lint`, `check:types`,
  `check:i18n`, and `check:deps` all clean.