### PR TITLE
fix(payments): fall back to first gateway processor + clarify trial subscription

### DIFF
--- a/src/libs/IQPro.test.ts
+++ b/src/libs/IQPro.test.ts
@@ -636,4 +636,45 @@ describe('getGatewayProcessors', () => {
 
     expect(result).toEqual({ cardProcessorId: 'card_proc', achProcessorId: 'ach_proc' });
   });
+
+  it('falls back to the first processor when none is flagged default (#214/#264)', async () => {
+    const mod = await import('./IQPro');
+    mod.resetOAuthTokenCache();
+    mod.resetGatewayProcessorsCache();
+
+    mockOAuthOk();
+    mockFetch.mockResolvedValueOnce(new Response(
+      JSON.stringify({
+        data: {
+          processors: [
+            { processorId: 'p1', isDefaultCard: false, isDefaultAch: false },
+            { processorId: 'p2', isDefaultCard: false, isDefaultAch: false },
+          ],
+        },
+      }),
+      { status: 200 },
+    ));
+
+    const result = await mod.getGatewayProcessors(testConfig);
+
+    // Both fall back to the first available processor rather than null, which
+    // previously hard-failed every charge as a "declined" payment.
+    expect(result).toEqual({ cardProcessorId: 'p1', achProcessorId: 'p1' });
+  });
+
+  it('returns null when the gateway has no processors at all', async () => {
+    const mod = await import('./IQPro');
+    mod.resetOAuthTokenCache();
+    mod.resetGatewayProcessorsCache();
+
+    mockOAuthOk();
+    mockFetch.mockResolvedValueOnce(new Response(
+      JSON.stringify({ data: { processors: [] } }),
+      { status: 200 },
+    ));
+
+    const result = await mod.getGatewayProcessors(testConfig);
+
+    expect(result).toEqual({ cardProcessorId: null, achProcessorId: null });
+  });
 });

--- a/src/libs/IQPro.ts
+++ b/src/libs/IQPro.ts
@@ -372,8 +372,14 @@ export async function getGatewayProcessors(config: IQProConfig): Promise<Gateway
     isDefaultAch: boolean;
   }>;
 
-  const defaultCard = processors.find(p => p.isDefaultCard);
-  const defaultAch = processors.find(p => p.isDefaultAch);
+  // Prefer the processor flagged as default, but fall back to the first
+  // available processor of that kind. Some gateways (notably the sandbox) have
+  // processors provisioned but none flagged isDefaultCard/isDefaultAch — the
+  // old behaviour returned null there, which hard-failed every charge with
+  // "No processor configured" and surfaced as a payment decline (#214/#215/#216
+  // card, #264 ACH, #219 vaulted). The fallback lets those gateways charge.
+  const defaultCard = processors.find(p => p.isDefaultCard) ?? processors[0];
+  const defaultAch = processors.find(p => p.isDefaultAch) ?? processors[0];
 
   const result: GatewayProcessors = {
     cardProcessorId: defaultCard?.processorId ?? null,
@@ -381,7 +387,9 @@ export async function getGatewayProcessors(config: IQProConfig): Promise<Gateway
   };
   processorsCache.set(config.gatewayId, result);
 
-  logger.info('[IQPro] Gateway processors loaded', result);
+  const usedCardFallback = !processors.some(p => p.isDefaultCard) && result.cardProcessorId !== null;
+  const usedAchFallback = !processors.some(p => p.isDefaultAch) && result.achProcessorId !== null;
+  logger.info('[IQPro] Gateway processors loaded', { ...result, usedCardFallback, usedAchFallback });
   return result;
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1594,7 +1594,7 @@
     "responsible_owner_heading": "Responsible Academy Owner",
     "responsible_owner_none": "No Academy Owner is assigned. Assign one in Clerk to manage billing.",
     "responsible_owner_unknown_name": "Academy Owner",
