### PR TITLE
fix(security): correct stats sources, trim event over-fetch

### DIFF
--- a/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx
+++ b/src/app/[locale]/(auth)/dashboard/members/[memberId]/edit/page.tsx
@@ -1856,7 +1856,7 @@ export default function EditMemberPage() {
 
       {currentMember && archiveModalMode && (
         <ArchiveMemberModal
-          isOpen={archiveModalMode !== null}
+          isOpen={true}
           onClose={() => setArchiveModalMode(null)}
           memberId={currentMember.id}
           memberName={`${currentMember.firstName || ''} ${currentMember.lastName || ''}`.trim()}

--- a/src/app/[locale]/(auth)/dashboard/transactions/page.tsx
+++ b/src/app/[locale]/(auth)/dashboard/transactions/page.tsx
@@ -37,16 +37,6 @@ function formatPaymentMethod(paymentMethod: string | null, description: string |
   }
 }
 
-function getTransactionsInPast30Days(transactions: Transaction[]): Transaction[] {
-  const thirtyDaysAgo = new Date();
-  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-
-  return transactions.filter((transaction) => {
-    const transactionDate = new Date(transaction.date);
-    return transactionDate >= thirtyDaysAgo;
-  });
-}
-
 export default function TransactionsPage() {
   const t = useTranslations('TransactionsPage');
   const { transactions: rawTransactions, loading } = useTransactionsCache();
@@ -69,14 +59,23 @@ export default function TransactionsPage() {
   }, [rawTransactions, t]);
 
   const stats = useMemo(() => {
-    const recentTransactions = getTransactionsInPast30Days(transactions);
+    const thirtyDaysAgo = new Date();
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+    // Filter on the raw `createdAt` timestamp (a real Date from ORPC), NOT the
+    // localized display string on the transformed Transaction — re-parsing that
+    // string with `new Date()` is locale/environment-dependent and can yield
+    // Invalid Date, silently dropping rows from the count.
+    const recentTransactions = rawTransactions.filter(
+      tx => new Date(tx.createdAt) >= thirtyDaysAgo,
+    );
 
     const paid = recentTransactions.filter(tx => tx.status === 'paid').length;
     const declined = recentTransactions.filter(tx => tx.status === 'declined').length;
     const refunded = recentTransactions.filter(tx => tx.status === 'refunded').length;
 
     return { paid, declined, refunded };
-  }, [transactions]);
+  }, [rawTransactions]);
 
   const statsData = useMemo(() => [
     { id: 'paid', label: t('stats_paid_label'), value: stats.paid },

--- a/src/services/DashboardService.ts
+++ b/src/services/DashboardService.ts
@@ -274,7 +274,7 @@ export async function getFinancialStats(organizationId: string): Promise<Financi
   const paymentsLast30Days = Number(paymentsResult?.total ?? 0);
   const paymentsPending = Number(pendingResult?.total ?? 0);
   const failedPaymentsLast30Days = Number(failedResult?.total ?? 0);
-  const totalStudents = studentsResult?.count ?? 1;
+  const totalStudents = studentsResult?.count ?? 0;
   const incomePerStudent30Days = totalStudents > 0 ? paymentsLast30Days / totalStudents : 0;
 
   return {

--- a/src/services/EventsService.test.ts
+++ b/src/services/EventsService.test.ts
@@ -79,11 +79,24 @@ function selectResolving(rows: SelectResult) {
   };
 }
 
-// getOrganizationEvents chain: an event with one billing tier.
-function queueGetOrganizationEvents(event: Record<string, unknown>, billing: Array<Record<string, unknown>> = []) {
+// Like selectResolving but the chain ends in .limit() — used for the single-row
+// lookups (getEventById's event query, member/registration lookups).
+function selectResolvingWithLimit(rows: SelectResult) {
+  return {
+    from: () => ({
+      where: () => ({
+        limit: () => Promise.resolve(rows),
+      }),
+    }),
+  };
+}
+
+// getEventById chain: the single event query (.limit(1)) followed by its four
+// related-data fetches (sessions, billing, eventTags, allTags).
+function queueGetEventById(event: Record<string, unknown>, billing: Array<Record<string, unknown>> = []) {
   const eventRow = { isActive: true, ...event };
   dbMock.select
-    .mockReturnValueOnce(selectResolving([eventRow])) // events
+    .mockReturnValueOnce(selectResolvingWithLimit([eventRow])) // event (.limit(1))
     .mockReturnValueOnce(selectResolving([])) // sessions
     .mockReturnValueOnce(selectResolving(billing)) // billing
     .mockReturnValueOnce(selectResolving([])) // eventTags
@@ -137,7 +150,7 @@ describe('EventsService.registerMemberForEvent', () => {
   });
 
   it('inserts a registration and returns the registrant (with tier price)', async () => {
-    queueGetOrganizationEvents(EVENT, [TIER]);
+    queueGetEventById(EVENT, [TIER]);
     dbMock.select
       .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([MEMBER]) }) }) }) // member
       .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([]) }) }) }); // existing reg (none)
