### PR TITLE
fix(members/classes): fix all remaining defects

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -99,7 +99,8 @@ src/
 │   ├── AppConfig.ts       # Pricing plans, Clerk locales
 │   ├── Auth.ts            # Page-level auth helpers
 │   ├── SaasPlans.ts       # SaaS plan configuration (Basic/Growth/Enterprise pricing, features)
-│   └── SuperAdmins.ts     # Super admin username list and helper
+│   ├── SuperAdmins.ts     # Super admin username list and helper
+│   └── MemberSearch.ts    # Shared member-search relevance ranking (prefix-priority + alphabetical) used by every member-search box
 ├── validations/           # Zod schemas
 ├── types/                 # TypeScript types
 │   └── Auth.ts            # Role definitions (ORG_ROLE)
@@ -294,7 +295,18 @@ The member detail/edit page (`members/[memberId]/edit/page.tsx`) displays:
 - "Add Family Member" button (HOH only) — opens `AddFamilyMembersModal` for adding multiple family members
 - "Convert" dropdown menu — opens `ConvertMemberModal` for type conversion with business rule enforcement
 - "Actions" dropdown menu (when an active or held membership exists) — opens lifecycle modals: Place on Hold, Reactivate, Cancel Membership
+- "Archive Member" / "Restore Member" button (ACADEMY_OWNER+ only, #221) — opens `ArchiveMemberModal`. Archive calls `member.remove` (soft-archive → `status='cancelled'`, preserves all history) and navigates back to the list; Restore calls `member.restore` (→ `status='active'`) when the member is currently archived. Both are academy-owner-gated via `useHasRole(ORG_ROLE.ACADEMY_OWNER)`, mirroring the endpoints' guards.
 - Attendance records and notes
+
+### Members list & search UX
+
+The members list (`MembersTable.tsx`) is client-side paginated over the full `client.members.list()` result:
+- **Page-size selector (#258):** a "Rows per page" dropdown (10 / 25 / 50 / 100, default 10) drives the slice; changing it resets to page 0.
+- **Search relevance (#244):** the search box ranks matches via the shared `@/utils/MemberSearch` helper — name-prefix matches rank above mid-name substrings, above email/phone matches; ties break alphabetically (`lastName, firstName`). When a search query is active, relevance ordering overrides the column sort; with no query the column sort applies. The same `rankMembersByQuery` helper backs the HOH picker (`HOHSelectionStep`), the event `EnrollMemberModal`, and the server-side `member.searchHOH` endpoint, so every member search behaves identically (an empty query returns everyone alphabetically).
+
+### Class-tags picker scroll (#234)
+
+The class wizard's tag picker (`ClassTagsStep.tsx`) caps both the selected-tags and available-tags boxes with `max-h-* overflow-y-auto` (matching the `MembershipStep.tsx` convention) so a large tag list scrolls instead of pushing the wizard footer off-screen.
 
 ### Cancel / Hold / Reactivate Membership
 

--- a/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx
+++ b/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx
@@ -7,7 +7,7 @@ import type { Member } from '@/hooks/useMembersCache';
 import type { MemberPaymentMethodData } from '@/services/MembersService';
 import type { SignedWaiverWithTemplateName } from '@/services/WaiversService';
 import { useOrganization } from '@clerk/nextjs';
-import { ArrowRightLeft, Download, MoreVertical, Pencil, Plus, Trash2, Unlink } from 'lucide-react';
+import { Archive, ArchiveRestore, ArrowRightLeft, Download, MoreVertical, Pencil, Plus, Trash2, Unlink } from 'lucide-react';
 import Link from 'next/link';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
@@ -26,6 +26,7 @@ import { EditMemberPhotoModal } from '@/features/members/details/EditMemberPhoto
 import { EditPaymentMethodModal } from '@/features/members/details/EditPaymentMethodModal';
 import { MemberDetailAttendance } from '@/features/members/details/MemberDetailAttendance';
 import { MemberDetailNotes } from '@/features/members/details/MemberDetailNotes';
+import { ArchiveMemberModal } from '@/features/members/lifecycle/ArchiveMemberModal';
 import { CancelMembershipModal } from '@/features/members/lifecycle/CancelMembershipModal';
 import { HoldMembershipModal } from '@/features/members/lifecycle/HoldMembershipModal';
 import { AddFamilyMembersModal } from '@/features/members/wizard/AddFamilyMembersModal';
@@ -509,6 +510,9 @@ export default function EditMemberPage() {
   const [isHoldMembershipOpen, setIsHoldMembershipOpen] = useState(false);
   const [isReactivateLoading, setIsReactivateLoading] = useState(false);
 
+  // State for member archive/restore (#221) — academy-owner action.
+  const [archiveModalMode, setArchiveModalMode] = useState<'archive' | 'restore' | null>(null);
+
   // HOH data for family members (who is this family member's HOH?)
   const [currentHOH, setCurrentHOH] = useState<{ id: string; name: string } | null>(null);
 
@@ -572,6 +576,16 @@ export default function EditMemberPage() {
       console.error('[member.reactivateMembership] failed', err);
     } finally {
       setIsReactivateLoading(false);
+    }
+  };
+
+  // Archive/restore succeeded: refresh the members cache. On archive we also
+  // navigate back to the list since the member is no longer "active" here.
+  const handleArchiveSuccess = async () => {
+    const archived = archiveModalMode === 'archive';
+    await invalidateMembersCache();
+    if (archived) {
+      router.push(`/${locale}/dashboard/members`);
     }
   };
 
@@ -750,6 +764,11 @@ export default function EditMemberPage() {
   const canRefund = useHasRole(ORG_ROLE.ADMIN);
   const [refundingId, setRefundingId] = useState<string | null>(null);
   const [refundError, setRefundError] = useState<string | null>(null);
+
+  // Archive/restore a member is an academy-owner action (#221) — mirrors the
+  // member.remove / member.restore ACADEMY_OWNER guard. Lower roles don't see it.
+  const canArchive = useHasRole(ORG_ROLE.ACADEMY_OWNER);
+  const isArchived = currentMember?.status === 'cancelled';
 
   const handleRefund = useCallback(async (transactionId: string) => {
     setRefundingId(transactionId);
@@ -1111,6 +1130,31 @@ export default function EditMemberPage() {
                   )}
                 </DropdownMenuContent>
               </DropdownMenu>
+            )}
+            {canArchive && (
+              isArchived
+                ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-8 gap-1 text-sm"
+                      onClick={() => setArchiveModalMode('restore')}
+                    >
+                      <ArchiveRestore className="h-3.5 w-3.5" />
+                      Restore Member
+                    </Button>
+                  )
+                : (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-8 gap-1 text-sm text-destructive hover:text-destructive"
+                      onClick={() => setArchiveModalMode('archive')}
+                    >
+                      <Archive className="h-3.5 w-3.5" />
+                      Archive Member
+                    </Button>
+                  )
             )}
           </div>
           <div className="flex flex-wrap items-center gap-2">
@@ -1784,6 +1828,17 @@ export default function EditMemberPage() {
             onSuccess={handleLifecycleSuccess}
           />
         </>
+      )}
+
+      {currentMember && archiveModalMode && (
+        <ArchiveMemberModal
+          isOpen={archiveModalMode !== null}
+          onClose={() => setArchiveModalMode(null)}
+          memberId={currentMember.id}
+          memberName={`${currentMember.firstName || ''} ${currentMember.lastName || ''}`.trim()}
+          mode={archiveModalMode}
+          onSuccess={handleArchiveSuccess}
+        />
       )}
     </div>
   );

