### PR TITLE
fix(members): persist member conversion, fix upload size

### DIFF
--- a/src/features/members/conversion/ConvertMemberModal.tsx
+++ b/src/features/members/conversion/ConvertMemberModal.tsx
@@ -283,14 +283,28 @@ export const ConvertMemberModal = ({
     }
   };
 
-  const handleConfirmNext = () => {
-    if (conversionType === 'individual-to-hoh') {
-      // Simple conversion — no additional steps needed
+  // Advance to the next step, but run the actual conversion (handleConvert) when
+  // the next step is `success` — i.e. this is the last data-entry step. The
+  // payment step wires handleConvert directly; this covers every other case
+  // where the final step before success is confirm/subscription/waiver:
+  //  - Individual→HOH (steps: confirm → success)
+  //  - HOH→Individual with a membership + payment method already on file
+  //    (steps: confirm → success)
+  //  - HOH→Individual with a payment method but no membership
+  //    (steps: confirm → subscription → waiver → success, no payment step)
+  // Without this, the wizard advanced straight to the success screen and the
+  // conversion RPC never fired, so the member type never changed (#224, #210).
+  const handleStepNext = () => {
+    const currentIndex = wizard.steps.indexOf(wizard.step);
+    const nextStep = wizard.steps[currentIndex + 1];
+    if (nextStep === 'success') {
       handleConvert();
     } else {
       wizard.nextStep();
     }
   };
+
+  const handleConfirmNext = handleStepNext;
 
   const getDialogTitle = (): string => {
     switch (wizard.step) {
@@ -329,7 +343,7 @@ export const ConvertMemberModal = ({
             <MembershipStep
               data={wizard.data}
               onUpdate={updateDataWithRef}
-              onNext={wizard.nextStep}
+              onNext={handleStepNext}
               onBack={wizard.previousStep}
               onCancel={handleCancel}
               isLoading={wizard.isLoading}
@@ -340,7 +354,7 @@ export const ConvertMemberModal = ({
             <WaiverStep
               data={wizard.data}
               onUpdate={updateDataWithRef}
-              onNext={wizard.nextStep}
+              onNext={handleStepNext}
               onBack={wizard.previousStep}
               onCancel={handleCancel}
               isLoading={wizard.isLoading}

--- a/src/hooks/useConvertMemberWizard.test.ts
+++ b/src/hooks/useConvertMemberWizard.test.ts
@@ -127,6 +127,14 @@ describe('useConvertMemberWizard', () => {
       expect(result.current.isLoading).toBe(false);
     });
 
+    it('should expose the computed steps (used to detect the last step before success)', async () => {
+      const { result } = await renderHook(() => useConvertMemberWizard(defaultInit));
+
+      // defaultInit is hoh-to-individual with membership + payment method on file.
+      expect(result.current.steps).toEqual(getStepsForConversion('hoh-to-individual', true, true));
+      expect(result.current.steps).toEqual(['confirm', 'success']);
+    });
+
     it('should include HOH data when provided', async () => {
       const init = {
         ...defaultInit,

--- a/src/hooks/useConvertMemberWizard.ts
+++ b/src/hooks/useConvertMemberWizard.ts
@@ -161,6 +161,7 @@ export const useConvertMemberWizard = (init: ConvertMemberWizardInit) => {
   return {
     step,
     setStep,
+    steps: getSteps(),
     data,
     updateData,
     nextStep,

--- a/src/utils/imageCompression.ts
+++ b/src/utils/imageCompression.ts
@@ -16,10 +16,14 @@ export async function compressImageForStorage(
 ): Promise<ImageCompressionResult> {
   const originalSize = file.size;
 
-  // Compression options optimized for avatar/profile pictures
-  // Target: 400x400px max, 80% JPEG quality = ~50-150KB
+  // Compression options optimized for avatar/profile pictures.
+  // Target: 400x400px max, 80% JPEG quality = ~50-150KB.
+  // maxSizeMB is kept well under the server-side photo cap: base64 encoding
+  // inflates the byte size by ~33%, so a 200KB file → ~267KB data URL, which
+  // stays under the 400KB validation limit (previously 500KB → ~666KB base64
+  // exceeded the old 300KB cap and the upload was rejected — #208/#209/#212).
   const options = {
-    maxSizeMB: 0.5, // 500KB max
+    maxSizeMB: 0.2, // 200KB max
     maxWidthOrHeight: 400, // Resize to max 400px
     useWebWorker: true,
     fileType: 'image/jpeg',

--- a/src/validations/MemberValidation.test.ts
+++ b/src/validations/MemberValidation.test.ts
@@ -109,6 +109,30 @@ describe('MemberValidation', () => {
 
       expect(result.success).toBe(true);
     });
+
+    it('accepts a valid image data URL for photoUrl', () => {
+      const result = MemberValidation.safeParse({
+        email: 'john@example.com',
+        firstName: 'John',
+        lastName: 'Doe',
+        dateOfBirth: '2000-01-01',
+        photoUrl: 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD',
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects a photoUrl exceeding 400KB', () => {
+      const result = MemberValidation.safeParse({
+        email: 'john@example.com',
+        firstName: 'John',
+        lastName: 'Doe',
+        dateOfBirth: '2000-01-01',
+        photoUrl: `data:image/jpeg;base64,${'A'.repeat(400_000)}`,
+      });
+
+      expect(result.success).toBe(false);
+    });
   });
 
   describe('EditMemberValidation schema', () => {
@@ -772,8 +796,8 @@ describe('MemberValidation', () => {
       expect(result.success).toBe(false);
     });
 
-    it('rejects a photoUrl exceeding 300KB', () => {
-      const oversized = `data:image/jpeg;base64,${'A'.repeat(300_000)}`;
+    it('rejects a photoUrl exceeding 400KB', () => {
+      const oversized = `data:image/jpeg;base64,${'A'.repeat(400_000)}`;
       const result = UpdateMemberPhotoValidation.safeParse({
         id: 'member-123',
         photoUrl: oversized,
@@ -782,9 +806,9 @@ describe('MemberValidation', () => {
       expect(result.success).toBe(false);
     });
 
-    it('accepts a photoUrl exactly at the 300KB cap', () => {
+    it('accepts a photoUrl exactly at the 400KB cap', () => {
       const prefix = 'data:image/jpeg;base64,';
-      const padding = 'A'.repeat(300_000 - prefix.length);
+      const padding = 'A'.repeat(400_000 - prefix.length);
       const atCap = `${prefix}${padding}`;
       const result = UpdateMemberPhotoValidation.safeParse({
         id: 'member-123',

--- a/src/validations/MemberValidation.ts
+++ b/src/validations/MemberValidation.ts
@@ -1,5 +1,11 @@
 import * as z from 'zod';
 
+// Base64 data URLs inflate the raw byte size by ~33%. The client compresses
+// avatars to ≤200KB (see compressImageForStorage), so ≤400KB of base64 leaves
+// comfortable headroom while still keeping the request payload manageable.
+const PHOTO_DATA_URL_MAX = 400_000;
+const PHOTO_DATA_URL_REGEX = /^data:image\/(jpeg|png|gif);base64,/;
+
 export const MemberValidation = z.object({
   email: z.string().email(),
   firstName: z.string().min(1),
@@ -16,7 +22,13 @@ export const MemberValidation = z.object({
     zipCode: z.string(),
     country: z.string(),
   }).optional(),
-  photoUrl: z.string().optional(),
+  // Optional avatar as a base64 image data URL, capped so the create payload
+  // stays manageable (same limit as UpdateMemberPhotoValidation).
+  photoUrl: z
+    .string()
+    .max(PHOTO_DATA_URL_MAX, 'Photo data URL must be 400KB or less')
+    .regex(PHOTO_DATA_URL_REGEX, 'photoUrl must be a data URL for an image (jpeg, png, gif)')
+    .optional(),
   status: z.enum(['active', 'hold', 'trial', 'cancelled', 'past due']).optional(),
 });
 
@@ -54,11 +66,11 @@ export const UpdateMemberContactInfoValidation = z.object({
 export const UpdateMemberPhotoValidation = z.object({
   id: z.string().min(1),
   // null clears the photo. When set, must be a base64 data URL of a supported
-  // image type, capped at ~300KB so the request payload stays manageable.
+  // image type, capped so the request payload stays manageable.
   photoUrl: z
     .string()
-    .max(300_000, 'Photo data URL must be 300KB or less')
-    .regex(/^data:image\/(jpeg|png|gif);base64,/, 'photoUrl must be a data URL for an image (jpeg, png, gif)')
+    .max(PHOTO_DATA_URL_MAX, 'Photo data URL must be 400KB or less')
+    .regex(PHOTO_DATA_URL_REGEX, 'photoUrl must be a data URL for an image (jpeg, png, gif)')
     .nullable(),
 });
 


### PR DESCRIPTION
## Summary

Fixes member type conversion silently not persisting, and photo uploads being
rejected because the compression ceiling exceeded the server-side size cap.

Fixes:

- Fixes #210
- Fixes #224
- Fixes #208
- Fixes #209
- Fixes #212

## Group H — conversion doesn't persist (#210, #224)

**Root cause (not what it looked like):** a live DB repro confirmed the service
layer (`updateMember`) writes `memberType` correctly. The real bug was in the
conversion wizard: `handleConvert` (which fires the `updateMemberType` RPC) was
only invoked from the `individual-to-hoh` confirm shortcut and the `payment`
step. When the last step before `success` was `confirm`/`subscription`/`waiver`
instead of `payment`, the wizard advanced straight to the success screen via
`nextStep` and the conversion RPC never fired:

- **#224**: HOH→Individual with no membership but a saved payment method
  (steps: confirm → subscription → waiver → success, no payment step).
- **#210**: HOH→Individual with membership + payment method already on file
  (steps: confirm → success).

**Fix:**
- `useConvertMemberWizard.ts`: expose the computed `steps` array.
- `ConvertMemberModal.tsx`: new `handleStepNext` that runs `handleConvert` when
  the next step is `success`, otherwise advances. Wired into the confirm,
  subscription, and waiver steps. The payment step already called handleConvert.

## Group I — photo upload rejected (#208, #209, #212)

**Root cause:** a compression-vs-validation limit mismatch. The client
compressed avatars to a 500KB ceiling, but base64 encoding inflates size by
~33% (→ ~666KB), while the server capped the base64 data URL at 300KB — so
legitimately-added photos were rejected. (Every photo code path already had
try/catch, so the reported hard crash was not reproducible in current code; this
addresses the concrete underlying rejection bug.)

**Fix:**
- `imageCompression.ts`: tighten `maxSizeMB` 0.5 → 0.2 (200KB file → ~267KB
  base64).
- `MemberValidation.ts`: raise the photo cap 300KB → 400KB for headroom, and add
  the same cap + image-type regex to the create schema (`MemberValidation.photoUrl`),
  which previously had no size or type validation at all.

## Tests

- `useConvertMemberWizard.test.ts`: assert the wizard exposes `steps` (what the
  conversion fix keys off).
- `MemberValidation.test.ts`: update the photo-cap tests 300KB → 400KB and add
  create-schema photo accept/reject cases.
- Full suite: 253 files, 4633 tests pass. `npm run lint`, `check:types`,
  `check:i18n`, and `check:deps` all clean.