### PR TITLE
chore(transactions): fixed kiosk one-off transactions

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -796,7 +796,7 @@ await deleteUserWithOrganization();
 - `event_billing` - Event pricing tiers
 - `tag` - Polymorphic tags for classes/memberships/events
 - `coupon` - Discount codes
-- `transaction` - Financial transactions (membership payments, signup fees, event registrations, refunds, adjustments), optional `iqproTransactionId`
+- `transaction` - Financial transactions (membership payments, signup fees, event registrations, refunds, adjustments), optional `iqproTransactionId`. `member_id` is **nullable**: a null member = a guest / non-member sale (e.g. a kiosk store purchase by someone who isn't a member). Member-scoped queries filter on `member_id` so guest rows don't appear on a member's page; the org-wide transactions list/detail (`TransactionsService`) `leftJoin` member (NOT inner — an inner join would drop guest rows) and the UI shows "Non-member" when there's no member name. Guest purchase detail rides in `description`; there is no separate customer-name column.
 - `attendance` - Check-in records
 - `audit_event` - SOC2 compliance audit logging
 - `payment_method` - Saved payment methods (card, bank_transfer, cash, check), optional `iqproPaymentMethodId`

--- a/migrations/0000_baseline.sql
+++ b/migrations/0000_baseline.sql
@@ -499,7 +499,7 @@ CREATE TABLE "tag" (
 CREATE TABLE "transaction" (
 	"id" text PRIMARY KEY NOT NULL,
 	"organization_id" text NOT NULL,
-	"member_id" text NOT NULL,
+	"member_id" text,
 	"member_membership_id" text,
 	"event_registration_id" text,
 	"stripe_payment_intent_id" text,

--- a/src/app/[locale]/(auth)/dashboard/transactions/page.tsx
+++ b/src/app/[locale]/(auth)/dashboard/transactions/page.tsx
@@ -57,12 +57,14 @@ export default function TransactionsPage() {
       purpose: TRANSACTION_TYPE_LABELS[tx.transactionType] ?? tx.transactionType,
       method: formatPaymentMethod(tx.paymentMethod, tx.description),
       transactionId: `TXN${tx.id.slice(0, 12).toUpperCase()}`,
-      memberName: [tx.memberFirstName, tx.memberLastName].filter(Boolean).join(' '),
+      // Guest / non-member transactions (e.g. kiosk store sales) have no member
+      // — show a "Non-member" label instead of a blank cell.
+      memberName: [tx.memberFirstName, tx.memberLastName].filter(Boolean).join(' ') || t('non_member'),
       memberId: tx.memberId,
       status: tx.status as Transaction['status'],
       transactionType: tx.transactionType,
     }));
-  }, [rawTransactions]);
+  }, [rawTransactions, t]);
 
   const stats = useMemo(() => {
     const recentTransactions = getTransactionsInPast30Days(transactions);

--- a/src/features/finances/FinancesTable.test.tsx
+++ b/src/features/finances/FinancesTable.test.tsx
@@ -340,6 +340,27 @@ describe('FinancesTable', () => {
       expect(table.getByText('Alice Brown')).toBeInTheDocument();
       expect(table.getByText('Zack Williams')).toBeInTheDocument();
     });
+
+    it('renders a guest/non-member transaction (null memberId) and sorts without error', async () => {
+      // The page maps a memberless row to the "Non-member" label; memberId is
+      // null. The table must render/sort it without crashing.
+      const mockTransactions = [
+        createMockTransaction({ id: '1', memberName: 'Alice Brown', memberId: 'M001' }),
+        createMockTransaction({ id: '2', memberName: 'Non-member', memberId: null }),
+      ];
+
+      render(<FinancesTable transactions={mockTransactions} />);
+
+      const table = page.getByRole('table');
+
+      expect(table.getByText('Non-member')).toBeInTheDocument();
+
+      const memberHeader = page.getByRole('button', { name: /table_member/i });
+      await memberHeader.click();
+
+      expect(table.getByText('Alice Brown')).toBeInTheDocument();
+      expect(table.getByText('Non-member')).toBeInTheDocument();
+    });
   });
 
   describe('Status column', () => {

--- a/src/features/finances/FinancesTable.tsx
+++ b/src/features/finances/FinancesTable.tsx
@@ -21,7 +21,8 @@ export type Transaction = {
   method: string;
   transactionId: string;
   memberName: string;
-  memberId: string;
+  // null for a guest / non-member transaction (e.g. a kiosk store sale).
+  memberId: string | null;
   status: TransactionStatus;
   transactionType: string;
 };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -939,6 +939,7 @@
     "stats_refunded_label": "Refunded (Last 30 Days)",
     "table_date": "Date",
     "table_member": "Member",
+    "non_member": "Non-member",
     "table_amount": "Amount",
     "table_origin": "Origin",
     "table_method": "Method",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -942,6 +942,7 @@
     "stats_refunded_label": "Remboursé (30 derniers jours)",
     "table_date": "Date",
     "table_member": "Membre",
+    "non_member": "Non-membre",
     "table_amount": "Montant",
     "table_origin": "Origine",
     "table_method": "Méthode",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -939,6 +939,7 @@
     "stats_refunded_label": "返金済み（過去30日間）",
     "table_date": "日付",
     "table_member": "会員",
+    "non_member": "非会員",
     "table_amount": "金額",
     "table_origin": "区分",
     "table_method": "支払い方法",

--- a/src/models/Schema.ts
+++ b/src/models/Schema.ts
@@ -958,7 +958,11 @@ export const transactionSchema = pgTable(
   {
     id: text('id').primaryKey(), // UUID v4
     organizationId: text('organization_id').notNull(),
-    memberId: text('member_id').references(() => memberSchema.id).notNull(),
+    // Nullable: a null member_id is a guest / non-member sale (e.g. a kiosk
+    // store purchase by someone who isn't a member). Member-scoped queries
+    // filter on member_id so guest rows simply don't match; the org-wide
+    // transactions list leftJoins member and shows "Non-member" for these.
+    memberId: text('member_id').references(() => memberSchema.id),
     memberMembershipId: text('member_membership_id').references(() => memberMembershipSchema.id),
     eventRegistrationId: text('event_registration_id').references(() => eventRegistrationSchema.id),
     stripePaymentIntentId: text('stripe_payment_intent_id'),

--- a/src/routers/Transactions.test.ts
+++ b/src/routers/Transactions.test.ts
@@ -75,6 +75,21 @@ describe('Transactions Router', () => {
           processedAt: new Date('2026-01-02'),
           createdAt: new Date('2026-01-02'),
         },
+        {
+          // Guest / non-member sale (e.g. kiosk store purchase): null member.
+          id: 'txn_guest',
+          memberId: null,
+          memberFirstName: null,
+          memberLastName: null,
+          transactionType: 'adjustment',
+          amount: 8000,
+          currency: 'USD',
+          status: 'paid',
+          paymentMethod: 'card',
+          description: 'Store: Black Belt — John Customer',
+          processedAt: new Date('2026-01-03'),
+          createdAt: new Date('2026-01-03'),
+        },
       ];
 
       vi.mocked(guardRole).mockResolvedValue(mockContext);

--- a/src/services/TransactionsService.test.ts
+++ b/src/services/TransactionsService.test.ts
@@ -96,8 +96,8 @@ describe('TransactionsService', () => {
       const mockLimit = vi.fn().mockReturnValue({ offset: mockOffset });
       const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimit });
       const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
-      const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
-      const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+      const mockMemberJoin = vi.fn().mockReturnValue({ where: mockWhere });
+      const mockFrom = vi.fn().mockReturnValue({ leftJoin: mockMemberJoin });
       const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
 
       const { db } = await import('@/libs/DB');
@@ -110,11 +110,51 @@ describe('TransactionsService', () => {
       expect(result).toEqual(mockTransactions);
       expect(db.select).toHaveBeenCalledTimes(1);
       expect(mockFrom).toHaveBeenCalledTimes(1);
-      expect(mockInnerJoin).toHaveBeenCalledTimes(1);
+      expect(mockMemberJoin).toHaveBeenCalledTimes(1);
       expect(mockWhere).toHaveBeenCalledTimes(1);
       expect(mockOrderBy).toHaveBeenCalledTimes(1);
       expect(mockLimit).toHaveBeenCalledWith(500);
       expect(mockOffset).toHaveBeenCalledWith(0);
+    });
+
+    it('returns guest/non-member transactions (null member) via the leftJoin', async () => {
+      // A kiosk store sale has member_id = NULL and no member row. The leftJoin
+      // must keep it in the list (an innerJoin would drop it) with null names.
+      const mockTransactions = [
+        {
+          id: 'txn-guest',
+          memberId: null,
+          memberFirstName: null,
+          memberLastName: null,
+          transactionType: 'adjustment',
+          amount: 8000,
+          currency: 'USD',
+          status: 'paid',
+          paymentMethod: 'card',
+          description: 'Store: Black Belt — John Customer',
+          processedAt: new Date('2026-01-20'),
+          createdAt: new Date('2026-01-20'),
+        },
+      ];
+
+      const mockOffset = vi.fn().mockResolvedValue(mockTransactions);
+      const mockLimit = vi.fn().mockReturnValue({ offset: mockOffset });
+      const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimit });
+      const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+      const mockMemberJoin = vi.fn().mockReturnValue({ where: mockWhere });
+      const mockFrom = vi.fn().mockReturnValue({ leftJoin: mockMemberJoin });
+      const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
+
+      const { db } = await import('@/libs/DB');
+      vi.mocked(db.select).mockReturnValue(mockSelect() as any);
+
+      const { getOrganizationTransactions } = await import('./TransactionsService');
+      const result = await getOrganizationTransactions('org-test-123');
+
+      expect(result).toEqual(mockTransactions);
+      expect(result[0]?.memberId).toBeNull();
+      expect(result[0]?.memberFirstName).toBeNull();
+      expect(mockMemberJoin).toHaveBeenCalledTimes(1);
     });
 
     it('should filter by status when provided', async () => {
@@ -139,8 +179,8 @@ describe('TransactionsService', () => {
       const mockLimit = vi.fn().mockReturnValue({ offset: mockOffset });
       const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimit });
       const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
-      const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
-      const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+      const mockMemberJoin = vi.fn().mockReturnValue({ where: mockWhere });
+      const mockFrom = vi.fn().mockReturnValue({ leftJoin: mockMemberJoin });
       const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
 
       const { db } = await import('@/libs/DB');
@@ -179,8 +219,8 @@ describe('TransactionsService', () => {
       const mockLimit = vi.fn().mockReturnValue({ offset: mockOffset });
       const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimit });
       const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
-      const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
-      const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+      const mockMemberJoin = vi.fn().mockReturnValue({ where: mockWhere });
+      const mockFrom = vi.fn().mockReturnValue({ leftJoin: mockMemberJoin });
       const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
 
       const { db } = await import('@/libs/DB');
@@ -219,8 +259,8 @@ describe('TransactionsService', () => {
       const mockLimit = vi.fn().mockReturnValue({ offset: mockOffset });
       const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimit });
       const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
-      const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
-      const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+      const mockMemberJoin = vi.fn().mockReturnValue({ where: mockWhere });
+      const mockFrom = vi.fn().mockReturnValue({ leftJoin: mockMemberJoin });
       const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
 
       const { db } = await import('@/libs/DB');
@@ -245,8 +285,8 @@ describe('TransactionsService', () => {
       const mockLimit = vi.fn().mockReturnValue({ offset: mockOffset });
       const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimit });
       const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
-      const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
-      const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+      const mockMemberJoin = vi.fn().mockReturnValue({ where: mockWhere });
+      const mockFrom = vi.fn().mockReturnValue({ leftJoin: mockMemberJoin });
       const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
 
       const { db } = await import('@/libs/DB');
@@ -283,8 +323,8 @@ describe('TransactionsService', () => {
       const mockLimit = vi.fn().mockReturnValue({ offset: mockOffset });
       const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimit });
       const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
-      const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
-      const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+      const mockMemberJoin = vi.fn().mockReturnValue({ where: mockWhere });
+      const mockFrom = vi.fn().mockReturnValue({ leftJoin: mockMemberJoin });
       const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
 
       const { db } = await import('@/libs/DB');
@@ -323,8 +363,8 @@ describe('TransactionsService', () => {
       const mockLimit = vi.fn().mockReturnValue({ offset: mockOffset });
       const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimit });
       const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
-      const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
-      const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+      const mockMemberJoin = vi.fn().mockReturnValue({ where: mockWhere });
+      const mockFrom = vi.fn().mockReturnValue({ leftJoin: mockMemberJoin });
       const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
 
       const { db } = await import('@/libs/DB');
@@ -376,8 +416,8 @@ describe('TransactionsService', () => {
       const mockLeftJoin3 = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin4 });
       const mockLeftJoin2 = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin3 });
       const mockLeftJoin1 = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin2 });
