### PR TITLE
fix(settings): fixed modal for edit location, payment settings to fill in with values already set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ build-archive.log
 /playwright/.cache/
 .playwright/auth.json
 .playwright/e2e-credentials.json
+.env*

--- a/src/features/settings/EditLocationModal.test.tsx
+++ b/src/features/settings/EditLocationModal.test.tsx
@@ -234,6 +234,46 @@ describe('EditLocationModal', () => {
     expect(page.getByText('Please enter a valid email address.')).toBeDefined();
   });
 
+  it('should populate fields from props supplied after mount when opened', async () => {
+    // Reproduces the location-settings bug: the modal first mounts while the
+    // location is still loading (closed, empty props), then the parent flips
+    // isOpen to true once real data has arrived. The programmatic open does not
+    // fire Radix's onOpenChange, so the sync must come from the isOpen effect.
+    const { rerender } = await render(
+      <EditLocationModal
+        {...defaultProps}
+        isOpen={false}
+        address=""
+        phone=""
+        email=""
+        taxRate={0}
+      />,
+    );
+
+    await rerender(
+      <EditLocationModal
+        {...defaultProps}
+        isOpen
+        address="123 Main St. San Francisco. CA"
+        phone="(415) 555-0123"
+        email="downtown@example.com"
+        taxRate={9.75}
+      />,
+    );
+
+    await vi.waitFor(() => {
+      const addressInput = page.getByPlaceholder('Enter address');
+      const phoneInput = page.getByPlaceholder('(555) 123-4567');
+      const emailInput = page.getByPlaceholder('location@example.com');
+      const taxRateInput = page.getByPlaceholder('0.00');
+
+      expect(addressInput.element()).toHaveProperty('value', '123 Main St. San Francisco. CA');
+      expect(phoneInput.element()).toHaveProperty('value', '(415) 555-0123');
+      expect(emailInput.element()).toHaveProperty('value', 'downtown@example.com');
+      expect(taxRateInput.element()).toHaveProperty('value', '9.75');
+    });
+  });
+
   it('should accept valid email format', async () => {
     render(<EditLocationModal {...defaultProps} />);
 

--- a/src/features/settings/EditLocationModal.tsx
+++ b/src/features/settings/EditLocationModal.tsx
@@ -46,6 +46,26 @@ export function EditLocationModal({
   const [touched, setTouched] = useState<Record<string, boolean>>({});
   const [isLoading, setIsLoading] = useState(false);
 
+  // Re-seed the form from the incoming props each time the modal transitions
+  // to open. The `useState` initializers only run on mount, and Radix's
+  // `onOpenChange` does not fire when the parent flips `isOpen`
+  // programmatically — so without this re-seed the form keeps whatever (often
+  // empty, still-loading) values it captured at mount time and the edit dialog
+  // appears blank. This is the React "adjust state during render" pattern
+  // (https://react.dev/reference/react/useState#storing-information-from-previous-renders),
+  // which avoids a state-syncing effect.
+  const [wasOpen, setWasOpen] = useState(isOpen);
+  if (isOpen && !wasOpen) {
+    setWasOpen(true);
+    setAddress(initialAddress);
+    setPhone(initialPhone);
+    setEmail(initialEmail);
+    setTaxRate(initialTaxRate.toFixed(2));
+    setTouched({});
+  } else if (!isOpen && wasOpen) {
+    setWasOpen(false);
+  }
+
   const handleInputBlur = (field: string) => {
     setTouched(prev => ({ ...prev, [field]: true }));
   };

--- a/src/features/settings/EditPaymentSettingsModal.test.tsx
+++ b/src/features/settings/EditPaymentSettingsModal.test.tsx
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { page, userEvent } from 'vitest/browser';
+import { EditPaymentSettingsModal } from './EditPaymentSettingsModal';
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  clientId: 'client-abc-123',
+  gatewayId: 'gateway-xyz-789',
+  hasSecret: true,
+  onSave: vi.fn(),
+};
+
+describe('EditPaymentSettingsModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render the modal title', () => {
+    render(<EditPaymentSettingsModal {...defaultProps} />);
+
+    expect(page.getByText('Edit IQPro Credentials')).toBeDefined();
+  });
+
+  it('should display initial values in form fields', () => {
+    render(<EditPaymentSettingsModal {...defaultProps} />);
+
+    const clientIdInput = page.getByPlaceholder('e.g. abc123-...');
+    const gatewayIdInput = page.getByPlaceholder('IQPro merchant gateway identifier');
+
+    expect(clientIdInput.element()).toHaveProperty('value', 'client-abc-123');
+    expect(gatewayIdInput.element()).toHaveProperty('value', 'gateway-xyz-789');
+  });
+
+  it('should not render when isOpen is false', () => {
+    render(<EditPaymentSettingsModal {...defaultProps} isOpen={false} />);
+
+    expect(page.getByText('Edit IQPro Credentials').elements()).toHaveLength(0);
+  });
+
+  it('should call onClose when cancel button is clicked', async () => {
+    const onClose = vi.fn();
+    render(<EditPaymentSettingsModal {...defaultProps} onClose={onClose} />);
+
+    await userEvent.click(page.getByRole('button', { name: /cancel/i }).element());
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('should keep save enabled and omit clientSecret when secret already exists', async () => {
+    const onSave = vi.fn();
+    render(<EditPaymentSettingsModal {...defaultProps} onSave={onSave} />);
+
+    const saveButton = page.getByRole('button', { name: /^save$/i });
+
+    expect(saveButton.element()).not.toBeDisabled();
+
+    await userEvent.click(saveButton.element());
+
+    await vi.waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith({
+        clientId: 'client-abc-123',
+        gatewayId: 'gateway-xyz-789',
+      });
+    });
+  });
+
+  it('should include clientSecret when one is entered', async () => {
+    const onSave = vi.fn();
+    render(<EditPaymentSettingsModal {...defaultProps} onSave={onSave} />);
+
+    const secretInput = page.getByPlaceholder('••••••••  Leave blank to keep current secret');
+    await userEvent.type(secretInput.element(), 'new-secret-value');
+
+    await userEvent.click(page.getByRole('button', { name: /^save$/i }).element());
+
+    await vi.waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith({
+        clientId: 'client-abc-123',
+        gatewayId: 'gateway-xyz-789',
+        clientSecret: 'new-secret-value',
+      });
+    });
+  });
+
+  it('should require a secret when none has ever been saved', () => {
+    render(<EditPaymentSettingsModal {...defaultProps} hasSecret={false} />);
+
+    // No saved secret and none entered → form invalid, save disabled.
+    expect(page.getByRole('button', { name: /^save$/i }).element()).toBeDisabled();
+  });
+
+  it('should populate fields from props supplied after mount when opened', async () => {
+    // Reproduces the payment-settings bug: the modal first mounts while the
+    // config is still loading (closed, empty props), then the parent flips
+    // isOpen to true once real data has arrived. The programmatic open does not
+    // fire Radix's onOpenChange, so the sync must come from the open-transition
+    // re-seed during render.
+    const { rerender } = await render(
+      <EditPaymentSettingsModal
+        {...defaultProps}
+        isOpen={false}
+        clientId=""
+        gatewayId=""
+        hasSecret={false}
+      />,
+    );
+
+    await rerender(
+      <EditPaymentSettingsModal
+        {...defaultProps}
+        isOpen
+        clientId="client-abc-123"
+        gatewayId="gateway-xyz-789"
+        hasSecret
+      />,
+    );
+
+    await vi.waitFor(() => {
+      const clientIdInput = page.getByPlaceholder('e.g. abc123-...');
+      const gatewayIdInput = page.getByPlaceholder('IQPro merchant gateway identifier');
+
+      expect(clientIdInput.element()).toHaveProperty('value', 'client-abc-123');
+      expect(gatewayIdInput.element()).toHaveProperty('value', 'gateway-xyz-789');
+    });
+  });
+});