@@ -168,7 +181,7 @@ describe('EventsService.registerMemberForEvent', () => {
   });
 
   it('records amountPaid = 0 / null tier when no billing tier is chosen', async () => {
-    queueGetOrganizationEvents(EVENT, [TIER]);
+    queueGetEventById(EVENT, [TIER]);
     dbMock.select
       .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([MEMBER]) }) }) })
       .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([]) }) }) });
@@ -189,7 +202,7 @@ describe('EventsService.registerMemberForEvent', () => {
   });
 
   it('back-links a supplied transaction to the new registration', async () => {
-    queueGetOrganizationEvents(EVENT, [TIER]);
+    queueGetEventById(EVENT, [TIER]);
     dbMock.select
       .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([MEMBER]) }) }) })
       .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([]) }) }) });
@@ -209,7 +222,7 @@ describe('EventsService.registerMemberForEvent', () => {
   });
 
   it('rejects a duplicate non-cancelled registration', async () => {
-    queueGetOrganizationEvents(EVENT, [TIER]);
+    queueGetEventById(EVENT, [TIER]);
     dbMock.select
       .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([MEMBER]) }) }) })
       .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'existing' }]) }) }) });
@@ -222,8 +235,8 @@ describe('EventsService.registerMemberForEvent', () => {
   });
 
   it('throws EventNotFoundError when the event is not in the org', async () => {
-    // getOrganizationEvents returns no events → getEventById → null
-    dbMock.select.mockReturnValueOnce(selectResolving([]));
+    // getEventById returns no event row → null
+    dbMock.select.mockReturnValueOnce(selectResolvingWithLimit([]));
 
     const { registerMemberForEvent, EventNotFoundError } = await import('./EventsService');
 
@@ -233,7 +246,7 @@ describe('EventsService.registerMemberForEvent', () => {
   });
 
   it('throws MemberNotFoundError when the member is not in the org', async () => {
-    queueGetOrganizationEvents(EVENT, [TIER]);
+    queueGetEventById(EVENT, [TIER]);
     dbMock.select
       .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([]) }) }) }); // member missing
 