-      const mockInnerJoin = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin1 });
-      const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+      const mockMemberJoin = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin1 });
+      const mockFrom = vi.fn().mockReturnValue({ leftJoin: mockMemberJoin });
       const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
 
       const { db } = await import('@/libs/DB');
@@ -388,7 +428,7 @@ describe('TransactionsService', () => {
 
       expect(result).toEqual(mockRow);
       expect(db.select).toHaveBeenCalledTimes(1);
-      expect(mockInnerJoin).toHaveBeenCalledTimes(1);
+      expect(mockMemberJoin).toHaveBeenCalledTimes(1);
       expect(mockLeftJoin1).toHaveBeenCalledTimes(1);
       expect(mockLeftJoin2).toHaveBeenCalledTimes(1);
       expect(mockLeftJoin3).toHaveBeenCalledTimes(1);
@@ -428,8 +468,8 @@ describe('TransactionsService', () => {
       const mockLeftJoin3 = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin4 });
       const mockLeftJoin2 = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin3 });
       const mockLeftJoin1 = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin2 });
-      const mockInnerJoin = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin1 });
-      const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+      const mockMemberJoin = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin1 });
+      const mockFrom = vi.fn().mockReturnValue({ leftJoin: mockMemberJoin });
       const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
 
       const { db } = await import('@/libs/DB');