--- a/src/features/settings/EditPaymentSettingsModal.tsx
+++ b/src/features/settings/EditPaymentSettingsModal.tsx
@@ -41,6 +41,25 @@ export function EditPaymentSettingsModal({
   const [touched, setTouched] = useState<Record<string, boolean>>({});
   const [isLoading, setIsLoading] = useState(false);
 
+  // Re-seed the form from the incoming props each time the modal transitions
+  // to open. The `useState` initializers only run on mount, and Radix's
+  // `onOpenChange` does not fire when the parent flips `isOpen`
+  // programmatically — so without this re-seed the form keeps whatever (often
+  // empty, still-loading) values it captured at mount time and the edit dialog
+  // appears blank. This is the React "adjust state during render" pattern
+  // (https://react.dev/reference/react/useState#storing-information-from-previous-renders),
+  // which avoids a state-syncing effect.
+  const [wasOpen, setWasOpen] = useState(isOpen);
+  if (isOpen && !wasOpen) {
+    setWasOpen(true);
+    setClientId(initialClientId);
+    setGatewayId(initialGatewayId);
+    setClientSecret('');
+    setTouched({});
+  } else if (!isOpen && wasOpen) {
+    setWasOpen(false);
+  }
+
   const handleInputBlur = (field: string) => {
     setTouched(prev => ({ ...prev, [field]: true }));
   };


### PR DESCRIPTION
fix(settings): re-seed edit modals from props when opened after data loads

The Edit Location and Edit Payment Settings modals appeared blank when
opened. Both mount while their data is still loading (closed, with empty
props), and the parent later flips `isOpen` to `true` once the real
location/IQPro config has arrived. Because `useState` initializers only
run on mount — and Radix's `onOpenChange` does not fire when the parent
opens the dialog programmatically — the forms kept the empty values they
captured at mount time.

Fix both modals to re-seed their fields from the incoming props on the
closed→open transition, using React's "adjust state during render"
pattern (a `wasOpen` sentinel) rather than a syncing effect.

## Changes
- **EditLocationModal**: on open, re-seed address, phone, email, and tax
  rate (formatted to 2 decimals) from props and clear touched state.
- **EditPaymentSettingsModal**: on open, re-seed client ID and gateway ID
  from props, reset the client secret to empty (secret is never echoed
  back), and clear touched state.
- **.gitignore**: ignore all `.env*` files.

## Tests
- **EditLocationModal.test.tsx**: add a regression test asserting fields
  populate from props supplied after mount when the modal is opened.
- **EditPaymentSettingsModal.test.tsx** (new): full suite covering title
  render, initial values, closed state, cancel, save with/without a new
  client secret, the "secret required when none saved" rule, and the same
  open-after-load regression case.