@@ -252,7 +265,7 @@ describe('EventsService.getEventRegistrations', () => {
   });
 
   it('returns joined registrants with the tier name resolved', async () => {
-    queueGetOrganizationEvents(EVENT, [TIER]);
+    queueGetEventById(EVENT, [TIER]);
     dbMock.select.mockReturnValueOnce({
       from: () => ({
         innerJoin: () => ({
@@ -288,7 +301,7 @@ describe('EventsService.getEventRegistrations', () => {
   });
 
   it('returns [] when the event is not in the org', async () => {
-    dbMock.select.mockReturnValueOnce(selectResolving([]));
+    dbMock.select.mockReturnValueOnce(selectResolvingWithLimit([]));
 
     const { getEventRegistrations } = await import('./EventsService');
     const result = await getEventRegistrations('ev-1', 'org-1');
@@ -307,7 +320,7 @@ describe('EventsService.cancelEventRegistration', () => {
     dbMock.select.mockReturnValueOnce({
       from: () => ({ where: () => ({ limit: () => Promise.resolve([{ eventId: 'ev-1' }]) }) }),
     });
-    queueGetOrganizationEvents(EVENT, [TIER]);
+    queueGetEventById(EVENT, [TIER]);
     const updateWhere = vi.fn().mockResolvedValue(undefined);
     const updateSet = vi.fn().mockReturnValue({ where: updateWhere });
     dbMock.update.mockReturnValue({ set: updateSet });
@@ -339,7 +352,7 @@ describe('EventsService.cancelEventRegistration', () => {
       from: () => ({ where: () => ({ limit: () => Promise.resolve([{ eventId: 'ev-1' }]) }) }),
     });
     // getEventById resolves no events for this org → cross-org guard
-    dbMock.select.mockReturnValueOnce(selectResolving([]));
+    dbMock.select.mockReturnValueOnce(selectResolvingWithLimit([]));
 
     const { cancelEventRegistration } = await import('./EventsService');
     const ok = await cancelEventRegistration('reg-1', 'other-org');

--- a/src/services/EventsService.ts
+++ b/src/services/EventsService.ts
@@ -92,6 +92,21 @@ export async function getOrganizationEvents(organizationId: string): Promise<Eve
     db.select().from(tagSchema).where(eq(tagSchema.organizationId, organizationId)),
   ]);
 
+  return assembleEventData(events, sessions, billings, eventTags, allTags);
+}
+
+/**
+ * Assemble the EventData shape from raw event rows and their related
+ * sessions / billing / tag rows. Shared by getOrganizationEvents (whole
+ * catalog) and getEventById (single event) so the mapping stays in one place.
+ */
+function assembleEventData(
+  events: typeof eventSchema.$inferSelect[],
+  sessions: typeof eventSessionSchema.$inferSelect[],
+  billings: typeof eventBillingSchema.$inferSelect[],
+  eventTags: typeof eventTagSchema.$inferSelect[],
+  allTags: typeof tagSchema.$inferSelect[],
+): EventData[] {
   // Create lookup maps
   const tagMap = new Map(allTags.map(t => [t.id, t]));
 
@@ -157,11 +172,37 @@ export async function getOrganizationEvents(organizationId: string): Promise<Eve
 }
 
 /**
- * Get a single event by ID
+ * Get a single event by ID (org-scoped). Queries only the one event row and
+ * its related sessions / billing / tags — NOT the whole org catalog — since
+ * this is called on every event registration read/write/cancel.
  */
 export async function getEventById(eventId: string, organizationId: string): Promise<EventData | null> {
-  const events = await getOrganizationEvents(organizationId);
-  return events.find(e => e.id === eventId) || null;
+  const events = await db
+    .select()
+    .from(eventSchema)
+    .where(and(
+      eq(eventSchema.id, eventId),
+      eq(eventSchema.organizationId, organizationId),
+      eq(eventSchema.isActive, true),
+    ))
+    .limit(1);
+
+  if (events.length === 0) {
+    return null;
+  }
+
+  // Fetch related data for just this event in parallel. Tags still scope to the
+  // org (the tag rows themselves are org-owned), but sessions/billing/tag-links
+  // are constrained to this one event.
+  const [sessions, billings, eventTags, allTags] = await Promise.all([
+    db.select().from(eventSessionSchema).where(eq(eventSessionSchema.eventId, eventId)),
+    db.select().from(eventBillingSchema).where(eq(eventBillingSchema.eventId, eventId)),
+    db.select().from(eventTagSchema).where(eq(eventTagSchema.eventId, eventId)),
+    db.select().from(tagSchema).where(eq(tagSchema.organizationId, organizationId)),
+  ]);
+
+  const [assembled] = assembleEventData(events, sessions, billings, eventTags, allTags);
+  return assembled ?? null;
 }
 
 // =============================================================================

--- a/src/services/TransactionsService.ts
+++ b/src/services/TransactionsService.ts
@@ -17,6 +17,11 @@ export type TransactionData = {
   createdAt: Date;
 };
 
+// Default page size for the org-wide transactions list when the caller doesn't
+// specify one. Bounds payload/heap for orgs with large histories; the list UI
+// paginates client-side over this slice.
+const DEFAULT_TRANSACTION_LIMIT = 500;
+
 export type TransactionListOptions = {
   limit?: number;
   offset?: number;
@@ -58,7 +63,7 @@ export async function getOrganizationTransactions(
     .leftJoin(memberSchema, eq(transactionSchema.memberId, memberSchema.id))
     .where(and(...conditions))
     .orderBy(desc(transactionSchema.createdAt))
-    .limit(options?.limit ?? 500)
+    .limit(options?.limit ?? DEFAULT_TRANSACTION_LIMIT)
     .offset(options?.offset ?? 0);
 
   return rows;


### PR DESCRIPTION
Address a batch of code-quality findings across the finances/dashboard/events
services.

## Changes

- **fix(dashboard): use 0 (not 1) as the zero-students sentinel**
  `getFinancialStats` fell back to `totalStudents = 1` when the count query
  returned nullish, so the `> 0` guard passed and `incomePerStudent30Days`
  computed `payments / 1` instead of `0`. Fall back to `0`.

- **fix(transactions): compute the 30-day stat cards from raw timestamps**
  The top cards filtered on `transaction.date`, which had already been turned
  into a localized display string (e.g. `"July 1, 2025"`); re-parsing it with
  `new Date()` is locale/environment-dependent and can yield `Invalid Date`,
  silently dropping rows from the count. The cards now filter `rawTransactions`
  on the real `createdAt` Date before the display transform. Removes the
  `getTransactionsInPast30Days` helper.

- **perf(events): stop over-fetching in `getEventById`**
  It previously loaded the entire org's active event catalog (plus every
  event's sessions, billing, tags, and all org tags) and `.find()`-ed one row —
  on every event registration read/write/cancel. It now queries only the single
  event and its related data. Extracted a shared `assembleEventData(...)` mapper
  so `getOrganizationEvents` and `getEventById` keep identical mapping logic.

- **refactor(transactions): name the default list limit**
  Replace the magic `500` in `getOrganizationTransactions` with a documented
  `DEFAULT_TRANSACTION_LIMIT` constant.

## Tests

- Update `EventsService.test.ts` mocks for the new single-event query shape:
  the event lookup now ends in `.limit(1)` (new `selectResolvingWithLimit`
  helper), and the priming helper is renamed `queueGetEventById`.

## Verification

- `npm run check:types` — clean
- `npm run lint` (changed files) — clean
- `npm run test` for EventsService, TransactionsService, DashboardService, and
  the transactions page — all pass (84 tests)