-    "trial_notice": "You're on a free trial. Choose a plan and subscribe to continue access.",
+    "trial_notice": "You're on a free trial. Choosing a plan starts a paid subscription and requires a payment method — you can switch between monthly and annual afterward.",
     "monthly_button": "Monthly",
     "annual_button": "Annual",
     "billing_history_heading": "My Billing History",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1598,7 +1598,7 @@
     "responsible_owner_heading": "Propriétaire d'académie responsable",
     "responsible_owner_none": "Aucun propriétaire d'académie n'est assigné. Assignez-en un dans Clerk pour gérer la facturation.",
     "responsible_owner_unknown_name": "Propriétaire d'académie",
-    "trial_notice": "Vous êtes en période d'essai gratuite. Choisissez un forfait et abonnez-vous pour continuer.",
+    "trial_notice": "Vous êtes en période d'essai gratuite. Choisir un forfait démarre un abonnement payant et nécessite un moyen de paiement — vous pourrez ensuite passer du mensuel à l'annuel.",
     "monthly_button": "Mensuel",
     "annual_button": "Annuel",
     "billing_history_heading": "Mon historique de facturation",


### PR DESCRIPTION
## Summary

Fixes the "payment declined" cluster (a null default processor hard-failed every
charge) and clarifies the SaaS trial subscription flow. #282 was investigated and
found to be correct behavior, not a bug.

Fixes:

- Fixes #214
- Fixes #215
- Fixes #216
- Fixes #264
- Fixes #219
- Fixes #282

## Group P — "payment declined" (#214/#215/#216 card, #264 ACH, #219 vaulted HOH)

**Root cause:** `getGatewayProcessors` resolved processors ONLY by the
`isDefaultCard`/`isDefaultAch` flags. When a gateway has processors provisioned
but none flagged default (the Preview/sandbox situation), both came back `null`
and every charge hard-failed at `MemberPaymentService.ts:371` with "No processor
configured" — surfaced to the wizard as a decline, for card, ACH, and vaulted
charges alike, BEFORE any IQPro Sale was attempted.

**Fix:**
- `IQPro.ts` `getGatewayProcessors`: fall back to the first available card/ACH
  processor when none is flagged default, instead of returning null. Logs
  `usedCardFallback` / `usedAchFallback` when the fallback triggers.
- This is a code safety net. The primary Preview fix is a config change: flag a
  default card + ACH processor on the sandbox gateway in the IQPro/Basys console
  (owner action, not in this PR).

## Group T — #282 "cannot change plan" — not a bug

Investigation verdict: correct behavior, a Preview-data artifact. On a synthetic
trial (`status: 'trial'`, null IQPro ids) the SubscriptionDialog correctly routes
to "Subscribe" (real card-collecting flow) rather than `changePlan`, which is
intentionally bypassed and would reject an unbacked subscription. On a real paid
org, monthly↔annual calls `changePlan` and works. The only confusion is that a
trial shows "Subscribe" (card required) instead of an instant plan toggle.

**Fix:** close #282 as works-as-designed, plus a copy tweak — the trial banner
(`trial_notice`, en + fr) now explains that choosing a plan starts a paid
subscription requiring a payment method, switchable between monthly/annual
afterward. No logic change.

## Tests

- `IQPro.test.ts`: two new `getGatewayProcessors` cases — processors present but
  no default flag → returns the first processor; empty processors → null. 35
  pass.
- `npm run check:types`, `lint`, `check:i18n`, and `check:deps` all pass. Every
  affected suite passes in isolation (the full parallel `npm run test` shows the
  known flaky "1-per-UI-suite" browser artifact on unrelated files; each passes
  when run alone).

## Notes

- The code fallback can't help if the sandbox gateway has ZERO processors
  provisioned (vs. just none flagged default) — that's purely a console
  provisioning task. Confirm on Preview via Better Stack: look for
  `[IQPro] Gateway processors loaded` with non-null ids and a
  `[IQPro] POST …/transaction` present after a test charge.