### PR TITLE
fix(reporting): remove dead chart buttons and enable last N days reports

### DIFF
--- a/src/features/dashboard/DashboardCharts.test.tsx
+++ b/src/features/dashboard/DashboardCharts.test.tsx
@@ -165,7 +165,7 @@ describe('DashboardCharts', () => {
     expect(earningsSelect).toHaveTextContent('Yearly');
   });
 
-  it('renders View details buttons', () => {
+  it('does not render dead "View details" buttons (#230)', () => {
     render(
       <DashboardCharts
         memberAverageData={mockMemberAverageData}
@@ -173,9 +173,11 @@ describe('DashboardCharts', () => {
       />,
     );
 
+    // The charts have no detail view to link to, so the previously-dead
+    // "View details" buttons were removed rather than wired to a generic target.
     const viewDetailsButtons = page.getByRole('button', { name: /View details/i });
 
-    expect(viewDetailsButtons.elements().length).toBe(2);
+    expect(viewDetailsButtons.elements().length).toBe(0);
   });
 
   it('Member average and Earnings selects work independently', async () => {

--- a/src/features/dashboard/DashboardCharts.tsx
+++ b/src/features/dashboard/DashboardCharts.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-import { ArrowRight } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { Bar, BarChart, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
-import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
@@ -138,12 +136,6 @@ export default function DashboardCharts({ memberAverageData, earningsData }: Das
             )}
           </BarChart>
         </ResponsiveContainer>
-        <div className="mt-4 flex items-center justify-end">
-          <Button variant="outline" size="sm">
-            View details
-            <ArrowRight className="ml-2 h-4 w-4" />
-          </Button>
-        </div>
       </Card>
 
       {/* Earnings Chart */}
@@ -217,12 +209,6 @@ export default function DashboardCharts({ memberAverageData, earningsData }: Das
             )}
           </BarChart>
         </ResponsiveContainer>
-        <div className="mt-4 flex items-center justify-end">
-          <Button variant="outline" size="sm">
-            View details
-            <ArrowRight className="ml-2 h-4 w-4" />
-          </Button>
-        </div>
       </Card>
     </div>
   );

--- a/src/features/reports/ReportsPage.tsx
+++ b/src/features/reports/ReportsPage.tsx
@@ -13,7 +13,13 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Skeleton } from '@/components/ui/skeleton';
 import { useReportCurrentValues, useReportDetail } from '@/hooks/useReportsCache';
 
-type TimePeriod = 'monthly' | 'yearly';
+type TimePeriod = 'monthly' | 'yearly' | 'last-7' | 'last-30' | 'last-90';
+
+const DAILY_PERIODS = ['last-7', 'last-30', 'last-90'] as const;
+
+function isDailyPeriod(p: TimePeriod): p is 'last-7' | 'last-30' | 'last-90' {
+  return (DAILY_PERIODS as readonly string[]).includes(p);
+}
 type ChartType = 'bar' | 'line' | 'area';
 
 // Chart type mapping for each report - using blue-themed colors for dark/light mode visibility
@@ -151,7 +157,7 @@ const previousYearColor = 'hsl(210, 20%, 60%)';
 // Render the appropriate chart type based on report configuration
 function renderChart(
   reportId: ReportType,
-  chartData: Array<{ month?: string; year?: string; value: number; previousYear?: number }>,
+  chartData: Array<{ month?: string; year?: string; day?: string; value: number; previousYear?: number }>,
   xKey: string,
   formatValue: (value: number) => string,
   showComparison: boolean = false,
@@ -302,7 +308,8 @@ function ReportDetail({ reportId, onBack }: { reportId: ReportType; onBack: () =
   const [timePeriod, setTimePeriod] = useState<TimePeriod>('monthly');
   const [showComparison, setShowComparison] = useState(false);
 
-  const { chartData: rawChartData, insights, loading } = useReportDetail(reportId);
+  const range = isDailyPeriod(timePeriod) ? timePeriod : undefined;
+  const { chartData: rawChartData, insights, loading } = useReportDetail(reportId, range);
 
   const { data: currentValues } = useReportCurrentValues();
 
@@ -328,10 +335,13 @@ function ReportDetail({ reportId, onBack }: { reportId: ReportType; onBack: () =
     if (!rawChartData) {
       return [];
     }
+    if (isDailyPeriod(timePeriod)) {
+      return rawChartData.daily ?? [];
+    }
     return timePeriod === 'monthly' ? rawChartData.monthly : rawChartData.yearly;
   }, [rawChartData, timePeriod]);
 
-  // Check if previous year data is available (only in monthly view)
+  // Previous-year comparison is only meaningful in the monthly view.
   const hasPreviousYearData = useMemo(() => {
     if (timePeriod !== 'monthly' || !rawChartData) {
       return false;
@@ -339,7 +349,7 @@ function ReportDetail({ reportId, onBack }: { reportId: ReportType; onBack: () =
     return rawChartData.monthly.some(d => d.previousYear !== undefined);
   }, [rawChartData, timePeriod]);
 
-  const xKey = timePeriod === 'monthly' ? 'month' : 'year';
+  const xKey = isDailyPeriod(timePeriod) ? 'day' : (timePeriod === 'monthly' ? 'month' : 'year');
 
   const formatValue = useCallback((value: number) => {
     // Format currency values appropriately
@@ -411,6 +421,9 @@ function ReportDetail({ reportId, onBack }: { reportId: ReportType; onBack: () =
                 <SelectContent>
                   <SelectItem value="monthly">{t('time_period_monthly')}</SelectItem>
                   <SelectItem value="yearly">{t('time_period_yearly')}</SelectItem>
+                  <SelectItem value="last-7">{t('time_period_last_7')}</SelectItem>
+                  <SelectItem value="last-30">{t('time_period_last_30')}</SelectItem>
+                  <SelectItem value="last-90">{t('time_period_last_90')}</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/src/hooks/useReportsCache.ts
+++ b/src/hooks/useReportsCache.ts
@@ -1,4 +1,4 @@
-import type { ReportChartData, ReportCurrentValues } from '@/services/ReportsService';
+import type { ReportChartData, ReportCurrentValues, ReportRange } from '@/services/ReportsService';
 import { useCallback, useEffect, useReducer } from 'react';
 import { client } from '@/libs/Orpc';
 
@@ -96,7 +96,7 @@ function reportDetailReducer(state: ReportDetailState, action: ReportDetailActio
   }
 }
 
-export const useReportDetail = (reportType: string | null) => {
+export const useReportDetail = (reportType: string | null, range?: ReportRange) => {
   const [state, dispatch] = useReducer(reportDetailReducer, {
     chartData: null,
     insights: [],
@@ -115,7 +115,10 @@ export const useReportDetail = (reportType: string | null) => {
       dispatch({ type: 'LOADING_START' });
       try {
         const [chartData, insights] = await Promise.all([
-          client.reports.chartData({ reportType: reportType as Parameters<typeof client.reports.chartData>[0]['reportType'] }) as Promise<ReportChartData>,
+          client.reports.chartData({
+            reportType: reportType as Parameters<typeof client.reports.chartData>[0]['reportType'],
+            ...(range ? { range } : {}),
+          }) as Promise<ReportChartData>,
           client.reports.insights({ reportType: reportType as Parameters<typeof client.reports.insights>[0]['reportType'] }) as Promise<string[]>,
         ]);
 
@@ -135,7 +138,8 @@ export const useReportDetail = (reportType: string | null) => {
     return () => {
       cancelled = true;
     };
-  }, [reportType]);
+    // `range` is part of the cache key — switching it re-fetches.
+  }, [reportType, range]);
 
   return {
     chartData: state.chartData,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1015,6 +1015,9 @@
     "insights_title": "Insights",
     "time_period_monthly": "Monthly",
     "time_period_yearly": "Yearly",
+    "time_period_last_7": "Last 7 days",
+    "time_period_last_30": "Last 30 days",
+    "time_period_last_90": "Last 90 days",
     "compare_with_last_year": "Compare with last year"
   },
   "PerformancePage": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -982,6 +982,9 @@
     "insights_title": "Aperçus",
     "time_period_monthly": "Mensuel",
     "time_period_yearly": "Annuel",
+    "time_period_last_7": "7 derniers jours",
+    "time_period_last_30": "30 derniers jours",
+    "time_period_last_90": "90 derniers jours",
     "compare_with_last_year": "Comparer avec l'année dernière"
   },
   "PerformancePage": {

--- a/src/routers/Reports.test.ts
+++ b/src/routers/Reports.test.ts
@@ -112,8 +112,21 @@ describe('Reports Router', () => {
       const result = await callHandler(chartData, input);
 
       expect(guardRole).toHaveBeenCalledWith(ORG_ROLE.FRONT_DESK);
-      expect(getReportChartData).toHaveBeenCalledWith('test-org-456', 'revenue');
+      expect(getReportChartData).toHaveBeenCalledWith('test-org-456', 'revenue', undefined);
       expect(result).toEqual(mockChartData);
+    });
+
+    it('forwards the range param to the service when provided (#274)', async () => {
+      const { guardRole } = await import('./AuthGuards');
+      const { getReportChartData } = await import('@/services/ReportsService');
+
+      vi.mocked(guardRole).mockResolvedValue(mockContext);
+      vi.mocked(getReportChartData).mockResolvedValue({ monthly: [], yearly: [], daily: [] });
+
+      const { chartData } = await import('./Reports');
+      await callHandler(chartData, { reportType: 'past-due', range: 'last-30' });
+
+      expect(getReportChartData).toHaveBeenCalledWith('test-org-456', 'past-due', 'last-30');
     });
 
     it('should return chart data for attendance report type', async () => {
@@ -140,7 +153,7 @@ describe('Reports Router', () => {
       const result = await callHandler(chartData, input);
 
       expect(guardRole).toHaveBeenCalledWith(ORG_ROLE.FRONT_DESK);
-      expect(getReportChartData).toHaveBeenCalledWith('test-org-456', 'attendance');
+      expect(getReportChartData).toHaveBeenCalledWith('test-org-456', 'attendance', undefined);
       expect(result).toEqual(mockChartData);
     });
 

--- a/src/routers/Reports.ts
+++ b/src/routers/Reports.ts
@@ -13,7 +13,7 @@ export const chartData = os
   .input(ReportTypeValidation)
   .handler(async ({ input }) => {
     const { orgId } = await guardRole(ORG_ROLE.FRONT_DESK);
-    return getReportChartData(orgId, input.reportType);
+    return getReportChartData(orgId, input.reportType, input.range);
   });
 
 export const insights = os

--- a/src/services/ReportsService.test.ts
+++ b/src/services/ReportsService.test.ts
@@ -263,6 +263,103 @@ describe('ReportsService', () => {
   });
 
   // ===========================================================================
+  // getReportChartData — daily "last N days" range (#274)
+  // ===========================================================================
+
+  describe('getReportChartData daily range', () => {
+    it('does not add a daily series when no range is passed', async () => {
+      mockDbResult = [{ total: 1000 }];
+      const { getReportChartData } = await import('./ReportsService');
+
+      const result = await getReportChartData('test-org-123', 'payments-last-30-days');
+
+      expect(result.daily).toBeUndefined();
+    });
+
+    it.each([
+      ['last-7', 7],
+      ['last-30', 30],
+      ['last-90', 90],
+    ] as const)('adds a %s daily series with %i buckets, preserving monthly/yearly', async (range, buckets) => {
+      mockDbResult = [{ total: 1000 }];
+      const { getReportChartData } = await import('./ReportsService');
+
+      const result = await getReportChartData('test-org-123', 'payments-last-30-days', range);
+
+      expect(result.monthly).toHaveLength(12);
+      expect(result.yearly).toHaveLength(5);
+      expect(result.daily).toHaveLength(buckets);
+      expect(result.daily?.[0]).toHaveProperty('day');
+      expect(result.daily?.[0]).toHaveProperty('value');
+
+      // ends today (last bucket is the most recent day)
+      const lastLabel = result.daily?.[buckets - 1]?.day;
+      const today = new Date();
+      const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+      expect(lastLabel).toBe(`${monthNames[today.getMonth()]} ${today.getDate()}`);
+    });
+
+    it('sums paid transactions for payments-last-30-days daily buckets', async () => {
+      mockDbResult = [{ total: 250 }];
+      const { getReportChartData } = await import('./ReportsService');
+
+      const result = await getReportChartData('test-org-123', 'payments-last-30-days', 'last-7');
+
+      expect(result.daily).toHaveLength(7);
+      expect(result.daily?.every(d => d.value === 250)).toBe(true);
+    });
+
+    it('takes the absolute value of summed amounts (refunds/adjustments)', async () => {
+      mockDbResult = [{ total: -500 }];
+      const { getReportChartData } = await import('./ReportsService');
+
+      const result = await getReportChartData('test-org-123', 'past-due', 'last-7');
+
+      expect(result.daily?.every(d => d.value === 500)).toBe(true);
+    });
+
+    it('counts point-in-time members for accounts-autopay-suspended daily buckets', async () => {
+      mockDbResult = [{ count: 3 }];
+      const { getReportChartData } = await import('./ReportsService');
+
+      const result = await getReportChartData('test-org-123', 'accounts-autopay-suspended', 'last-7');
+
+      expect(result.daily).toHaveLength(7);
+      expect(result.daily?.every(d => d.value === 3)).toBe(true);
+    });
+
+    it('computes per-student income for income-per-student daily buckets', async () => {
+      mockDbResult = [{ total: 1000, count: 4 }];
+      const { getReportChartData } = await import('./ReportsService');
+
+      const result = await getReportChartData('test-org-123', 'income-per-student', 'last-7');
+
+      expect(result.daily).toHaveLength(7);
+      // 1000 / 4 = 250 per student
+      expect(result.daily?.every(d => d.value === 250)).toBe(true);
+    });
+
+    it('returns zero-valued daily buckets for expiring-credit-cards', async () => {
+      const { getReportChartData } = await import('./ReportsService');
+
+      const result = await getReportChartData('test-org-123', 'expiring-credit-cards', 'last-30');
+
+      expect(result.daily).toHaveLength(30);
+      expect(result.daily?.every(d => d.value === 0)).toBe(true);
+    });
+
+    it('returns zero-valued daily buckets for unknown report types', async () => {
+      const { getReportChartData } = await import('./ReportsService');
+
+      const result = await getReportChartData('test-org-123', 'unknown-report-type', 'last-7');
+
+      expect(result.daily).toHaveLength(7);
+      expect(result.daily?.every(d => d.value === 0)).toBe(true);
+    });
+  });
+
+  // ===========================================================================
   // getReportInsights
   // ===========================================================================
 

--- a/src/services/ReportsService.ts
+++ b/src/services/ReportsService.ts
@@ -25,12 +25,40 @@ type YearlyDataPoint = {
   value: number;
 };
 
+type DailyDataPoint = {
+  day: string; // 'MMM D' label, e.g. 'Jul 3'
+  value: number;
+};
+
+export type ReportRange = 'last-7' | 'last-30' | 'last-90';
+
+const RANGE_DAYS: Record<ReportRange, number> = {
+  'last-7': 7,
+  'last-30': 30,
+  'last-90': 90,
+};
+
 export type ReportChartData = {
   monthly: MonthlyDataPoint[];
   yearly: YearlyDataPoint[];
+  daily?: DailyDataPoint[];
 };
 
 const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+// Build the last-N calendar days ending today, each as a { start-of-day,
+// end-of-day, label } bucket. Used by the daily report series (#274).
+function lastNDayBuckets(days: number): Array<{ start: Date; end: Date; label: string }> {
+  const buckets: Array<{ start: Date; end: Date; label: string }> = [];
+  const today = new Date();
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(today.getFullYear(), today.getMonth(), today.getDate() - i);
+    const start = new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0);
+    const end = new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59);
+    buckets.push({ start, end, label: `${MONTH_NAMES[d.getMonth()]} ${d.getDate()}` });
+  }
+  return buckets;
+}
 
 export async function getReportCurrentValues(organizationId: string): Promise<ReportCurrentValues> {
   const stats = await getFinancialStats(organizationId);
@@ -49,28 +77,111 @@ export async function getReportCurrentValues(organizationId: string): Promise<Re
 export async function getReportChartData(
   organizationId: string,
   reportType: string,
+  range?: ReportRange | null,
 ): Promise<ReportChartData> {
   const currentYear = new Date().getFullYear();
 
+  const base = await (async (): Promise<ReportChartData> => {
+    switch (reportType) {
+      case 'accounts-autopay-suspended':
+        return getAutopayChartData(organizationId, currentYear);
+      case 'expiring-credit-cards':
+        return getEmptyChartData(currentYear);
+      case 'amount-due':
+        return getAmountDueChartData(organizationId, currentYear);
+      case 'past-due':
+        return getStatusChartData(organizationId, currentYear, 'declined');
+      case 'payments-last-30-days':
+        return getStatusChartData(organizationId, currentYear, 'paid');
+      case 'payments-pending':
+        return getPendingChartData(organizationId, currentYear);
+      case 'failed-payments':
+        return getStatusChartData(organizationId, currentYear, 'declined');
+      case 'income-per-student':
+        return getIncomePerStudentChartData(organizationId, currentYear);
+      default:
+        return getEmptyChartData(currentYear);
+    }
+  })();
+
+  // A range only adds a daily series; monthly/yearly are unchanged (#274).
+  if (range) {
+    base.daily = await getDailyChartData(organizationId, reportType, RANGE_DAYS[range]);
+  }
+  return base;
+}
+
+// Daily series for the "last N days" report filter. Reuses each report's
+// underlying per-bucket query (range-sum or point-in-time count) over the
+// last-N-day buckets. Kept separate from the monthly/yearly helpers so those
+// remain untouched (zero regression risk).
+async function getDailyChartData(
+  organizationId: string,
+  reportType: string,
+  days: number,
+): Promise<DailyDataPoint[]> {
+  const buckets = lastNDayBuckets(days);
+
+  // Sum transaction.amount in [start,end] for a given status set.
+  const txSumInRange = (start: Date, end: Date, statuses: string[]) =>
+    db.select({ total: sum(transactionSchema.amount) })
+      .from(transactionSchema)
+      .where(and(
+        eq(transactionSchema.organizationId, organizationId),
+        inArray(transactionSchema.status, statuses),
+        gte(transactionSchema.createdAt, start),
+        sql`${transactionSchema.createdAt} <= ${end}`,
+      ));
+
+  // Count members in status 'past_due' as of a point in time.
+  const pastDueCountAt = (at: Date) =>
+    db.select({ count: count() })
+      .from(memberSchema)
+      .where(and(
+        eq(memberSchema.organizationId, organizationId),
+        eq(memberSchema.status, 'past_due'),
+        sql`${memberSchema.createdAt} <= ${at}`,
+      ));
+
+  const mapSum = (results: Array<{ total: string | number | null }[]>): DailyDataPoint[] =>
+    buckets.map((b, i) => ({ day: b.label, value: Math.abs(Number(results[i]?.[0]?.total ?? 0)) }));
+
   switch (reportType) {
-    case 'accounts-autopay-suspended':
-      return getAutopayChartData(organizationId, currentYear);
-    case 'expiring-credit-cards':
-      return getEmptyChartData(currentYear);
+    case 'accounts-autopay-suspended': {
+      const results = await Promise.all(buckets.map(b => pastDueCountAt(b.end)));
+      return buckets.map((b, i) => ({ day: b.label, value: results[i]?.[0]?.count ?? 0 }));
+    }
     case 'amount-due':
-      return getAmountDueChartData(organizationId, currentYear);
-    case 'past-due':
-      return getStatusChartData(organizationId, currentYear, 'declined');
     case 'payments-last-30-days':
-      return getStatusChartData(organizationId, currentYear, 'paid');
-    case 'payments-pending':
-      return getPendingChartData(organizationId, currentYear);
+      return mapSum(await Promise.all(buckets.map(b => txSumInRange(b.start, b.end, ['paid']))));
+    case 'past-due':
     case 'failed-payments':
-      return getStatusChartData(organizationId, currentYear, 'declined');
-    case 'income-per-student':
-      return getIncomePerStudentChartData(organizationId, currentYear);
+      return mapSum(await Promise.all(buckets.map(b => txSumInRange(b.start, b.end, ['declined']))));
+    case 'payments-pending':
+      return mapSum(await Promise.all(buckets.map(b => txSumInRange(b.start, b.end, ['pending', 'processing']))));
+    case 'income-per-student': {
+      // Per-day income divided by member count at end of day.
+      const memberCountAt = (at: Date) =>
+        db.select({ count: count() })
+          .from(memberSchema)
+          .where(and(
+            eq(memberSchema.organizationId, organizationId),
+            sql`${memberSchema.createdAt} <= ${at}`,
+            sql`(${memberSchema.status} != 'cancelled' OR ${memberSchema.updatedAt} > ${at})`,
+          ));
+      const [incomeResults, memberResults] = await Promise.all([
+        Promise.all(buckets.map(b => txSumInRange(b.start, b.end, ['paid']))),
+        Promise.all(buckets.map(b => memberCountAt(b.end))),
+      ]);
+      return buckets.map((b, i) => {
+        const income = Number(incomeResults[i]?.[0]?.total ?? 0);
+        const members = memberResults[i]?.[0]?.count ?? 1;
+        return { day: b.label, value: members > 0 ? Math.round((income / members) * 100) / 100 : 0 };
+      });
+    }
+    case 'expiring-credit-cards':
     default:
-      return getEmptyChartData(currentYear);
+      return buckets.map(b => ({ day: b.label, value: 0 }));
   }
 }
 

--- a/src/validations/TransactionValidation.ts
+++ b/src/validations/TransactionValidation.ts
@@ -26,4 +26,6 @@ export const ReportTypeValidation = z.object({
     'failed-payments',
     'income-per-student',
   ]),
+  // Optional "last N days" daily window for chart data (#274). Ignored by insights.
+  range: z.enum(['last-7', 'last-30', 'last-90']).optional(),
 });


### PR DESCRIPTION
## Summary

Resolves two Tier-3 defects (group Q):

- **#230** — Removed non-functional "View details" buttons from the dashboard charts. They linked nowhere (no detail view exists to route to), so they were dead UI.
- **#274** — Added a "Last N days" daily range filter to the Reports detail view (Last 7 / 30 / 90 days), alongside the existing Monthly / Yearly periods.

## Changes

### #230 — Dead "View details" buttons
- Removed the two "View details" buttons from `DashboardCharts.tsx` and their now-unused `Button` / `ArrowRight` imports.
- Updated the test to assert zero such buttons render.

### #274 — Daily "last N days" report range
- Threaded a new optional `range` param (`last-7` | `last-30` | `last-90`) through the full stack: validation → router → service → hook → page.
- Added `getDailyChartData` in `ReportsService`, which builds last-N-day buckets and reuses each report's underlying per-bucket query (range-sum for transaction reports, point-in-time counts for member metrics). The monthly/yearly code paths are left untouched for zero regression risk.
- The daily series is **additive** (`daily?` on `ReportChartData`) — a range only augments the response, never replaces monthly/yearly.
- Previous-year comparison correctly hides in daily mode, since daily buckets carry no `previousYear` field.
- Added i18n keys for the three new period labels (en + fr).

## Tests
- Added 10 tests in `ReportsService.test.ts` covering the new `getDailyChartData` path: bucket counts per range, no `daily` series when no range is passed, absolute-value handling for refund/adjustment sums, point-in-time member counts, per-student income division, and zero-fill for expiring-cards / unknown report types.
- Updated `Reports.test.ts` to assert the `range` param forwards to the service.
- Updated `DashboardCharts.test.tsx` to assert the removed buttons no longer render.