@@ -451,8 +491,8 @@ describe('TransactionsService', () => {
       const mockLeftJoin3 = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin4 });
       const mockLeftJoin2 = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin3 });
       const mockLeftJoin1 = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin2 });
-      const mockInnerJoin = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin1 });
-      const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+      const mockMemberJoin = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin1 });
+      const mockFrom = vi.fn().mockReturnValue({ leftJoin: mockMemberJoin });
       const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
 
       const { db } = await import('@/libs/DB');
@@ -496,8 +536,8 @@ describe('TransactionsService', () => {
       const mockLeftJoin3 = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin4 });
       const mockLeftJoin2 = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin3 });
       const mockLeftJoin1 = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin2 });
-      const mockInnerJoin = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin1 });
-      const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+      const mockMemberJoin = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin1 });
+      const mockFrom = vi.fn().mockReturnValue({ leftJoin: mockMemberJoin });
       const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
 
       const { db } = await import('@/libs/DB');

--- a/src/services/TransactionsService.ts
+++ b/src/services/TransactionsService.ts
@@ -4,7 +4,7 @@ import { eventRegistrationSchema, eventSchema, memberMembershipSchema, memberSch
 
 export type TransactionData = {
   id: string;
-  memberId: string;
+  memberId: string | null;
   memberFirstName: string | null;
   memberLastName: string | null;
   transactionType: string;
@@ -53,7 +53,9 @@ export async function getOrganizationTransactions(
       createdAt: transactionSchema.createdAt,
     })
     .from(transactionSchema)
-    .innerJoin(memberSchema, eq(transactionSchema.memberId, memberSchema.id))
+    // leftJoin (not inner): a guest/non-member transaction has a null member_id
+    // and no member row — an inner join would silently drop it from the list.
+    .leftJoin(memberSchema, eq(transactionSchema.memberId, memberSchema.id))
     .where(and(...conditions))
     .orderBy(desc(transactionSchema.createdAt))
     .limit(options?.limit ?? 500)
@@ -64,7 +66,7 @@ export async function getOrganizationTransactions(
 
 export type TransactionDetailData = {
   id: string;
-  memberId: string;
+  memberId: string | null;
   memberFirstName: string | null;
   memberLastName: string | null;
   memberType: string | null;
@@ -119,7 +121,9 @@ export async function getTransactionById(
       eventType: eventSchema.eventType,
     })
     .from(transactionSchema)
-    .innerJoin(memberSchema, eq(transactionSchema.memberId, memberSchema.id))
+    // leftJoin (not inner): a guest/non-member transaction has a null member_id
+    // and no member row — an inner join would 404 the detail lookup.
+    .leftJoin(memberSchema, eq(transactionSchema.memberId, memberSchema.id))
     .leftJoin(memberMembershipSchema, eq(transactionSchema.memberMembershipId, memberMembershipSchema.id))
     .leftJoin(membershipPlanSchema, eq(memberMembershipSchema.membershipPlanId, membershipPlanSchema.id))
     .leftJoin(eventRegistrationSchema, eq(transactionSchema.eventRegistrationId, eventRegistrationSchema.id))


### PR DESCRIPTION
# Allow non-member (guest/store) transactions

## Problem

A store purchase in the **kiosk** — a one-off "Black Belt" sale to a non-member ("John Customer") — was charged successfully but never showed up on the planner's Transactions page or in reporting.

Two gaps stacked:
1. The planner **couldn't store a non-member transaction**: `transaction.member_id` was `NOT NULL` with an FK to `member`, and the transactions queries `innerJoin`ed the member table — so any memberless row was rejected at write time and would be silently dropped from the list at read time.
2. (Separate, handled in the kiosk repo) the kiosk store checkout charges IQPro but doesn't yet write a `transaction` row.

This PR fixes gap #1 on the planner side so guest/non-member transactions can be recorded and surfaced.

## Changes

- **DB — `transaction.member_id` is now nullable.** Dropped `NOT NULL` in `src/models/Schema.ts` and `migrations/0000_baseline.sql`; the FK reference stays (a nullable FK simply skips the check on null). Metadata-only change — **existing member transactions are untouched** (no rows rewritten).
- **Reads — inner → left joins.** `TransactionsService.getOrganizationTransactions` and `getTransactionById` now `leftJoin` the member table so a guest row (null `member_id`, no member) stays in the list / doesn't 404 the detail lookup.
- **Types.** `TransactionData.memberId`, `TransactionDetailData.memberId`, and the UI `Transaction.memberId` are now `string | null`.
- **UI — "Non-member" label.** The transactions page shows a localized "Non-member" (i18n key `TransactionsPage.non_member`, added to en/fr/ja) when a row has no member name. Purchase detail rides in the existing `description` field; no new customer-name column.
- **Docs.** Updated the `transaction` table description in `CLAUDE.md`.

Reporting/dashboard revenue sums already filter by org/status/date with no member join, so guest revenue flows into reporting automatically once rows exist. `refundTransaction` copies `memberId` and now works with a null (previously would have failed the NOT NULL insert). Per-member billing history filters on `member_id`, so guest sales correctly never appear on a member's page.

## Companion change (kiosk repo, out of scope here)

The kiosk redeclares this table and its `transaction.member_id` was made nullable to match (schema parity). The kiosk's store `payment/process` route still needs to be wired to actually write the `transaction` row (null `member_id`) — tracked separately.

## Migrations

No new migration file (index/constraint DDL is applied to the baseline per repo convention). Run this metadata-only, non-row-rewriting DDL against **each** live database — Neon `main`, Neon `preview`, and any local `local.db`:

```sql
ALTER TABLE "transaction" ALTER COLUMN "member_id" DROP NOT NULL;