### PR TITLE
fix(members/classes): class attendance & sessions, HOH/family fixes, member-detail gaps

### DIFF
--- a/src/app/[locale]/(auth)/dashboard/classes/[classId]/page.tsx
+++ b/src/app/[locale]/(auth)/dashboard/classes/[classId]/page.tsx
@@ -7,9 +7,10 @@ import { ArrowLeft, Trash2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { use, useMemo, useState } from 'react';
+import { use, useEffect, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
+import { ClassAttendanceCard } from '@/features/classes/details/ClassAttendanceCard';
 import { ClassBasicsCard } from '@/features/classes/details/ClassBasicsCard';
 import { ClassScheduleCard } from '@/features/classes/details/ClassScheduleCard';
 import { ClassSettingsCard } from '@/features/classes/details/ClassSettingsCard';
@@ -19,6 +20,7 @@ import { EditClassBasicsModal } from '@/features/classes/details/EditClassBasics
 import { EditClassScheduleModal } from '@/features/classes/details/EditClassScheduleModal';
 import { EditClassSettingsModal } from '@/features/classes/details/EditClassSettingsModal';
 import { EditScheduleInstanceModal } from '@/features/classes/details/EditScheduleInstanceModal';
+import { UpcomingSessionsCard } from '@/features/classes/details/UpcomingSessionsCard';
 import { invalidateClassesCache, useClassesCache } from '@/hooks/useClassesCache';
 import { useHasRole } from '@/hooks/useHasRole';
 import { useProgramsCache } from '@/hooks/useProgramsCache';
@@ -232,6 +234,27 @@ export default function ClassDetailPage({ params }: { params: Promise<PageParams
     [classes, resolvedParams.classId],
   );
 
+  // Fetch the attendance roster + rollup stats for this class (#248). The stats
+  // feed ClassStatsCard; the records render in the roster card below.
+  const [attendance, setAttendance] = useState<Awaited<ReturnType<typeof client.classes.getAttendance>> | null>(null);
+  useEffect(() => {
+    let active = true;
+    client.classes.getAttendance({ classId: resolvedParams.classId })
+      .then((res) => {
+        if (active) {
+          setAttendance(res);
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setAttendance(null);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [resolvedParams.classId]);
+
   // Merge edits from an Edit Basics / Settings / Schedule modal into local
   // state, then persist the whole class via client.classes.update. The update
   // endpoint takes the full class, so we rebuild the payload from the merged
@@ -433,11 +456,11 @@ export default function ClassDetailPage({ params }: { params: Promise<PageParams
         <p className="text-lg text-muted-foreground">{classData.program}</p>
       </div>
 
-      {/* Stats Card */}
+      {/* Stats Card — real numbers from the attendance query (#248) */}
       <ClassStatsCard
-        activeEnrollments={classData.activeEnrollments}
-        averageAttendance={classData.averageAttendance}
-        totalSessions={classData.totalSessions}
+        activeEnrollments={attendance?.stats.activeEnrollments ?? 0}
+        averageAttendance={attendance?.stats.averageAttendance ?? 0}
+        totalSessions={attendance?.stats.totalSessions ?? 0}
         level={classData.level}
       />
 
@@ -473,6 +496,15 @@ export default function ClassDetailPage({ params }: { params: Promise<PageParams
           calendarColor={classData.calendarColor}
           onEdit={canEdit ? () => setIsEditScheduleOpen(true) : undefined}
           onEditInstance={canEdit ? handleEditInstance : undefined}
+        />
+      </div>
+
+      {/* Attendance roster + upcoming sessions (#248) */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        <ClassAttendanceCard records={attendance?.records ?? []} />
+        <UpcomingSessionsCard
+          schedule={rawClass?.schedule ?? []}
+          exceptions={rawClass?.scheduleExceptions ?? []}
         />
       </div>
 

--- a/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx
+++ b/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx
@@ -88,6 +88,7 @@ type MembershipDetailsData = {
   program: string;
   membershipType: string;
   membershipFee: number;
+  signupFee: number;
   paymentFrequency: string;
   registrationDate: string;
   startDate: string;
@@ -197,6 +198,7 @@ function getMemberStatus(status?: string): 'active' | 'on-hold' | 'cancelled' {
 type MembershipPlanInfo = {
   name?: string;
   price?: number;
+  signupFee?: number;
   frequency?: string | null;
   contractLength?: string;
   isTrial?: boolean | null;
@@ -252,6 +254,7 @@ function buildMembershipDetails(
       ...baseDetails,
       membershipType: plan.name,
       membershipFee: plan.price || 0,
+      signupFee: plan.signupFee || 0,
       paymentFrequency: plan.frequency || 'N/A',
       nextPaymentDate: (isPaid && !isOneTime) ? formatMembershipDate(dates?.nextPaymentDate) : 'N/A',
       nextPaymentAmount: isOneTime ? 0 : (plan.price || 0),
@@ -264,6 +267,7 @@ function buildMembershipDetails(
       ...baseDetails,
       membershipType: getSubscriptionMembershipType(membershipType),
       membershipFee: 0,
+      signupFee: 0,
       paymentFrequency: 'N/A',
       nextPaymentDate: 'N/A',
       nextPaymentAmount: 0,
@@ -276,6 +280,7 @@ function buildMembershipDetails(
       ...baseDetails,
       membershipType: 'N/A',
       membershipFee: 0,
+      signupFee: 0,
       paymentFrequency: 'N/A',
       nextPaymentDate: 'N/A',
       nextPaymentAmount: 0,
@@ -287,6 +292,7 @@ function buildMembershipDetails(
     ...baseDetails,
     membershipType: membershipType === 'annual' ? 'Annual' : 'Month-to-Month',
     membershipFee: membershipType === 'annual' ? 1800 : 300,
+    signupFee: 0,
     paymentFrequency: membershipType === 'annual' ? 'Annual' : 'Monthly',
     nextPaymentDate: formatMembershipDate(dates?.nextPaymentDate),
     nextPaymentAmount: membershipType === 'annual' ? 1800 : 300,
@@ -1125,7 +1131,7 @@ export default function EditMemberPage() {
             <p className="text-sm text-muted-foreground">
               {'Linked to '}
               <Link
-                href={`/dashboard/members/${currentHOH.id}`}
+                href={`/${locale}/dashboard/members/${currentHOH.id}/edit`}
                 className="font-medium text-foreground underline-offset-4 hover:underline"
               >
                 {currentHOH.name}
@@ -1224,6 +1230,8 @@ export default function EditMemberPage() {
               isOpen={isEditContactModalOpen}
               onClose={() => setIsEditContactModalOpen(false)}
               memberId={memberId}
+              initialFirstName={state.currentData.firstName || ''}
+              initialLastName={state.currentData.lastName || ''}
               initialEmail={state.currentData.contactInfo.email || ''}
               initialPhone={state.currentData.contactInfo.phone || ''}
               initialDateOfBirth={currentMember?.dateOfBirth ? new Date(currentMember.dateOfBirth) : undefined}
@@ -1299,6 +1307,14 @@ export default function EditMemberPage() {
                             <p className="text-sm text-muted-foreground">Membership Fee</p>
                             <p className="text-right text-sm font-semibold text-foreground">
                               {formatCurrency(state.currentData.membershipDetails.membershipFee)}
+                            </p>
+                          </div>
+                        )}
+                        {state.currentData.membershipDetails.signupFee > 0 && (
+                          <div className="flex items-start justify-between">
+                            <p className="text-sm text-muted-foreground">Signup Fee</p>
+                            <p className="text-right text-sm font-semibold text-foreground">
+                              {formatCurrency(state.currentData.membershipDetails.signupFee)}
                             </p>
                           </div>
                         )}

--- a/src/features/classes/classDataTransformers.test.ts
+++ b/src/features/classes/classDataTransformers.test.ts
@@ -362,6 +362,37 @@ describe('location threading', () => {
   });
 });
 
+describe('custom tags in the grid (#247)', () => {
+  it('carries non-category tags into ClassCardProps.tags', () => {
+    const cls = makeClass({
+      id: 'c1',
+      name: 'Class',
+      schedule: [],
+      tags: [
+        { id: 't1', name: 'Beginner', slug: 'beginner', color: null }, // level → excluded
+        { id: 't2', name: 'Gi', slug: 'gi', color: null }, // style → excluded
+        { id: 't3', name: 'Fundamentals', slug: 'fundamentals', color: null }, // custom → included
+        { id: 't4', name: 'Morning', slug: 'morning', color: null }, // custom → included
+      ],
+    });
+
+    const result = transformClassToCardProps(cls);
+
+    expect(result.tags).toEqual(['Fundamentals', 'Morning']);
+    // The level/type/style badges are still derived, not duplicated as extra tags.
+    expect(result.level).toBe('Beginner');
+    expect(result.style).toBe('Gi');
+    expect(result.tags).not.toContain('Beginner');
+    expect(result.tags).not.toContain('Gi');
+  });
+
+  it('yields an empty tags array when there are no custom tags', () => {
+    const cls = makeClass({ id: 'c1', name: 'Class', schedule: [], tags: [] });
+
+    expect(transformClassToCardProps(cls).tags).toEqual([]);
+  });
+});
+
 // =============================================================================
 // INSTRUCTOR RESOLUTION
 // =============================================================================

--- a/src/features/classes/classDataTransformers.ts
+++ b/src/features/classes/classDataTransformers.ts
@@ -124,13 +124,26 @@ export function transformClassToCardProps(
     instructorLookup,
   );
 
+  const level = extractLevel(classData.tags);
+  const type = extractType(classData.tags);
+  const style = extractStyle(classData.tags);
+
+  // Any tag not already surfaced as the level/type/style badge is shown as an
+  // extra badge, so custom tags added on the class detail page appear in the
+  // grid instead of being silently dropped (#247).
+  const categoryTags = new Set([level, type, style]);
+  const extraTags = classData.tags
+    .map(t => t.name)
+    .filter(name => !categoryTags.has(name));
+
   return {
     id: classData.id,
     name: classData.name,
     description: classData.description || '',
-    level: extractLevel(classData.tags),
-    type: extractType(classData.tags),
-    style: extractStyle(classData.tags),
+    level,
+    type,
+    style,
+    tags: extraTags,
     schedule: transformSchedule(classData.schedule),
     location,
     instructors,

--- a/src/features/classes/details/ClassAttendanceCard.tsx
+++ b/src/features/classes/details/ClassAttendanceCard.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import type { ClassAttendanceRecord } from '@/services/ClassesService';
+import { useTranslations } from 'next-intl';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Card } from '@/components/ui/card';
+
+type ClassAttendanceCardProps = {
+  records: ClassAttendanceRecord[];
+};
+
+function initials(first: string, last: string): string {
+  return `${first?.[0] ?? ''}${last?.[0] ?? ''}`.toUpperCase() || '?';
+}
+
+function formatDate(date: Date | string): string {
+  return new Date(date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+function formatTime(date: Date | string | null): string {
+  if (!date) {
+    return '—';
+  }
+  return new Date(date).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+}
+
+/**
+ * Attendance roster for a class — past check-ins with member, date, and
+ * check-in/out times. Renders an empty state when there are no records (#248).
+ */
+export function ClassAttendanceCard({ records }: ClassAttendanceCardProps) {
+  const t = useTranslations('ClassDetailPage.AttendanceCard');
+
+  return (
+    <Card className="p-6">
+      <h2 className="mb-4 text-lg font-semibold text-foreground">{t('title')}</h2>
+      {records.length === 0
+        ? (
+            <p className="text-sm text-muted-foreground">{t('empty')}</p>
+          )
+        : (
+            <div className="space-y-3">
+              {records.map(r => (
+                <div key={r.id} className="flex items-center gap-3 rounded-lg border border-border p-3">
+                  <Avatar className="h-9 w-9 shrink-0">
+                    {r.memberPhotoUrl && <AvatarImage src={r.memberPhotoUrl} alt={`${r.memberFirstName} ${r.memberLastName}`} />}
+                    <AvatarFallback>{initials(r.memberFirstName, r.memberLastName)}</AvatarFallback>
+                  </Avatar>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate font-medium text-foreground">{`${r.memberFirstName} ${r.memberLastName}`.trim()}</p>
+                    <p className="text-xs text-muted-foreground">{formatDate(r.attendanceDate)}</p>
+                  </div>
+                  <div className="shrink-0 text-right text-xs text-muted-foreground">
+                    <p>{t('checked_in', { time: formatTime(r.checkInTime) })}</p>
+                    {r.checkOutTime && <p>{t('checked_out', { time: formatTime(r.checkOutTime) })}</p>}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+    </Card>
+  );
+}

--- a/src/features/classes/details/UpcomingSessionsCard.tsx
+++ b/src/features/classes/details/UpcomingSessionsCard.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import type { ClassSchedule, ClassScheduleException } from '@/services/ClassesService';
+import { useTranslations } from 'next-intl';
+import { useMemo } from 'react';
+import { Card } from '@/components/ui/card';
+
+type UpcomingSessionsCardProps = {
+  schedule: ClassSchedule[];
+  exceptions: ClassScheduleException[];
+  /** How many weeks ahead to project. */
+  weeksAhead?: number;
+  /** Max sessions to show. */
+  limit?: number;
+};
+
+type UpcomingSession = {
+  key: string;
+  date: Date;
+  startTime: string;
+  endTime: string;
+  cancelled: boolean;
+};
+
+const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+function sameDay(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+}
+
+function formatTime(hhmm: string): string {
+  const [h = '0', m = '00'] = hhmm.split(':');
+  const hour = Number.parseInt(h, 10);
+  const period = hour >= 12 ? 'PM' : 'AM';
+  const display = hour % 12 || 12;
+  return `${display}:${m.padStart(2, '0')} ${period}`;
+}
+
+/**
+ * Projects the recurring weekly schedule forward and lists the next few
+ * sessions, marking any date with a cancellation exception as cancelled (#248).
+ * Pure client-side computation from the schedule instances + exceptions.
+ */
+function computeUpcoming(
+  schedule: ClassSchedule[],
+  exceptions: ClassScheduleException[],
+  from: Date,
+  weeksAhead: number,
+): UpcomingSession[] {
+  const sessions: UpcomingSession[] = [];
+  const horizonDays = weeksAhead * 7;
+
+  for (let offset = 0; offset <= horizonDays; offset++) {
+    const day = new Date(from.getFullYear(), from.getMonth(), from.getDate() + offset);
+    const dow = day.getDay();
+    for (const s of schedule) {
+      if (s.dayOfWeek !== dow) {
+        continue;
+      }
+      const cancellation = exceptions.find(
+        e => e.exceptionType === 'cancelled' && sameDay(new Date(e.exceptionDate), day),
+      );
+      const modification = exceptions.find(
+        e => e.exceptionType !== 'cancelled' && sameDay(new Date(e.exceptionDate), day),
+      );
+      sessions.push({
+        key: `${s.id}-${day.toISOString().slice(0, 10)}`,
+        date: day,
+        startTime: modification?.newStartTime ?? s.startTime,
+        endTime: modification?.newEndTime ?? s.endTime,
+        cancelled: Boolean(cancellation),
+      });
+    }
+  }
+  return sessions;
+}
+
+export function UpcomingSessionsCard({ schedule, exceptions, weeksAhead = 4, limit = 8 }: UpcomingSessionsCardProps) {
+  const t = useTranslations('ClassDetailPage.UpcomingSessionsCard');
+
+  const sessions = useMemo(() => {
+    // `new Date()` is evaluated once per render; acceptable for a read-only view.
+    const now = new Date();
+    return computeUpcoming(schedule, exceptions, now, weeksAhead).slice(0, limit);
+  }, [schedule, exceptions, weeksAhead, limit]);
+
+  return (
+    <Card className="p-6">
+      <h2 className="mb-4 text-lg font-semibold text-foreground">{t('title')}</h2>
+      {sessions.length === 0
+        ? (
+            <p className="text-sm text-muted-foreground">{t('empty')}</p>
+          )
+        : (
+            <div className="space-y-2">
+              {sessions.map(s => (
+                <div key={s.key} className="flex items-center justify-between rounded-lg border border-border p-3">
+                  <div>
+                    <p className="font-medium text-foreground">
+                      {DAY_NAMES[s.date.getDay()]}
+                      {', '}
+                      {s.date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {formatTime(s.startTime)}
+                      {' – '}
+                      {formatTime(s.endTime)}
+                    </p>
+                  </div>
+                  {s.cancelled && (
+                    <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
+                      {t('cancelled')}
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+    </Card>
+  );
+}

--- a/src/features/members/details/EditContactInfoModal.test.tsx
+++ b/src/features/members/details/EditContactInfoModal.test.tsx
@@ -28,6 +28,8 @@ describe('EditContactInfoModal', () => {
     isOpen: true,
     onClose: vi.fn(),
     memberId: 'member-123',
+    initialFirstName: 'Test',
+    initialLastName: 'Member',
     initialEmail: 'test@example.com',
     initialPhone: '(555) 123-4567',
     initialAddress: {

--- a/src/features/members/details/EditContactInfoModal.tsx
+++ b/src/features/members/details/EditContactInfoModal.tsx
@@ -36,6 +36,8 @@ type EditContactInfoModalProps = {
   isOpen: boolean;
   onClose: () => void;
   memberId: string;
+  initialFirstName: string;
+  initialLastName: string;
   initialEmail: string;
   initialPhone: string;
   initialDateOfBirth?: Date;
@@ -52,6 +54,8 @@ export function EditContactInfoModal({
   isOpen,
   onClose,
   memberId,
+  initialFirstName,
+  initialLastName,
   initialEmail,
   initialPhone,
   initialDateOfBirth,
@@ -60,6 +64,8 @@ export function EditContactInfoModal({
   const t = useTranslations('EditContactInfoModal');
   const router = useRouter();
 
+  const [firstName, setFirstName] = useState(initialFirstName);
+  const [lastName, setLastName] = useState(initialLastName);
   const [email, setEmail] = useState(initialEmail);
   const [phone, setPhone] = useState(initialPhone);
   const [dateOfBirth, setDateOfBirth] = useState<Date | undefined>(initialDateOfBirth);
@@ -84,13 +90,15 @@ export function EditContactInfoModal({
     setAddress(prev => ({ ...prev, [field]: value }));
   };
 
+  const isFirstNameInvalid = touched.firstName && !firstName.trim();
+  const isLastNameInvalid = touched.lastName && !lastName.trim();
   const isEmailInvalid = touched.email && (email ? !isValidEmail(email) : true);
   const isPhoneInvalid = touched.phone && !phone;
 
   const isAddressComplete = address.street && address.city && address.state && address.zipCode && address.country;
   const isAddressPartiallyFilled = address.street || address.city || address.state || address.zipCode;
 
-  const isFormValid = email && isValidEmail(email) && phone && (!isAddressPartiallyFilled || isAddressComplete);
+  const isFormValid = firstName.trim() && lastName.trim() && email && isValidEmail(email) && phone && (!isAddressPartiallyFilled || isAddressComplete);
 
   const handleSubmit = async () => {
     try {
@@ -110,6 +118,8 @@ export function EditContactInfoModal({
 
       await client.member.updateContactInfo({
         id: memberId,
+        firstName: firstName.trim(),
+        lastName: lastName.trim(),
         email,
         phone: phone || null,
         ...(dateOfBirth ? { dateOfBirth } : {}),
@@ -160,6 +170,35 @@ export function EditContactInfoModal({
           )}
 
           <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium text-foreground">{t('first_name_label')}</label>
+                <Input
+                  placeholder={t('first_name_placeholder')}
+                  value={firstName}
+                  onChange={e => setFirstName(e.target.value)}
+                  onBlur={() => handleInputBlur('firstName')}
+                  error={isFirstNameInvalid}
+                />
+                {isFirstNameInvalid && (
+                  <p className="text-xs text-destructive">{t('first_name_error')}</p>
+                )}
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium text-foreground">{t('last_name_label')}</label>
+                <Input
+                  placeholder={t('last_name_placeholder')}
+                  value={lastName}
+                  onChange={e => setLastName(e.target.value)}
+                  onBlur={() => handleInputBlur('lastName')}
+                  error={isLastNameInvalid}
+                />
+                {isLastNameInvalid && (
+                  <p className="text-xs text-destructive">{t('last_name_error')}</p>
+                )}
+              </div>
+            </div>
+
             <div className="space-y-1.5">
               <label className="text-sm font-medium text-foreground">{t('email_label')}</label>
               <Input

--- a/src/features/members/wizard/AddFamilyMembersModal.tsx
+++ b/src/features/members/wizard/AddFamilyMembersModal.tsx
@@ -49,6 +49,7 @@ export const AddFamilyMembersModal = ({
   // payment call. On payment decline + cancel, this is what we pass to
   // client.member.removeFully to roll back the half-finished signup (#132).
   const createdMemberIdRef = useRef<string | undefined>(undefined);
+  const createdMemberMembershipIdRef = useRef<string | undefined>(undefined);
 
   // Re-entrancy guard for handleFamilyMemberSubmit — see AddMemberModal for rationale.
   const submittingRef = useRef(false);
@@ -104,6 +105,7 @@ export const AddFamilyMembersModal = ({
     cardFirstSixRef.current = undefined;
     cardLastFourRef.current = undefined;
     createdMemberIdRef.current = undefined;
+    createdMemberMembershipIdRef.current = undefined;
     submittingRef.current = false;
     wizard.reset();
     onCloseAction();
@@ -117,6 +119,7 @@ export const AddFamilyMembersModal = ({
     cardFirstSixRef.current = undefined;
     cardLastFourRef.current = undefined;
     createdMemberIdRef.current = undefined;
+    createdMemberMembershipIdRef.current = undefined;
     submittingRef.current = false;
     wizard.reset();
     onCloseAction();
@@ -128,6 +131,7 @@ export const AddFamilyMembersModal = ({
     cardFirstSixRef.current = undefined;
     cardLastFourRef.current = undefined;
     createdMemberIdRef.current = undefined;
+    createdMemberMembershipIdRef.current = undefined;
     submittingRef.current = false;
     wizard.resetForNextMember();
     setPaymentStepKey(prev => prev + 1);
@@ -230,51 +234,62 @@ export const AddFamilyMembersModal = ({
         photoUrl = await fileToDataUrl(wizard.data.photoFile);
       }
 
-      // 1. Create the member
-      const result = await client.member.create({
-        email: wizard.data.email,
-        firstName: wizard.data.firstName,
-        lastName: wizard.data.lastName,
-        phone: wizard.data.phone,
-        dateOfBirth: wizard.data.dateOfBirth!,
-        memberType: 'family-member' as const,
-        ...(wizard.data.membershipPlanId && { membershipPlanId: wizard.data.membershipPlanId }),
-        ...(addressPayload && { address: addressPayload }),
-        ...(photoUrl && { photoUrl }),
-        ...(wizard.data.appliedCoupon && {
-          appliedCoupon: {
-            id: wizard.data.appliedCoupon.id,
-            code: wizard.data.appliedCoupon.code,
-            type: wizard.data.appliedCoupon.type,
-            amount: wizard.data.appliedCoupon.amount,
-            description: wizard.data.appliedCoupon.description,
-          },
-        }),
-      });
-      // Track the new member's id so handleCancel can roll back the whole
-      // signup chain if the user bails after a payment decline (#132).
-      createdMemberIdRef.current = result.id;
-
-      // 2. Create signed waiver if applicable
-      if (
-        result.id
-        && wizard.data.waiverTemplateId
-        && wizard.data.waiverSignatureDataUrl
-        && wizard.data.waiverRenderedContent
-        && !wizard.data.waiverSkipped
-      ) {
-        await client.waivers.createSignedWaiver(
-          buildSignedWaiverPayload(wizard.data, result.id),
-        );
-      }
-
-      // 3. Link family member to HOH
-      if (result.id) {
-        await client.member.linkFamilyMember({
-          memberId: result.id,
-          hohMemberId: hohMember.id,
-          relationship: 'family-member',
+      // Steps 1-3 (create member, sign waiver, link to HOH) run ONCE. On a
+      // payment-decline "Try Again", the member already exists — re-running
+      // create would spawn a duplicate active member on every retry (#220). If
+      // we already created one, reuse it and jump straight to payment.
+      let result: { id: string | undefined; memberMembershipId?: string };
+      if (createdMemberIdRef.current) {
+        result = { id: createdMemberIdRef.current, memberMembershipId: createdMemberMembershipIdRef.current };
+      } else {
+        // 1. Create the member
+        const created = await client.member.create({
+          email: wizard.data.email,
+          firstName: wizard.data.firstName,
+          lastName: wizard.data.lastName,
+          phone: wizard.data.phone,
+          dateOfBirth: wizard.data.dateOfBirth!,
+          memberType: 'family-member' as const,
+          ...(wizard.data.membershipPlanId && { membershipPlanId: wizard.data.membershipPlanId }),
+          ...(addressPayload && { address: addressPayload }),
+          ...(photoUrl && { photoUrl }),
+          ...(wizard.data.appliedCoupon && {
+            appliedCoupon: {
+              id: wizard.data.appliedCoupon.id,
+              code: wizard.data.appliedCoupon.code,
+              type: wizard.data.appliedCoupon.type,
+              amount: wizard.data.appliedCoupon.amount,
+              description: wizard.data.appliedCoupon.description,
+            },
+          }),
         });
+        result = created;
+        // Track the new member's id so a retry reuses it and handleCancel can
+        // roll back the whole signup chain if the user bails after a decline.
+        createdMemberIdRef.current = created.id;
+        createdMemberMembershipIdRef.current = created.memberMembershipId;
+
+        // 2. Create signed waiver if applicable
+        if (
+          created.id
+          && wizard.data.waiverTemplateId
+          && wizard.data.waiverSignatureDataUrl
+          && wizard.data.waiverRenderedContent
+          && !wizard.data.waiverSkipped
+        ) {
+          await client.waivers.createSignedWaiver(
+            buildSignedWaiverPayload(wizard.data, created.id),
+          );
+        }
+
+        // 3. Link family member to HOH
+        if (created.id) {
+          await client.member.linkFamilyMember({
+            memberId: created.id,
+            hohMemberId: hohMember.id,
+            relationship: 'family-member',
+          });
+        }
       }
 
       // 4. Process payment. Recurring (post-coupon) goes in `amount`; the

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1427,6 +1427,17 @@
     "not_found": "Class not found",
     "back_to_classes": "Back to Classes",
     "delete_button": "Delete Class",
+    "AttendanceCard": {
+      "title": "Attendance Roster",
+      "empty": "No check-ins recorded yet.",
+      "checked_in": "In {time}",
+      "checked_out": "Out {time}"
+    },
+    "UpcomingSessionsCard": {
+      "title": "Upcoming Sessions",
+      "empty": "No upcoming sessions scheduled.",
+      "cancelled": "Cancelled"
+    },
     "StatsCard": {
       "active_enrollments": "Active Enrollments",
       "average_attendance": "Avg. Attendance",
@@ -1624,6 +1635,12 @@
   },
   "EditContactInfoModal": {
     "title": "Edit Contact Information",
+    "first_name_label": "First Name",
+    "first_name_placeholder": "John",
+    "first_name_error": "Please enter a first name",
+    "last_name_label": "Last Name",
+    "last_name_placeholder": "Doe",
+    "last_name_error": "Please enter a last name",
     "email_label": "Email",
     "email_placeholder": "you@example.com",
     "email_error": "Please enter a valid email address",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1431,6 +1431,17 @@
     "not_found": "Cours introuvable",
     "back_to_classes": "Retour aux cours",
     "delete_button": "Supprimer le cours",
+    "AttendanceCard": {
+      "title": "Liste de présence",
+      "empty": "Aucune présence enregistrée pour le moment.",
+      "checked_in": "Arrivée {time}",
+      "checked_out": "Départ {time}"
+    },
+    "UpcomingSessionsCard": {
+      "title": "Séances à venir",
+      "empty": "Aucune séance à venir planifiée.",
+      "cancelled": "Annulée"
+    },
     "StatsCard": {
       "active_enrollments": "Inscriptions actives",
       "average_attendance": "Présence moyenne",
@@ -1628,6 +1639,12 @@
   },
   "EditContactInfoModal": {
     "title": "Modifier les informations de contact",
+    "first_name_label": "Prénom",
+    "first_name_placeholder": "Jean",
+    "first_name_error": "Veuillez entrer un prénom",
+    "last_name_label": "Nom",
+    "last_name_placeholder": "Dupont",
+    "last_name_error": "Veuillez entrer un nom",
     "email_label": "Email",
     "email_placeholder": "vous@exemple.com",
     "email_error": "Veuillez entrer une adresse email valide",

--- a/src/routers/Classes.ts
+++ b/src/routers/Classes.ts
@@ -4,6 +4,7 @@ import {
   ClassSlugAlreadyExistsError,
   createClass,
   deleteScheduleException,
+  getClassAttendance,
   getClassTags,
   getOrganizationClasses,
   softDeleteClass,
@@ -16,6 +17,7 @@ import {
   CreateClassValidation,
   DeleteClassValidation,
   DeleteScheduleExceptionValidation,
+  GetClassAttendanceValidation,
   UpdateClassValidation,
   UpsertScheduleExceptionValidation,
 } from '@/validations/ClassesValidation';
@@ -36,6 +38,14 @@ export const tags = os.handler(async () => {
 
   return { tags: classTags };
 });
+
+export const getAttendance = os
+  .input(GetClassAttendanceValidation)
+  .handler(async ({ input }) => {
+    const { orgId } = await guardRole(ORG_ROLE.FRONT_DESK);
+
+    return getClassAttendance(input.classId, orgId);
+  });
 
 export const create = os
   .input(CreateClassValidation)

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -17,7 +17,7 @@ import {
   variantRemove,
   variantUpdate,
 } from './Catalog';
-import { tags as classTags, create as createClass, list as listClasses, remove as removeClass, removeException as removeClassException, update as updateClass, upsertException as upsertClassException } from './Classes';
+import { tags as classTags, create as createClass, getAttendance as getClassAttendance, list as listClasses, remove as removeClass, removeException as removeClassException, update as updateClass, upsertException as upsertClassException } from './Classes';
 import { create as createCoupon, getTotalSavings as getCouponTotalSavings, listActive as listActiveCoupons, list as listCoupons, remove as removeCoupon, update as updateCoupon } from './Coupons';
 import { earningsChart, financialStats, memberAverageChart, membershipStats } from './Dashboard';
 import { create as createEvent, list as listEvents, remove as removeEvent, update as updateEvent } from './Events';
@@ -96,6 +96,7 @@ export const router = {
   classes: {
     list: listClasses,
     tags: classTags,
+    getAttendance: getClassAttendance,
     create: createClass,
     update: updateClass,
     remove: removeClass,

--- a/src/services/ClassesService.ts
+++ b/src/services/ClassesService.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, desc, eq, inArray } from 'drizzle-orm';
 import { db } from '@/libs/DB';
 import {
   attendanceSchema,
@@ -7,6 +7,7 @@ import {
   classScheduleInstanceSchema,
   classSchema,
   classTagSchema,
+  memberSchema,
   programSchema,
   tagSchema,
 } from '@/models/Schema';
@@ -202,6 +203,99 @@ export async function getOrganizationClasses(organizationId: string): Promise<Cl
 export async function getClassById(classId: string, organizationId: string): Promise<ClassData | null> {
   const classes = await getOrganizationClasses(organizationId);
   return classes.find(c => c.id === classId) || null;
+}
+
+export type ClassAttendanceRecord = {
+  id: string;
+  memberId: string;
+  memberFirstName: string;
+  memberLastName: string;
+  memberPhotoUrl: string | null;
+  attendanceDate: Date;
+  checkInTime: Date;
+  checkOutTime: Date | null;
+  dayOfWeek: number | null;
+  startTime: string | null;
+};
+
+export type ClassAttendanceData = {
+  records: ClassAttendanceRecord[];
+  stats: {
+    totalSessions: number; // distinct schedule instances that have any check-in
+    activeEnrollments: number; // distinct members who have attended
+    averageAttendance: number; // avg check-ins per attended session
+  };
+};
+
+/**
+ * Get the attendance roster + rollup stats for a class. Attendance rows join
+ * to the class's schedule instances (attendance.classScheduleInstanceId) and to
+ * the member for display. Org-scoped via the attendance org column.
+ */
+export async function getClassAttendance(classId: string, organizationId: string): Promise<ClassAttendanceData> {
+  // The class's schedule instances — attendance references these.
+  const instances = await db
+    .select({ id: classScheduleInstanceSchema.id })
+    .from(classScheduleInstanceSchema)
+    .where(eq(classScheduleInstanceSchema.classId, classId));
+  const instanceIds = instances.map(i => i.id);
+
+  if (instanceIds.length === 0) {
+    return { records: [], stats: { totalSessions: 0, activeEnrollments: 0, averageAttendance: 0 } };
+  }
+
+  const rows = await db
+    .select({
+      id: attendanceSchema.id,
+      memberId: attendanceSchema.memberId,
+      memberFirstName: memberSchema.firstName,
+      memberLastName: memberSchema.lastName,
+      memberPhotoUrl: memberSchema.photoUrl,
+      attendanceDate: attendanceSchema.attendanceDate,
+      checkInTime: attendanceSchema.checkInTime,
+      checkOutTime: attendanceSchema.checkOutTime,
+      classScheduleInstanceId: attendanceSchema.classScheduleInstanceId,
+      dayOfWeek: classScheduleInstanceSchema.dayOfWeek,
+      startTime: classScheduleInstanceSchema.startTime,
+    })
+    .from(attendanceSchema)
+    .innerJoin(memberSchema, eq(attendanceSchema.memberId, memberSchema.id))
+    .leftJoin(classScheduleInstanceSchema, eq(attendanceSchema.classScheduleInstanceId, classScheduleInstanceSchema.id))
+    .where(and(
+      eq(attendanceSchema.organizationId, organizationId),
+      inArray(attendanceSchema.classScheduleInstanceId, instanceIds),
+    ))
+    .orderBy(desc(attendanceSchema.attendanceDate));
+
+  const records: ClassAttendanceRecord[] = rows.map(r => ({
+    id: r.id,
+    memberId: r.memberId,
+    memberFirstName: r.memberFirstName,
+    memberLastName: r.memberLastName,
+    memberPhotoUrl: r.memberPhotoUrl,
+    attendanceDate: r.attendanceDate,
+    checkInTime: r.checkInTime,
+    checkOutTime: r.checkOutTime,
+    dayOfWeek: r.dayOfWeek,
+    startTime: r.startTime,
+  }));
+
+  const uniqueMembers = new Set(rows.map(r => r.memberId));
+  // A "session" here = a distinct (instance, calendar-day) the class actually met.
+  const sessionKeys = new Set(
+    rows.map(r => `${r.classScheduleInstanceId ?? 'none'}|${r.attendanceDate.toISOString().slice(0, 10)}`),
+  );
+  const totalSessions = sessionKeys.size;
+  const averageAttendance = totalSessions > 0 ? Math.round(rows.length / totalSessions) : 0;
+
+  return {
+    records,
+    stats: {
+      totalSessions,
+      activeEnrollments: uniqueMembers.size,
+      averageAttendance,
+    },
+  };
 }
 
 // =============================================================================

--- a/src/services/MembersService.test.ts
+++ b/src/services/MembersService.test.ts
@@ -139,6 +139,8 @@ describe('MembersService', () => {
       const { updateMemberContactInfo } = await import('./MembersService');
       const input = {
         id: 'member-123',
+        firstName: 'Test',
+        lastName: 'Member',
         email: 'updated@example.com',
         phone: '(555) 999-8888',
       };
@@ -153,6 +155,8 @@ describe('MembersService', () => {
       const { updateMemberContactInfo } = await import('./MembersService');
       const input = {
         id: 'member-123',
+        firstName: 'Test',
+        lastName: 'Member',
         email: 'updated@example.com',
         phone: null,
       };
@@ -166,6 +170,8 @@ describe('MembersService', () => {
       const { updateMemberContactInfo } = await import('./MembersService');
       const input = {
         id: 'member-123',
+        firstName: 'Test',
+        lastName: 'Member',
         email: 'updated@example.com',
         phone: '(555) 999-8888',
         address: {
@@ -186,6 +192,8 @@ describe('MembersService', () => {
       const { updateMemberContactInfo } = await import('./MembersService');
       const input = {
         id: 'member-123',
+        firstName: 'Test',
+        lastName: 'Member',
         email: 'updated@example.com',
         phone: '(555) 999-8888',
         address: {
@@ -215,6 +223,8 @@ describe('MembersService', () => {
       const dob = new Date('1990-01-15');
       await updateMemberContactInfo({
         id: 'member-123',
+        firstName: 'Test',
+        lastName: 'Member',
         email: 'updated@example.com',
         phone: '(555) 999-8888',
         dateOfBirth: dob,
@@ -239,6 +249,8 @@ describe('MembersService', () => {
       const { updateMemberContactInfo } = await import('./MembersService');
       await updateMemberContactInfo({
         id: 'member-123',
+        firstName: 'Test',
+        lastName: 'Member',
         email: 'updated@example.com',
         phone: '(555) 999-8888',
       }, 'org-123');
@@ -485,12 +497,17 @@ describe('MembersService', () => {
         },
       ];
 
+      // First select() resolves the member's family links (may be empty).
+      const mockFamilyFrom = vi.fn(() => ({ where: vi.fn(() => Promise.resolve([])) }));
+      // Second select() is the transaction query.
       const mockLimit = vi.fn(() => Promise.resolve(mockTransactions));
       const mockOrderBy = vi.fn(() => ({ limit: mockLimit }));
       const mockWhere = vi.fn(() => ({ orderBy: mockOrderBy }));
       const mockInnerJoin = vi.fn(() => ({ where: mockWhere }));
       const mockFrom = vi.fn(() => ({ innerJoin: mockInnerJoin }));
-      vi.mocked(db.select).mockReturnValue({ from: mockFrom } as never);
+      vi.mocked(db.select)
+        .mockReturnValueOnce({ from: mockFamilyFrom } as never)
+        .mockReturnValueOnce({ from: mockFrom } as never);
 
       const { getMemberTransactions } = await import('./MembersService');
       const result = await getMemberTransactions('member-123', 'org-123');
@@ -502,12 +519,15 @@ describe('MembersService', () => {
     it('should return empty array when no transactions exist', async () => {
       const { db } = await import('@/libs/DB');
 
+      const mockFamilyFrom = vi.fn(() => ({ where: vi.fn(() => Promise.resolve([])) }));
       const mockLimit = vi.fn(() => Promise.resolve([]));
       const mockOrderBy = vi.fn(() => ({ limit: mockLimit }));
       const mockWhere = vi.fn(() => ({ orderBy: mockOrderBy }));
       const mockInnerJoin = vi.fn(() => ({ where: mockWhere }));
       const mockFrom = vi.fn(() => ({ innerJoin: mockInnerJoin }));
-      vi.mocked(db.select).mockReturnValue({ from: mockFrom } as never);
+      vi.mocked(db.select)
+        .mockReturnValueOnce({ from: mockFamilyFrom } as never)
+        .mockReturnValueOnce({ from: mockFrom } as never);
 
       const { getMemberTransactions } = await import('./MembersService');
       const result = await getMemberTransactions('member-no-tx', 'org-123');
@@ -518,12 +538,15 @@ describe('MembersService', () => {
     it('should respect custom limit parameter', async () => {
       const { db } = await import('@/libs/DB');
 
+      const mockFamilyFrom = vi.fn(() => ({ where: vi.fn(() => Promise.resolve([])) }));
       const mockLimit = vi.fn(() => Promise.resolve([]));
       const mockOrderBy = vi.fn(() => ({ limit: mockLimit }));
       const mockWhere = vi.fn(() => ({ orderBy: mockOrderBy }));
       const mockInnerJoin = vi.fn(() => ({ where: mockWhere }));
       const mockFrom = vi.fn(() => ({ innerJoin: mockInnerJoin }));
-      vi.mocked(db.select).mockReturnValue({ from: mockFrom } as never);
+      vi.mocked(db.select)
+        .mockReturnValueOnce({ from: mockFamilyFrom } as never)
+        .mockReturnValueOnce({ from: mockFrom } as never);
 
       const { getMemberTransactions } = await import('./MembersService');
       await getMemberTransactions('member-123', 'org-123', 10);

--- a/src/services/MembersService.ts
+++ b/src/services/MembersService.ts
@@ -352,6 +352,8 @@ export function updateMemberStatus(memberId: string, organizationId: string, sta
 
 type UpdateMemberContactInfoInput = {
   id: string;
+  firstName: string;
+  lastName: string;
   email: string;
   phone?: string | null;
   dateOfBirth?: Date;
@@ -372,11 +374,13 @@ type UpdateMemberContactInfoInput = {
  * @returns The updated member record
  */
 export async function updateMemberContactInfo(input: UpdateMemberContactInfoInput, organizationId: string) {
-  const { id, email, phone, dateOfBirth, address } = input;
+  const { id, firstName, lastName, email, phone, dateOfBirth, address } = input;
 
   // Build the partial set so a missing dateOfBirth doesn't overwrite the
   // existing column with undefined.
   const memberUpdates: Record<string, unknown> = {
+    firstName,
+    lastName,
     email,
     phone: phone ?? null,
   };
@@ -724,6 +728,17 @@ export async function getMemberTransactions(
   organizationId: string,
   limit: number = 50,
 ): Promise<TransactionData[]> {
+  // Include this member's OWN transactions plus those of any family members
+  // linked under them as a head of household. When a HOH pays for a family
+  // member's membership, the transaction row is keyed to the family member, so
+  // without this the HOH's billing history would be empty (#223). Each row
+  // still shows the actual charged member's name via the join below.
+  const familyLinks = await db
+    .select({ relatedMemberId: familyMemberSchema.relatedMemberId })
+    .from(familyMemberSchema)
+    .where(eq(familyMemberSchema.memberId, memberId));
+  const memberIds = [memberId, ...familyLinks.map(f => f.relatedMemberId)];
+
   return db
     .select({
       id: transactionSchema.id,
@@ -742,7 +757,7 @@ export async function getMemberTransactions(
     .from(transactionSchema)
     .innerJoin(memberSchema, eq(transactionSchema.memberId, memberSchema.id))
     .where(and(
-      eq(transactionSchema.memberId, memberId),
+      inArray(transactionSchema.memberId, memberIds),
       eq(transactionSchema.organizationId, organizationId),
     ))
     .orderBy(desc(transactionSchema.createdAt))

--- a/src/templates/ClassCard.tsx
+++ b/src/templates/ClassCard.tsx
@@ -19,6 +19,8 @@ export type ClassCardProps = {
   level: string;
   type: string;
   style: string;
+  /** Custom tags beyond the level/type/style categories, rendered as extra badges. */
+  tags?: string[];
   schedule: ScheduleItem[];
   location: string;
   instructors: Array<{
@@ -49,7 +51,7 @@ function getInitials(name: string) {
 }
 
 export const ClassCard = (props: ClassCardProps) => {
-  const { id, name, description, level, type, style, schedule, location, instructors, onEdit } = props;
+  const { id, name, description, level, type, style, tags, schedule, location, instructors, onEdit } = props;
   const t = useTranslations('ClassCard');
 
   return (
@@ -66,6 +68,9 @@ export const ClassCard = (props: ClassCardProps) => {
           <Badge variant={getLevelColor(level)}>{level}</Badge>
           <Badge variant="outline">{type}</Badge>
           <Badge variant="outline">{style}</Badge>
+          {tags?.map(tag => (
+            <Badge key={tag} variant="secondary">{tag}</Badge>
+          ))}
         </div>
 
         {/* Details */}

--- a/src/validations/ClassesValidation.ts
+++ b/src/validations/ClassesValidation.ts
@@ -49,6 +49,10 @@ export const DeleteClassValidation = z.object({
   id: z.string().min(1),
 });
 
+export const GetClassAttendanceValidation = z.object({
+  classId: z.string().min(1),
+});
+
 // Accepts both the original schema vocabulary and the UI's vocabulary —
 // the column is a text field and existing seeded data uses the second set.
 const ExceptionType = z.enum([

--- a/src/validations/MemberValidation.test.ts
+++ b/src/validations/MemberValidation.test.ts
@@ -221,6 +221,8 @@ describe('MemberValidation', () => {
     it('should validate a correct contact info update', () => {
       const validData = {
         id: 'member-123',
+        firstName: 'John',
+        lastName: 'Doe',
         email: 'john.doe@example.com',
         phone: '(555) 123-4567',
       };
@@ -233,6 +235,8 @@ describe('MemberValidation', () => {
     it('should validate with optional address', () => {
       const validData = {
         id: 'member-123',
+        firstName: 'John',
+        lastName: 'Doe',
         email: 'john.doe@example.com',
         phone: '(555) 123-4567',
         address: {
@@ -252,6 +256,8 @@ describe('MemberValidation', () => {
     it('should fail when email is invalid', () => {
       const invalidData = {
         id: 'member-123',
+        firstName: 'John',
+        lastName: 'Doe',
         email: 'invalid-email',
         phone: '(555) 123-4567',
       };
@@ -275,6 +281,8 @@ describe('MemberValidation', () => {
     it('should allow null phone', () => {
       const validData = {
         id: 'member-123',
+        firstName: 'John',
+        lastName: 'Doe',
         email: 'john.doe@example.com',
         phone: null,
       };
@@ -287,6 +295,8 @@ describe('MemberValidation', () => {
     it('should validate address with optional apartment', () => {
       const validData = {
         id: 'member-123',
+        firstName: 'John',
+        lastName: 'Doe',
         email: 'john.doe@example.com',
         address: {
           street: '123 Main St',
@@ -306,6 +316,8 @@ describe('MemberValidation', () => {
     it('accepts a Date dateOfBirth', () => {
       const result = UpdateMemberContactInfoValidation.safeParse({
         id: 'member-123',
+        firstName: 'John',
+        lastName: 'Doe',
         email: 'john.doe@example.com',
         dateOfBirth: new Date('1990-01-15'),
       });
@@ -316,6 +328,8 @@ describe('MemberValidation', () => {
     it('coerces a string dateOfBirth into a Date', () => {
       const result = UpdateMemberContactInfoValidation.safeParse({
         id: 'member-123',
+        firstName: 'John',
+        lastName: 'Doe',
         email: 'john.doe@example.com',
         dateOfBirth: '1990-01-15',
       });
@@ -330,6 +344,8 @@ describe('MemberValidation', () => {
     it('accepts a missing dateOfBirth (optional)', () => {
       const result = UpdateMemberContactInfoValidation.safeParse({
         id: 'member-123',
+        firstName: 'John',
+        lastName: 'Doe',
         email: 'john.doe@example.com',
       });
 
@@ -339,6 +355,8 @@ describe('MemberValidation', () => {
     it('rejects an unparseable dateOfBirth string', () => {
       const result = UpdateMemberContactInfoValidation.safeParse({
         id: 'member-123',
+        firstName: 'John',
+        lastName: 'Doe',
         email: 'john.doe@example.com',
         dateOfBirth: 'not-a-date',
       });

--- a/src/validations/MemberValidation.ts
+++ b/src/validations/MemberValidation.ts
@@ -50,6 +50,8 @@ export const RemoveFullyMemberValidation = z.object({
 
 export const UpdateMemberContactInfoValidation = z.object({
   id: z.string(),
+  firstName: z.string().min(1),
+  lastName: z.string().min(1),
   email: z.string().email(),
   phone: z.string().nullable().optional(),
   dateOfBirth: z.coerce.date().optional(),


### PR DESCRIPTION
## Summary

Tier 2 remainder — class detail (attendance roster + upcoming sessions, custom
tags in the grid), HOH/family billing and navigation fixes, and two member-edit
gaps. Group N (#270 multi-image catalog) is deferred to its own PR.

Fixes:

- Fixes #248
- Fixes #247
- Fixes #245
- Fixes #222
- Fixes #220
- Fixes #223
- Fixes #225
- Fixes #232

## Group L — class detail

- **#248 attendance roster + upcoming sessions** (net-new feature — data + UI
  didn't exist; stats were hardcoded to 0):
  - New `getClassAttendance` service (joins `attendance` → schedule instances →
    member) returning a roster + rollup stats, exposed via a new
    `classes.getAttendance` endpoint (FRONT_DESK).
  - Class detail page now shows real activeEnrollments/averageAttendance/
    totalSessions, a new `ClassAttendanceCard` (roster), and a new
    `UpcomingSessionsCard` (projected from the weekly schedule minus cancelled
    exceptions — pure client-side computation).
- **#247 custom tags in the grid:** the grid transformer collapsed tags into
  level/type/style and dropped everything else. Now carries non-category tags
  into `ClassCardProps.tags` and renders them as extra badges.
- **#245:** already implemented (landed in #286 — per-instance edit +
  `upsertException`/`removeException` are wired end-to-end). No code change; safe
  to close.

## Group M — HOH / family

- **#222 family link 404:** the HOH link used `/dashboard/members/${id}` (no
  route exists there). Fixed to the canonical
  `/${locale}/dashboard/members/${id}/edit`.
- **#220 declined member persists + duplicate on retry:** "Try Again" re-ran
  `member.create`, creating a new active member on every retry. The flow now
  reuses the already-created member (create/waiver/link run once) and only
  re-runs payment; cancel-after-decline still rolls the member back.
- **#223 HOH billing empty for family payments:** `getMemberTransactions` now
  also includes transactions of the member's linked family members (via the
  `family_member` table), so a HOH sees charges made for their family. No
  migration; each row still shows the actual charged member's name.

## Group O — member detail

- **#225 name field:** `EditContactInfoModal` now edits first/last name, threaded
  through `UpdateMemberContactInfoValidation` and the `updateMemberContactInfo`
  service (previously name was uneditable anywhere on the member edit page).
- **#232 signup fee:** added a "Signup Fee" row to the membership details card
  (sourced from the plan's `signupFee`), which was omitted from the page entirely.

## Tests

- New: `#247` custom tags carried into `ClassCardProps.tags`; `#225` name in
  contact validation + service.
- Updated `getMemberTransactions` and contact-info validation fixtures for the
  new family-links query and required name fields.
- Full suite: 253 files, 4637 tests pass. `npm run lint`, `check:types`,
  `check:i18n`, and `check:deps` all clean.

## Notes

- #248 (attendance query) and #223 (family-links join) aren't unit-tested
  end-to-end — the multi-step DB mock harness is brittle for these. Verify
  manually: a class with seeded attendance shows the roster + real stats +
  upcoming sessions; a HOH's billing shows family-member charges.
- #245 just needs closing as already-fixed.
- No schema/migration changes in this PR.