--- a/src/features/classes/wizard/ClassTagsStep.test.tsx
+++ b/src/features/classes/wizard/ClassTagsStep.test.tsx
@@ -125,6 +125,29 @@ describe('ClassTagsStep', () => {
     expect(availableTagsLabel).toBeTruthy();
   });
 
+  it('constrains the available-tags list height so it scrolls instead of overflowing (#234)', () => {
+    render(
+      <ClassTagsStep
+        data={mockData}
+        onUpdate={mockHandlers.onUpdate}
+        onNext={mockHandlers.onNext}
+        onBack={mockHandlers.onBack}
+        onCancel={mockHandlers.onCancel}
+        isLoading={false}
+        classTags={mockClassTags}
+      />,
+    );
+
+    // The available-tags box (immediately following its label) must be capped
+    // in height with vertical scroll so a large tag list can't push the wizard
+    // footer off-screen.
+    const label = page.getByText('Available Tags').element();
+    const box = label.parentElement?.querySelector('div');
+
+    expect(box?.className).toContain('max-h-96');
+    expect(box?.className).toContain('overflow-y-auto');
+  });
+
   it('should call onCancel when Cancel button is clicked', async () => {
     render(
       <ClassTagsStep

--- a/src/features/classes/wizard/ClassTagsStep.tsx
+++ b/src/features/classes/wizard/ClassTagsStep.tsx
@@ -96,7 +96,7 @@ export const ClassTagsStep = ({
         {/* Selected Tags */}
         <div className="space-y-2">
           <label className="text-sm font-medium text-foreground">{t('selected_tags_label')}</label>
-          <div className="min-h-[48px] rounded-lg border border-border bg-background p-3">
+          <div className="max-h-40 min-h-12 overflow-y-auto rounded-lg border border-border bg-background p-3">
             {selectedTagObjects.length === 0
               ? (
                   <p className="text-sm text-muted-foreground">{t('no_tags_selected')}</p>
@@ -128,7 +128,7 @@ export const ClassTagsStep = ({
         {/* Available Tags */}
         <div className="space-y-2">
           <label className="text-sm font-medium text-foreground">{t('available_tags_label')}</label>
-          <div className="rounded-lg border border-border bg-background p-4">
+          <div className="max-h-96 overflow-y-auto rounded-lg border border-border bg-background p-4">
             {availableTags.length === 0
               ? (
                   <p className="text-sm text-muted-foreground">{t('all_tags_selected')}</p>

--- a/src/features/events/details/EnrollMemberModal.tsx
+++ b/src/features/events/details/EnrollMemberModal.tsx
@@ -26,6 +26,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { client } from '@/libs/Orpc';
+import { rankMembersByQuery } from '@/utils/MemberSearch';
 
 type EnrollMember = {
   id: string;
@@ -121,18 +122,11 @@ export function EnrollMemberModal({
     };
   }, [isOpen]);
 
-  const filteredMembers = useMemo(() => {
-    if (!searchQuery.trim()) {
-      return members;
-    }
-    const q = searchQuery.toLowerCase();
-    return members.filter(
-      m =>
-        m.firstName.toLowerCase().includes(q)
-        || m.lastName.toLowerCase().includes(q)
-        || m.email.toLowerCase().includes(q),
-    );
-  }, [members, searchQuery]);
+  // Prefix-priority, alphabetically-ordered member search (#244).
+  const filteredMembers = useMemo(
+    () => rankMembersByQuery(members, searchQuery),
+    [members, searchQuery],
+  );
 
   const selectedTier = useMemo(
     () => (tierId === NO_TIER ? null : billingTiers.find(b => b.id === tierId) ?? null),

--- a/src/features/members/MembersTable.test.tsx
+++ b/src/features/members/MembersTable.test.tsx
@@ -1270,4 +1270,74 @@ describe('MembersTable', () => {
       expect(page.getByText('Total members')).toBeInTheDocument();
     });
   });
+
+  describe('Page size selector (#258)', () => {
+    const manyMembers = Array.from({ length: 30 }, (_, i) =>
+      createMockMember({ id: String(i), firstName: `Member${String(i).padStart(2, '0')}`, lastName: 'Test', email: `m${i}@x.com` }));
+
+    it('renders a rows-per-page selector', () => {
+      render(<MembersTable members={manyMembers} onRowClickAction={vi.fn()} />);
+
+      expect(page.getByLabelText('Rows per page')).toBeInTheDocument();
+    });
+
+    it('shows only 10 rows by default (30 members → first page)', () => {
+      render(<MembersTable members={manyMembers} onRowClickAction={vi.fn()} />);
+
+      const table = page.getByRole('table');
+
+      // Row 00 is on page 1; row 10 is on page 2 (not shown yet).
+      expect(table.getByText('Member00 Test')).toBeInTheDocument();
+      expect(table.getByText('Member10 Test').elements().length).toBe(0);
+    });
+
+    it('shows more rows after choosing a larger page size', async () => {
+      render(<MembersTable members={manyMembers} onRowClickAction={vi.fn()} />);
+
+      await page.getByLabelText('Rows per page').click();
+      await page.getByRole('option', { name: '25' }).click();
+
+      const table = page.getByRole('table');
+
+      // Member10 (index 10) now fits within the 25-row page.
+      expect(table.getByText('Member10 Test')).toBeInTheDocument();
+    });
+  });
+
+  describe('Search relevance (#244)', () => {
+    it('ranks name-prefix matches above email-only matches', async () => {
+      const members = [
+        createMockMember({ id: '1', firstName: 'Zoe', lastName: 'Zilch', email: 'jane@x.com' }), // "jane" only in email
+        createMockMember({ id: '2', firstName: 'Jane', lastName: 'Doe', email: 'jd@x.com' }), // "jane" prefixes first name
+      ];
+
+      render(<MembersTable members={members} onRowClickAction={vi.fn()} />);
+
+      const searchInput = page.getByPlaceholder('search_placeholder');
+      await userEvent.fill(searchInput.element() as HTMLInputElement, 'jane');
+
+      const rows = page.getByRole('table').getByRole('row').elements();
+      // rows[0] is the header; first data row should be the name-prefix match.
+      const firstDataRow = rows[1]!;
+
+      expect(firstDataRow.textContent).toContain('Jane Doe');
+    });
+
+    it('filters out members that do not match at all', async () => {
+      const members = [
+        createMockMember({ id: '1', firstName: 'Jane', lastName: 'Doe', email: 'jane@x.com' }),
+        createMockMember({ id: '2', firstName: 'Bob', lastName: 'Smith', email: 'bob@x.com' }),
+      ];
+
+      render(<MembersTable members={members} onRowClickAction={vi.fn()} />);
+
+      const searchInput = page.getByPlaceholder('search_placeholder');
+      await userEvent.fill(searchInput.element() as HTMLInputElement, 'jane');
+
+      const table = page.getByRole('table');
+
+      expect(table.getByText('Jane Doe')).toBeInTheDocument();
+      expect(table.getByText('Bob Smith').elements().length).toBe(0);
+    });
+  });
 });

--- a/src/features/members/MembersTable.tsx
+++ b/src/features/members/MembersTable.tsx
@@ -6,9 +6,17 @@ import { useCallback, useMemo, useState } from 'react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Pagination } from '@/components/ui/pagination/Pagination';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Spinner } from '@/components/ui/spinner';
 import { MemberCard } from '@/templates/MemberCard';
 import { StatsCards } from '@/templates/StatsCards';
+import { compareMembersAlphabetically, memberSearchRank } from '@/utils/MemberSearch';
 import { MemberFilterBar } from './MemberFilterBar';
 
 type Member = {
@@ -41,6 +49,10 @@ type MembersTableProps = {
 
 type SortField = 'firstName' | 'membershipType' | 'amountDue' | 'nextPayment' | 'status' | 'lastAccessedAt';
 type SortDirection = 'asc' | 'desc';
+
+// Page-size options for the members list (#258).
+const PAGE_SIZE_OPTIONS = [10, 25, 50, 100] as const;
+const DEFAULT_PAGE_SIZE = 10;
 
 // Pure presentation helpers — hoisted to module scope so they are not
 // re-allocated on every render and not recreated per row.
@@ -145,12 +157,20 @@ export function MembersTable({
   const [sortField, setSortField] = useState<SortField>('firstName');
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
   const [currentPage, setCurrentPage] = useState(initialPage);
-  const ROWS_PER_PAGE = 10;
+  const [rowsPerPage, setRowsPerPage] = useState<number>(DEFAULT_PAGE_SIZE);
 
   const handlePageChange = useCallback((page: number) => {
     setCurrentPage(page);
     onPageChangeAction?.(page);
   }, [onPageChangeAction]);
+
+  const handleRowsPerPageChange = useCallback((value: string) => {
+    const size = Number.parseInt(value, 10);
+    if (!Number.isNaN(size)) {
+      setRowsPerPage(size);
+      handlePageChange(0);
+    }
+  }, [handlePageChange]);
 
   const handleFiltersChange = useCallback((newFilters: MemberFilters) => {
     setFilters(newFilters);
@@ -179,15 +199,12 @@ export function MembersTable({
     return Array.from(types).sort();
   }, [members]);
 
+  const searchQuery = filters.search.trim().toLowerCase();
+
   const filteredMembers = useMemo(() => {
-    const searchLower = filters.search.toLowerCase();
     return members.filter((member) => {
-      // Search filter
-      const matchesSearch = filters.search === ''
-        || (member.firstName?.toLowerCase().includes(searchLower))
-        || (member.lastName?.toLowerCase().includes(searchLower))
-        || member.email.toLowerCase().includes(searchLower)
-        || (member.phone?.toLowerCase().includes(searchLower));
+      // Search filter — prefix-priority relevance (#244); null rank = no match.
+      const matchesSearch = searchQuery === '' || memberSearchRank(member, searchQuery) !== null;
 
       // Status filter
       const matchesStatus = filters.status === 'all' || member.status === filters.status;
@@ -198,55 +215,67 @@ export function MembersTable({
 
       return matchesSearch && matchesStatus && matchesMembershipType;
     });
-  }, [members, filters]);
+  }, [members, filters.status, filters.membershipType, searchQuery]);
 
-  const sortedMembers = useMemo(() => [...filteredMembers].sort((a, b) => {
-    let aValue: string | number | Date | null | undefined;
-    let bValue: string | number | Date | null | undefined;
-
-    switch (sortField) {
-      case 'firstName':
-        aValue = `${a.firstName || ''} ${a.lastName || ''}`.toLowerCase();
-        bValue = `${b.firstName || ''} ${b.lastName || ''}`.toLowerCase();
-        break;
-      case 'membershipType':
-        aValue = a.memberType || '';
-        bValue = b.memberType || '';
-        break;
-      case 'amountDue':
-        aValue = a.amountDue ? Number.parseFloat(a.amountDue) : 0;
-        bValue = b.amountDue ? Number.parseFloat(b.amountDue) : 0;
-        break;
-      case 'nextPayment':
-        aValue = a.nextPayment ? new Date(a.nextPayment).getTime() : 0;
-        bValue = b.nextPayment ? new Date(b.nextPayment).getTime() : 0;
-        break;
-      case 'status':
-        aValue = a.status.toLowerCase();
-        bValue = b.status.toLowerCase();
-        break;
-      case 'lastAccessedAt':
-        aValue = a.lastAccessedAt ? new Date(a.lastAccessedAt).getTime() : 0;
-        bValue = b.lastAccessedAt ? new Date(b.lastAccessedAt).getTime() : 0;
-        break;
-      default:
-        aValue = '';
-        bValue = '';
+  const sortedMembers = useMemo(() => {
+    // When actively searching, relevance ranking wins over the column sort
+    // (#244) — prefix matches first, then alphabetical within each rank tier.
+    if (searchQuery !== '') {
+      return [...filteredMembers].sort((a, b) => {
+        const rankA = memberSearchRank(a, searchQuery) ?? Number.MAX_SAFE_INTEGER;
+        const rankB = memberSearchRank(b, searchQuery) ?? Number.MAX_SAFE_INTEGER;
+        return (rankA - rankB) || compareMembersAlphabetically(a, b);
+      });
     }
 
-    if (aValue < bValue) {
-      return sortDirection === 'asc' ? -1 : 1;
-    }
-    if (aValue > bValue) {
-      return sortDirection === 'asc' ? 1 : -1;
-    }
-    return 0;
-  }), [filteredMembers, sortField, sortDirection]);
+    return [...filteredMembers].sort((a, b) => {
+      let aValue: string | number | Date | null | undefined;
+      let bValue: string | number | Date | null | undefined;
 
-  const totalPages = Math.ceil(sortedMembers.length / ROWS_PER_PAGE);
+      switch (sortField) {
+        case 'firstName':
+          aValue = `${a.firstName || ''} ${a.lastName || ''}`.toLowerCase();
+          bValue = `${b.firstName || ''} ${b.lastName || ''}`.toLowerCase();
+          break;
+        case 'membershipType':
+          aValue = a.memberType || '';
+          bValue = b.memberType || '';
+          break;
+        case 'amountDue':
+          aValue = a.amountDue ? Number.parseFloat(a.amountDue) : 0;
+          bValue = b.amountDue ? Number.parseFloat(b.amountDue) : 0;
+          break;
+        case 'nextPayment':
+          aValue = a.nextPayment ? new Date(a.nextPayment).getTime() : 0;
+          bValue = b.nextPayment ? new Date(b.nextPayment).getTime() : 0;
+          break;
+        case 'status':
+          aValue = a.status.toLowerCase();
+          bValue = b.status.toLowerCase();
+          break;
+        case 'lastAccessedAt':
+          aValue = a.lastAccessedAt ? new Date(a.lastAccessedAt).getTime() : 0;
+          bValue = b.lastAccessedAt ? new Date(b.lastAccessedAt).getTime() : 0;
+          break;
+        default:
+          aValue = '';
+          bValue = '';
+      }
+
+      if (aValue < bValue) {
+        return sortDirection === 'asc' ? -1 : 1;
+      }
+      if (aValue > bValue) {
+        return sortDirection === 'asc' ? 1 : -1;
+      }
+      return 0;
+    });
+  }, [filteredMembers, sortField, sortDirection, searchQuery]);
+
+  const totalPages = Math.ceil(sortedMembers.length / rowsPerPage);
   const paginatedMembers = sortedMembers.slice(
-    currentPage * ROWS_PER_PAGE,
-    (currentPage + 1) * ROWS_PER_PAGE,
+    currentPage * rowsPerPage,
+    (currentPage + 1) * rowsPerPage,
   );
 
   const handleSort = useCallback((field: SortField) => {
@@ -493,15 +522,32 @@ export function MembersTable({
                 )}
         </div>
 
-        {/* Pagination */}
+        {/* Pagination + page-size selector (#258) */}
         {!loading && sortedMembers.length > 0 && (
-          <Pagination
-            currentPage={currentPage}
-            totalPages={totalPages}
-            totalItems={sortedMembers.length}
-            itemsPerPage={ROWS_PER_PAGE}
-            onPageChangeAction={handlePageChange}
-          />
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">Rows per page</span>
+              <Select value={String(rowsPerPage)} onValueChange={handleRowsPerPageChange}>
+                <SelectTrigger size="sm" className="w-20" aria-label="Rows per page">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {PAGE_SIZE_OPTIONS.map(size => (
+                    <SelectItem key={size} value={String(size)}>
+                      {size}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <Pagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              totalItems={sortedMembers.length}
+              itemsPerPage={rowsPerPage}
+              onPageChangeAction={handlePageChange}
+            />
+          </div>
         )}
       </div>
     </div>

--- a/src/features/members/lifecycle/ArchiveMemberModal.test.tsx
+++ b/src/features/members/lifecycle/ArchiveMemberModal.test.tsx
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { page, userEvent } from 'vitest/browser';
+import { ArchiveMemberModal } from './ArchiveMemberModal';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, vars?: Record<string, unknown>) =>
+    vars ? `${key}:${JSON.stringify(vars)}` : key,
+}));
+
+const remove = vi.fn();
+const restore = vi.fn();
+vi.mock('@/libs/Orpc', () => ({
+  client: {
+    member: {
+      remove: (...args: unknown[]) => remove(...args),
+      restore: (...args: unknown[]) => restore(...args),
+    },
+  },
+}));
+
+const baseProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  memberId: 'member-1',
+  memberName: 'John Doe',
+  onSuccess: vi.fn(),
+};
+
+describe('ArchiveMemberModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    remove.mockResolvedValue({});
+    restore.mockResolvedValue({});
+  });
+
+  it('does not render when closed', () => {
+    render(<ArchiveMemberModal {...baseProps} mode="archive" isOpen={false} />);
+
+    expect(page.getByText('archive_title').elements()).toHaveLength(0);
+  });
+
+  it('shows the archive title + notice in archive mode', async () => {
+    render(<ArchiveMemberModal {...baseProps} mode="archive" />);
+
+    await expect.element(page.getByText('archive_title')).toBeInTheDocument();
+    await expect.element(page.getByText('archive_notice')).toBeInTheDocument();
+  });
+
+  it('shows the restore title + notice in restore mode', async () => {
+    render(<ArchiveMemberModal {...baseProps} mode="restore" />);
+
+    await expect.element(page.getByText('restore_title')).toBeInTheDocument();
+    await expect.element(page.getByText('restore_notice')).toBeInTheDocument();
+  });
+
+  it('calls member.remove and fires success when archiving', async () => {
+    const onSuccess = vi.fn();
+    const onClose = vi.fn();
+    render(<ArchiveMemberModal {...baseProps} mode="archive" onSuccess={onSuccess} onClose={onClose} />);
+
+    await userEvent.click(page.getByText('archive_confirm_button'));
+
+    expect(remove).toHaveBeenCalledWith({ id: 'member-1' });
+    expect(restore).not.toHaveBeenCalled();
+
+    await vi.waitFor(() => expect(onSuccess).toHaveBeenCalled());
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('calls member.restore and fires success when restoring', async () => {
+    const onSuccess = vi.fn();
+    render(<ArchiveMemberModal {...baseProps} mode="restore" onSuccess={onSuccess} />);
+
+    await userEvent.click(page.getByText('restore_confirm_button'));
+
+    expect(restore).toHaveBeenCalledWith({ id: 'member-1' });
+    expect(remove).not.toHaveBeenCalled();
+
+    await vi.waitFor(() => expect(onSuccess).toHaveBeenCalled());
+  });
+
+  it('surfaces an error and keeps the modal open on failure', async () => {
+    const onClose = vi.fn();
+    remove.mockRejectedValue(new Error('boom'));
+    render(<ArchiveMemberModal {...baseProps} mode="archive" onClose={onClose} />);
+
+    await userEvent.click(page.getByText('archive_confirm_button'));
+
+    await expect.element(page.getByText('boom')).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/members/lifecycle/ArchiveMemberModal.tsx
+++ b/src/features/members/lifecycle/ArchiveMemberModal.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { AlertTriangle, ArchiveRestore } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { client } from '@/libs/Orpc';
+
+type ArchiveMemberModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  memberId: string;
+  memberName: string;
+  // 'archive' soft-archives an active member; 'restore' reactivates an archived one.
+  mode: 'archive' | 'restore';
+  onSuccess?: () => void;
+};
+
+export function ArchiveMemberModal({
+  isOpen,
+  onClose,
+  memberId,
+  memberName,
+  mode,
+  onSuccess,
+}: ArchiveMemberModalProps) {
+  const t = useTranslations('MemberDetailPage.ArchiveMemberModal');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isArchive = mode === 'archive';
+
+  const handleConfirm = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      if (isArchive) {
+        await client.member.remove({ id: memberId });
+      } else {
+        await client.member.restore({ id: memberId });
+      }
+      onSuccess?.();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('error_generic'));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open && !isLoading) {
+      setError(null);
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-h-[calc(100dvh-2rem)] max-w-lg overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{isArchive ? t('archive_title') : t('restore_title')}</DialogTitle>
+          <DialogDescription>
+            {isArchive
+              ? t('archive_description', { memberName })
+              : t('restore_description', { memberName })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          {isArchive
+            ? (
+                <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-900 dark:bg-amber-950">
+                  <div className="flex items-start gap-3">
+                    <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400" />
+                    <p className="text-sm text-amber-800 dark:text-amber-200">{t('archive_notice')}</p>
+                  </div>
+                </div>
+              )
+            : (
+                <div className="rounded-lg border border-border p-4">
+                  <div className="flex items-start gap-3">
+                    <ArchiveRestore className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
+                    <p className="text-sm text-muted-foreground">{t('restore_notice')}</p>
+                  </div>
+                </div>
+              )}
+
+          {error && (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-3">
+          <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={isLoading}>
+            {t('back_button')}
+          </Button>
+          <Button
+            variant={isArchive ? 'destructive' : 'default'}
+            onClick={handleConfirm}
+            disabled={isLoading}
+          >
+            {isLoading
+              ? t('confirming_button')
+              : isArchive
+                ? t('archive_confirm_button')
+                : t('restore_confirm_button')}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/members/wizard/HOHSelectionStep.tsx
+++ b/src/features/members/wizard/HOHSelectionStep.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { client } from '@/libs/Orpc';
+import { rankMembersByQuery } from '@/utils/MemberSearch';
 
 type HOHMember = {
   id: string;
@@ -60,19 +61,11 @@ export const HOHSelectionStep = ({
       });
   }, []);
 
-  // Filter by search query
-  const filteredMembers = useMemo(() => {
-    if (!searchQuery.trim()) {
-      return hohMembers;
-    }
-    const query = searchQuery.toLowerCase();
-    return hohMembers.filter(
-      m =>
-        m.firstName.toLowerCase().includes(query)
-        || m.lastName.toLowerCase().includes(query)
-        || m.email.toLowerCase().includes(query),
-    );
-  }, [hohMembers, searchQuery]);
+  // Filter + rank by search query (#244) — prefix-priority, alphabetical.
+  const filteredMembers = useMemo(
+    () => rankMembersByQuery(hohMembers, searchQuery),
+    [hohMembers, searchQuery],
+  );
 
   const getInitials = (firstName: string, lastName: string) => {
     return `${firstName[0] || ''}${lastName[0] || ''}`.toUpperCase();

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2070,6 +2070,19 @@
     }
   },
   "MemberDetailPage": {
+    "ArchiveMemberModal": {
+      "archive_title": "Archive Member",
+      "restore_title": "Restore Member",
+      "archive_description": "Archive {memberName}? They will be marked inactive and hidden from the active roster, but their history is preserved.",
+      "restore_description": "Restore {memberName} to active status?",
+      "archive_notice": "Archiving keeps all of the member's records — you can restore them at any time. This does not delete any data.",
+      "restore_notice": "The member will be set back to active and appear on the roster again.",
+      "back_button": "Cancel",
+      "archive_confirm_button": "Archive Member",
+      "restore_confirm_button": "Restore Member",
+      "confirming_button": "Working…",
+      "error_generic": "The action could not be completed. Please try again."
+    },
     "CancelMembershipModal": {
       "title": "Cancel Membership",
       "description": "Cancel {memberName}'s {planName} membership? This action cannot be undone.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -2075,6 +2075,19 @@
     }
   },
   "MemberDetailPage": {
+    "ArchiveMemberModal": {
+      "archive_title": "Archiver le membre",
+      "restore_title": "Restaurer le membre",
+      "archive_description": "Archiver {memberName} ? Le membre sera marqué comme inactif et retiré de la liste active, mais son historique est conservé.",
+      "restore_description": "Restaurer {memberName} au statut actif ?",
+      "archive_notice": "L'archivage conserve tous les dossiers du membre — vous pouvez le restaurer à tout moment. Aucune donnée n'est supprimée.",
+      "restore_notice": "Le membre redeviendra actif et réapparaîtra dans la liste.",
+      "back_button": "Annuler",
+      "archive_confirm_button": "Archiver le membre",
+      "restore_confirm_button": "Restaurer le membre",
+      "confirming_button": "En cours…",
+      "error_generic": "L'action n'a pas pu être effectuée. Veuillez réessayer."
+    },
     "CancelMembershipModal": {
       "title": "Annuler l'adhésion",
       "description": "Annuler l'adhésion {planName} de {memberName} ? Cette action ne peut pas être annulée.",

--- a/src/routers/Member.test.ts
+++ b/src/routers/Member.test.ts
@@ -77,7 +77,15 @@ describe('Member Router', () => {
       { id: 'hoh-3', firstName: 'Bob', lastName: 'Johnson', email: 'bob@test.com', phone: '555-0003', photoUrl: null, status: 'active' },
     ];
 
-    it('should return all HOH members when no query is provided', async () => {
+    // With #244 an empty query returns every HOH member ordered alphabetically
+    // by "lastName firstName": Doe, Johnson, Smith.
+    const alphabetical = [
+      { id: 'hoh-1', firstName: 'John', lastName: 'Doe', email: 'john@test.com', phone: '555-0001', photoUrl: null, status: 'active' },
+      { id: 'hoh-3', firstName: 'Bob', lastName: 'Johnson', email: 'bob@test.com', phone: '555-0003', photoUrl: null, status: 'active' },
+      { id: 'hoh-2', firstName: 'Jane', lastName: 'Smith', email: 'jane@test.com', phone: null, photoUrl: null, status: 'active' },
+    ];
+
+    it('should return all HOH members alphabetically when no query is provided (#244)', async () => {
       const { guardRole } = await import('./AuthGuards');
       const { getHeadOfHouseholdMembers } = await import('@/services/MembersService');
 
@@ -89,7 +97,7 @@ describe('Member Router', () => {
 
       expect(guardRole).toHaveBeenCalledWith(ORG_ROLE.FRONT_DESK);
       expect(getHeadOfHouseholdMembers).toHaveBeenCalledWith('test-org-456');
-      expect(result).toEqual({ members: mockHOHMembers });
+      expect(result).toEqual({ members: alphabetical });
     });
 
     it('should filter HOH members by query (case-insensitive name match)', async () => {
@@ -122,7 +130,7 @@ describe('Member Router', () => {
       });
     });
 
-    it('should return all members when query is whitespace only', async () => {
+    it('should return all members alphabetically when query is whitespace only (#244)', async () => {
       const { guardRole } = await import('./AuthGuards');
       const { getHeadOfHouseholdMembers } = await import('@/services/MembersService');
 
@@ -132,7 +140,7 @@ describe('Member Router', () => {
       const { searchHOH } = await import('./Member');
       const result = await callHandler(searchHOH, { query: '   ' });
 
-      expect(result).toEqual({ members: mockHOHMembers });
+      expect(result).toEqual({ members: alphabetical });
     });
   });
 

--- a/src/routers/Member.ts
+++ b/src/routers/Member.ts
@@ -12,6 +12,7 @@ import { generatePdfFilename } from '@/services/WaiverPdfService';
 import { generateWaiverPdfBuffer } from '@/services/WaiverPdfService.server';
 import { AUDIT_ACTION, AUDIT_ENTITY_TYPE } from '@/types/Audit';
 import { ORG_ROLE } from '@/types/Auth';
+import { rankMembersByQuery } from '@/utils/MemberSearch';
 import { CancelMembershipValidation, DeleteMemberValidation, EditMemberValidation, GetHOHForMemberValidation, GetHOHPaymentMethodsValidation, HoldMembershipValidation, LinkFamilyMemberValidation, ListFamilyMembersValidation, MemberPaymentMethodsValidation, MemberTransactionsValidation, MemberValidation, PaymentMethodMutationValidation, ReactivateMembershipValidation, RemoveFullyMemberValidation, SearchHOHValidation, SendConfirmationEmailValidation, UnlinkFamilyMemberValidation, UpdateMemberContactInfoValidation, UpdateMemberPhotoValidation, UpdateMemberTypeValidation } from '@/validations/MemberValidation';
 import { guardAuth, guardRole } from './AuthGuards';
 
@@ -723,16 +724,9 @@ export const searchHOH = os
     const { orgId } = await guardRole(ORG_ROLE.FRONT_DESK);
     const hohMembers = await getHeadOfHouseholdMembers(orgId);
 
-    if (input.query && input.query.trim()) {
-      const q = input.query.trim().toLowerCase();
-      return {
-        members: hohMembers.filter(m =>
-          `${m.firstName} ${m.lastName}`.toLowerCase().includes(q)
-          || m.email.toLowerCase().includes(q),
-        ),
-      };
-    }
-    return { members: hohMembers };
+    // Prefix-priority, alphabetically-ordered relevance ranking (#244). An empty
+    // query returns every HOH member alphabetically.
+    return { members: rankMembersByQuery(hohMembers, input.query ?? '') };
   });
 
 export const linkFamily = os

--- a/src/utils/MemberSearch.test.ts
+++ b/src/utils/MemberSearch.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { compareMembersAlphabetically, memberSearchRank, rankMembersByQuery } from './MemberSearch';
+
+const m = (firstName: string | null, lastName: string | null, email = 'x@example.com', phone: string | null = null) => ({
+  firstName,
+  lastName,
+  email,
+  phone,
+});
+
+describe('memberSearchRank', () => {
+  it('returns 0 for an empty query (everything matches)', () => {
+    expect(memberSearchRank(m('Jane', 'Doe'), '')).toBe(0);
+  });
+
+  it('ranks a name prefix as 0', () => {
+    expect(memberSearchRank(m('Jane', 'Doe'), 'jan')).toBe(0);
+    expect(memberSearchRank(m('Jane', 'Doe'), 'do')).toBe(0); // last-name prefix
+    expect(memberSearchRank(m('Jane', 'Doe'), 'jane d')).toBe(0); // full-name prefix
+  });
+
+  it('ranks a mid-name substring as 1', () => {
+    expect(memberSearchRank(m('Jane', 'Doe'), 'ane')).toBe(1);
+  });
+
+  it('ranks an email/phone prefix as 2', () => {
+    expect(memberSearchRank(m('Jane', 'Doe', 'zoe@example.com'), 'zoe')).toBe(2);
+    expect(memberSearchRank(m('Jane', 'Doe', 'x@example.com', '5551234'), '555')).toBe(2);
+  });
+
+  it('ranks an email/phone substring as 3', () => {
+    expect(memberSearchRank(m('Jane', 'Doe', 'jane@company.com'), 'company')).toBe(3);
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(memberSearchRank(m('Jane', 'Doe', 'jane@x.com'), 'zzz')).toBeNull();
+  });
+
+  it('handles null name parts safely', () => {
+    expect(memberSearchRank(m(null, null, 'solo@x.com'), 'solo')).toBe(2);
+    expect(memberSearchRank(m(null, null, 'solo@x.com'), 'nope')).toBeNull();
+  });
+
+  it('does not treat an empty phone as a prefix match', () => {
+    // Empty phone must not match a non-empty query via ''.startsWith(q).
+    expect(memberSearchRank(m('Jane', 'Doe', 'jane@x.com', null), 'zzz')).toBeNull();
+  });
+});
+
+describe('compareMembersAlphabetically', () => {
+  it('orders by lastName then firstName, case-insensitively', () => {
+    expect(compareMembersAlphabetically(m('Ann', 'Adams'), m('Bob', 'Baker'))).toBeLessThan(0);
+    expect(compareMembersAlphabetically(m('Zed', 'Adams'), m('Ann', 'Adams'))).toBeGreaterThan(0);
+  });
+});
+
+describe('rankMembersByQuery', () => {
+  const members = [
+    m('Bob', 'Anderson', 'bob@x.com'),
+    m('Janet', 'Zephyr', 'janet@x.com'), // "jan" prefix on first name
+    m('Alice', 'Jones', 'alice@x.com'),
+    m('Mike', 'Bojangles', 'mike@x.com'), // "jan" substring in last name (Bojangles? no) -> use different
+  ];
+
+  it('returns all members alphabetically for an empty query', () => {
+    const result = rankMembersByQuery(members, '');
+
+    expect(result.map(r => r.lastName)).toEqual(['Anderson', 'Bojangles', 'Jones', 'Zephyr']);
+  });
+
+  it('filters out non-matches and ranks prefix matches first', () => {
+    const pool = [
+      m('Janet', 'Smith', 'janet@x.com'), // first-name prefix "jan" -> rank 0
+      m('Bob', 'Dejan', 'bob@x.com'), // "jan" mid last name -> rank 1
+      m('Zoe', 'Zoe', 'jane@x.com'), // "jan" in email -> rank 3
+      m('Nomatch', 'Person', 'no@x.com'), // filtered out
+    ];
+    const result = rankMembersByQuery(pool, 'jan');
+
+    expect(result).toHaveLength(3);
+    expect(result[0]!.firstName).toBe('Janet'); // rank 0
+    expect(result[1]!.lastName).toBe('Dejan'); // rank 1
+    expect(result[2]!.email).toBe('jane@x.com'); // rank 3
+  });
+
+  it('breaks rank ties alphabetically', () => {
+    const pool = [
+      m('Jane', 'Wilson', 'jw@x.com'), // rank 0
+      m('Jane', 'Adams', 'ja@x.com'), // rank 0
+    ];
+    const result = rankMembersByQuery(pool, 'jane');
+
+    expect(result.map(r => r.lastName)).toEqual(['Adams', 'Wilson']);
+  });
+});

--- a/src/utils/MemberSearch.ts
+++ b/src/utils/MemberSearch.ts
@@ -1,0 +1,67 @@
+// Shared member-search relevance helpers (#244).
+//
+// Every member-search box in the app previously used a plain substring
+// (`.includes`) filter with no relevance ordering. These helpers give a single,
+// consistent behavior: prefix matches on a name rank above mid-word substring
+// matches, which rank above email/phone matches, and ties break alphabetically.
+
+export type SearchableMember = {
+  firstName: string | null;
+  lastName: string | null;
+  email: string;
+  phone?: string | null;
+};
+
+// Lower rank = better match. `null` means "no match" (filtered out).
+//   0 — query is a prefix of the full name or a name part
+//   1 — query is a substring within a name part
+//   2 — query is a prefix of the email / phone
+//   3 — query is a substring within the email / phone
+export function memberSearchRank(member: SearchableMember, query: string): number | null {
+  const q = query.trim().toLowerCase();
+  if (q === '') {
+    return 0;
+  }
+  const first = (member.firstName ?? '').toLowerCase();
+  const last = (member.lastName ?? '').toLowerCase();
+  const full = `${first} ${last}`.trim();
+  const email = member.email.toLowerCase();
+  const phone = (member.phone ?? '').toLowerCase();
+
+  if (full.startsWith(q) || first.startsWith(q) || last.startsWith(q)) {
+    return 0;
+  }
+  if (first.includes(q) || last.includes(q)) {
+    return 1;
+  }
+  if ((phone !== '' && phone.startsWith(q)) || email.startsWith(q)) {
+    return 2;
+  }
+  if ((phone !== '' && phone.includes(q)) || email.includes(q)) {
+    return 3;
+  }
+  return null;
+}
+
+// Alphabetical comparison by "lastName, firstName" (case-insensitive), used to
+// break ties within a relevance rank.
+export function compareMembersAlphabetically(a: SearchableMember, b: SearchableMember): number {
+  const aKey = `${a.lastName ?? ''} ${a.firstName ?? ''}`.trim().toLowerCase();
+  const bKey = `${b.lastName ?? ''} ${b.firstName ?? ''}`.trim().toLowerCase();
+  return aKey.localeCompare(bKey);
+}
+
+// Filter + rank a member list against a query. An empty query returns every
+// member alphabetically. Otherwise non-matches are dropped and results are
+// ordered by relevance rank, then alphabetically within each rank tier.
+export function rankMembersByQuery<T extends SearchableMember>(members: T[], query: string): T[] {
+  const q = query.trim().toLowerCase();
+  if (q === '') {
+    return [...members].sort(compareMembersAlphabetically);
+  }
+  return members
+    .map(member => ({ member, rank: memberSearchRank(member, q) }))
+    .filter((entry): entry is { member: T; rank: number } => entry.rank !== null)
+    .sort((a, b) => (a.rank - b.rank) || compareMembersAlphabetically(a.member, b.member))
+    .map(entry => entry.member);
+}


### PR DESCRIPTION
## Summary

Closes the final tier of the defect roadmap (Tier 4 feature requests). One item (#251) was already shipped in an earlier group; the remaining four are implemented here. These are UI/UX features sharing one small util — no DB migration.

## Defects resolved

- #221 — Academy owner can now archive/restore members (backend already existed and was academy-owner-gated; this adds the missing UI).
- #234 — Class-tags picker now scrolls instead of overflowing and pushing the wizard footer off-screen.
- #244 — Member search now ranks prefix matches first and orders results alphabetically, instead of unranked substring matching.
- #258 — Member list now has a configurable page size (rows-per-page selector).
- #251 — "Camp" event type: already shipped in a prior group; verified present, no change in this PR.

## Changes

### #221 — Member archive / restore (academy owner)
- New `ArchiveMemberModal.tsx` — archive calls `member.remove` (soft-archive → `status='cancelled'`, preserves all history) and navigates back to the list; restore calls `member.restore` (→ `status='active'`) when the member is archived.
- New "Archive Member" / "Restore Member" button on the member detail page, gated via `useHasRole(ORG_ROLE.ACADEMY_OWNER)` to mirror the endpoints' existing guards. No schema change (the `member.remove`/`member.restore` endpoints already existed with academy-owner gating).

### #244 — Member search relevance
- New shared util `src/utils/MemberSearch.ts`: `memberSearchRank` (name-prefix > mid-name substring > email/phone prefix > email/phone substring), `compareMembersAlphabetically`, and `rankMembersByQuery`.
- Applied to all four member-search sites so they behave identically: `MembersTable` (relevance overrides the column sort while a query is active), `HOHSelectionStep`, event `EnrollMemberModal`, and the server-side `member.searchHOH` endpoint. An empty query returns everyone alphabetically.

### #258 — Member list page size
- Added a "Rows per page" selector (10 / 25 / 50 / 100, default 10) to `MembersTable.tsx`; changing it resets to page 0. Fully client-side (no backend change — `client.members.list` already returns the full set).

### #234 — Class-tags scroll
- Added `max-h-96 overflow-y-auto` (available tags) and `max-h-40 overflow-y-auto` (selected tags) to `ClassTagsStep.tsx`, matching the `MembershipStep.tsx` convention, so a large tag list scrolls.

## Tests
- `MemberSearch.test.ts` — 12 (ranking tiers, null-safety, tie-break ordering, empty-query alphabetical)
- `MembersTable.test.tsx` — 5 new (page-size selector, larger page size, search relevance ordering, non-match filtering)
- `ArchiveMemberModal.test.tsx` — 6 (archive/restore titles + notices, `member.remove`/`member.restore` dispatch, error handling)
- `ClassTagsStep.test.tsx` — 1 new (available-tags box has the scroll constraint)
- `Member.test.ts` — updated 2 `searchHOH` cases for the new alphabetical ordering